### PR TITLE
doc: Add Nix instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ brew install wader/tap/fq
 yay -S fq # or fq-bin
 ```
 
+### Nix
+
+```sh
+nix-shell -p fq
+```
+
 ### Build from source
 
 Make sure you have go 1.17 or later installed.


### PR DESCRIPTION
`fq` is packaged in Nixpkgs as of https://github.com/NixOS/nixpkgs/pull/151871, so these instructions will work within a few days (once the master channel advances.)