### PR TITLE
doc: use nix-env instead of nix-shell to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ yay -S fq # or fq-bin
 ### Nix
 
 ```sh
-nix-shell -p fq
+nix-env -iA nixpkgs.fq # or nixos.fq on NixOS
 ```
 
 ### Build from source


### PR DESCRIPTION
As mentioned on https://github.com/wader/fq/pull/22#issuecomment-1001554152, `nix-shell -p` is not actually installing the package, this PR updates it to use `nix-env -iA` instead, this way it's behavior is the same as `brew install` and `yay -S`, making `fq` available system wide.