### PR TITLE
doc: Update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ brew install wader/tap/fq
 ### Arch Linux
 
 ```sh
-yay -S fq # or fq-bin
+pacman -S fq
 ```
 
 ### Nix


### PR DESCRIPTION
`fq` is now moved to the Arch Linux [community] repository:
<https://archlinux.org/packages/community/x86_64/fq/>

Signed-off-by: Orhun Parmaksız <orhunparmaksiz@gmail.com>
