### PR TITLE
interp: Remove buffer smartness for regexp match functions

### DIFF
--- a/pkg/interp/buffer.go
+++ b/pkg/interp/buffer.go
@@ -21,7 +21,6 @@ func init() {
 	functionRegisterFns = append(functionRegisterFns, func(i *Interp) []Function {
 		return []Function{
 			{"_tobitsrange", 0, 2, i._toBitsRange, nil},
-			{"_is_buffer", 0, 0, i._isBuffer, nil},
 			{"open", 0, 0, i._open, nil},
 		}
 	})
@@ -106,11 +105,6 @@ func toBuffer(v interface{}) (Buffer, error) {
 		}
 		return newBufferFromBuffer(bb, 8), nil
 	}
-}
-
-func (i *Interp) _isBuffer(c interface{}, a []interface{}) interface{} {
-	_, ok := c.(ToBuffer)
-	return ok
 }
 
 // note is used to implement tobytes*/0 also

--- a/pkg/interp/match.jq
+++ b/pkg/interp/match.jq
@@ -6,7 +6,7 @@ def _buffer_fn(f):
 
 def _buffer_try_orig(bfn; fn):
   ( . as $c
-  | if type == "string" and (_is_buffer | not) then fn
+  | if type == "string" then fn
     else
       ( $c
       | tobytesrange

--- a/pkg/interp/testdata/match.fqtest
+++ b/pkg/interp/testdata/match.fqtest
@@ -1,12 +1,12 @@
 $ fq -i -d mp3 . /test.mp3
-mp3> .frames[1].data | match("3\u0085"; "b")
+mp3> .frames[1].data | tobytes | match("3\u0085"; "b")
 {
   "captures": [],
   "length": 2,
   "offset": 4,
   "string": "3\ufffd"
 }
-mp3> .frames[1].data | match([0x33, 0x85]), first(scan([0x33, 0x85]) | hex), first(splits([0x33, 0x85]) | hex), first(scan_toend([0x33, 0x85]) | hex)
+mp3> .frames[1].data | tobytes | match([0x33, 0x85]), first(scan([0x33, 0x85]) | hex), first(splits([0x33, 0x85]) | hex), first(scan_toend([0x33, 0x85]) | hex)
 {
   "captures": [],
   "length": 2,


### PR DESCRIPTION
Just confusing and breaks symbolic grep for decode values (as they are buffers).
To get buffer use tobytes functions intstead.