### PR TITLE
mp3: Decrease max sync seek length between frames to 4k

### DIFF
--- a/format/mp3/mp3.go
+++ b/format/mp3/mp3.go
@@ -16,7 +16,7 @@ var mp3Frame decode.Group
 
 // TODO: format options default
 const maxUniqueHeaderConfigs = 5
-const maxSyncSeek = 64 * 1024 * 8
+const maxSyncSeek = 4 * 1024 * 8
 
 func init() {
 	registry.MustRegister(decode.Format{


### PR DESCRIPTION
This might break mp3s with large id3v2 chunks embedded into the stream but
i think that is rare and probably means it is a dump of a mp3 radio stream etc.

An alternative approach is to also look for id3v2 etc between frames but then the mp3
root value probably should be an array of mix of things instead of a struct, or rename
header/footer to metadata?

Related to #103