### PR TITLE
interp: Cleanup display aliases, now: d, da, dd, dv, ddv

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -279,12 +279,14 @@ you currently have to do `fq -d raw 'mp3({force: true})' file`.
 - `probe`, `probe($opts)` probe and decode format
 - `mp3`, `mp3($opts)`, ..., `<name>`, `<name>($opts)` same as `decode(<name>)($opts)`, `decode($format; $opts)`  decode as format
 - Display shows hexdump/ASCII/tree for decode values and JSON for other values.
-  - `d`/`display` display value and truncate long arrays
-  - `f`/`full` display value and don't truncate arrays
-  - `v`/`verbose` display value verbosely and don't truncate array
+  - `d`/`d($opts)` display value and truncate long arrays and buffers
+  - `da`/`da($opts)` display value and don't truncate arrays
+  - `dd`/`dd($opts)` display value and don't truncate arrays or buffers
+  - `dv`/`dv($opts)` verbosely display value and don't truncate arrays but truncate buffers
+  - `ddv`/`ddv($opts)` verbosely display value and don't truncate arrays or buffers
 - `p`/`preview` show preview of field tree
 - `hd`/`hexdump` hexdump value
-- `repl` nested REPL, must be last in a pipeline. `1 | repl`, can "slurp" multiple outputs `1, 2, 3 | repl`.
+- `repl` nested REPL, must be last in a pipeline. `1 | repl`, can "slurp" outputs `1, 2, 3 | repl`.
 
 ## Arguments
 

--- a/format/ape/testdata/apev2.fqtest
+++ b/format/ape/testdata/apev2.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -f lavfi -i sine -ac 2 -t 10ms -f mp3 test.mp3
 # mp3gain test.mp3
 # fq '.footers[0] | tobytes' test.mp3 > apev2
-$ fq -d apev2 verbose /apev2
+$ fq -d apev2 dv /apev2
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /apev2 (apev2) 0x0-0xad.7 (174)
     |                                               |                |  header{}: 0x0-0x1f.7 (32)
 0x00|41 50 45 54 41 47 45 58                        |APETAGEX        |    preamble: "APETAGEX" (valid) 0x0-0x7.7 (8)

--- a/format/bencode/testdata/bbb.fqtest
+++ b/format/bencode/testdata/bbb.fqtest
@@ -1,4 +1,4 @@
-$ fq -d bencode v bbb.torrent
+$ fq -d bencode dv bbb.torrent
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: bbb.torrent (bencode) 0x0-0x3795.7 (14230)
 0x0000|64                                             |d               |  type: "dictionary" ("d") 0x0-0x0.7 (1)
       |                                               |                |  pairs[0:9]: 0x1-0x3794.7 (14228)

--- a/format/bson/testdata/test.fqtest
+++ b/format/bson/testdata/test.fqtest
@@ -1,6 +1,6 @@
 # https://github.com/dwight/bsontools
 # echo '{array: [1,2,3], object: {key: "value"}, number: 123, string: "abc", true: true, false: false, null: null}' | fromjson test.bson
-$ fq -d bson verbose /test.bson
+$ fq -d bson dv /test.bson
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.bson (bson) 0x0-0x72.7 (115)
 0x00|73 00 00 00                                    |s...            |  size: 115 0x0-0x3.7 (4)
     |                                               |                |  elements[0:7]: 0x4-0x71.7 (110)

--- a/format/bzip2/testdata/test.fqtest
+++ b/format/bzip2/testdata/test.fqtest
@@ -1,5 +1,5 @@
 # echo test | bzip2 > test.bz2
-$ fq -d bzip2 verbose /test.bz2
+$ fq -d bzip2 dv /test.bz2
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.bz2 (bzip2) 0x0-0x2c.7 (45)
 0x00|42 5a                                          |BZ              |  magic: "BZ" (valid) 0x0-0x1.7 (2)
 0x00|      68                                       |  h             |  version: 104 0x2-0x2.7 (1)

--- a/format/cbor/testdata/appendix_a.fqtest
+++ b/format/cbor/testdata/appendix_a.fqtest
@@ -35,7 +35,7 @@ json> map(select(.decoded) | (.cbor | base64 | cbor | torepr) as $a | select( .d
     }
   }
 ]
-json> .[] | select(.decoded) | .cbor | base64 | cbor | v
+json> .[] | select(.decoded) | .cbor | base64 | cbor | dv
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: (cbor) 0x0-0x0.7 (1)
 0x0|00|                                            |.|              |  major_type: "positive_int" (0) 0x0-0x0.2 (0.3)
 0x0|00|                                            |.|              |  short_count: 0 0x0.3-0x0.7 (0.5)

--- a/format/dns/testdata/cern-rsp.fqtest
+++ b/format/dns/testdata/cern-rsp.fqtest
@@ -1,4 +1,4 @@
-$ fq -d dns verbose /cern-rsp
+$ fq -d dns dv /cern-rsp
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /cern-rsp (dns) 0x0-0x4f.7 (80)
     |                                               |                |  header{}: 0x0-0x3.7 (4)
 0x00|71 02                                          |q.              |    id: 28930 0x0-0x1.7 (2)

--- a/format/elf/testdata/linux_386/a_dynamic.fqtest
+++ b/format/elf/testdata/linux_386/a_dynamic.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_dynamic
+$ fq -d elf dv a_dynamic
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_dynamic (elf) 0x0-0x41ef.7 (16880)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_386/a_static.fqtest
+++ b/format/elf/testdata/linux_386/a_static.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_static
+$ fq -d elf dv a_static
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_static (elf) 0x0-0x4207.7 (16904)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_386/a_stripped.fqtest
+++ b/format/elf/testdata/linux_386/a_stripped.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_stripped
+$ fq -d elf dv a_stripped
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_stripped (elf) 0x0-0x34df.7 (13536)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_386/libbbb.a.fqtest
+++ b/format/elf/testdata/linux_386/libbbb.a.fqtest
@@ -1,4 +1,4 @@
-$ fq -d ar v libbbb.a
+$ fq -d ar dv libbbb.a
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.a (ar) 0x0-0x5ed.7 (1518)
 0x000|21 3c 61 72 63 68 3e 0a                        |!<arch>.        |  signature: "!<arch>\n" (valid) 0x0-0x7.7 (8)
      |                                               |                |  files[0:2]: 0x8-0x5ed.7 (1510)

--- a/format/elf/testdata/linux_386/libbbb.so.fqtest
+++ b/format/elf/testdata/linux_386/libbbb.so.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v libbbb.so
+$ fq -d elf dv libbbb.so
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.so (elf) 0x0-0x3c6f.7 (15472)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_amd64/a_dynamic.fqtest
+++ b/format/elf/testdata/linux_amd64/a_dynamic.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_dynamic
+$ fq -d elf dv a_dynamic
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_dynamic (elf) 0x0-0x473f.7 (18240)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_amd64/a_static.fqtest
+++ b/format/elf/testdata/linux_amd64/a_static.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_static
+$ fq -d elf dv a_static
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_static (elf) 0x0-0x475f.7 (18272)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_amd64/a_stripped.fqtest
+++ b/format/elf/testdata/linux_amd64/a_stripped.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_stripped
+$ fq -d elf dv a_stripped
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_stripped (elf) 0x0-0x3727.7 (14120)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_amd64/libbbb.a.fqtest
+++ b/format/elf/testdata/linux_amd64/libbbb.a.fqtest
@@ -1,4 +1,4 @@
-$ fq -d ar v libbbb.a
+$ fq -d ar dv libbbb.a
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.a (ar) 0x0-0x67b.7 (1660)
 0x000|21 3c 61 72 63 68 3e 0a                        |!<arch>.        |  signature: "!<arch>\n" (valid) 0x0-0x7.7 (8)
      |                                               |                |  files[0:2]: 0x8-0x67b.7 (1652)

--- a/format/elf/testdata/linux_amd64/libbbb.so.fqtest
+++ b/format/elf/testdata/linux_amd64/libbbb.so.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v libbbb.so
+$ fq -d elf dv libbbb.so
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.so (elf) 0x0-0x404f.7 (16464)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm64/a_dynamic.fqtest
+++ b/format/elf/testdata/linux_arm64/a_dynamic.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_dynamic
+$ fq -d elf dv a_dynamic
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_dynamic (elf) 0x0-0x2b6f.7 (11120)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm64/a_static.fqtest
+++ b/format/elf/testdata/linux_arm64/a_static.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_static
+$ fq -d elf dv a_static
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_static (elf) 0x0-0x2bd7.7 (11224)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm64/a_stripped.fqtest
+++ b/format/elf/testdata/linux_arm64/a_stripped.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_stripped
+$ fq -d elf dv a_stripped
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_stripped (elf) 0x0-0x1697.7 (5784)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm64/libbbb.a.fqtest
+++ b/format/elf/testdata/linux_arm64/libbbb.a.fqtest
@@ -1,4 +1,4 @@
-$ fq -d ar v libbbb.a
+$ fq -d ar dv libbbb.a
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.a (ar) 0x0-0x6e3.7 (1764)
 0x000|21 3c 61 72 63 68 3e 0a                        |!<arch>.        |  signature: "!<arch>\n" (valid) 0x0-0x7.7 (8)
      |                                               |                |  files[0:2]: 0x8-0x6e3.7 (1756)

--- a/format/elf/testdata/linux_arm64/libbbb.so.fqtest
+++ b/format/elf/testdata/linux_arm64/libbbb.so.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v libbbb.so
+$ fq -d elf dv libbbb.so
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.so (elf) 0x0-0x2367.7 (9064)
       |                                               |                |  header{}: 0x0-0x3f.7 (64)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v6/a_dynamic.fqtest
+++ b/format/elf/testdata/linux_arm_v6/a_dynamic.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_dynamic
+$ fq -d elf dv a_dynamic
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_dynamic (elf) 0x0-0x2593.7 (9620)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v6/a_static.fqtest
+++ b/format/elf/testdata/linux_arm_v6/a_static.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_static
+$ fq -d elf dv a_static
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_static (elf) 0x0-0x25db.7 (9692)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v6/a_stripped.fqtest
+++ b/format/elf/testdata/linux_arm_v6/a_stripped.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_stripped
+$ fq -d elf dv a_stripped
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_stripped (elf) 0x0-0x14b7.7 (5304)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v6/libbbb.a.fqtest
+++ b/format/elf/testdata/linux_arm_v6/libbbb.a.fqtest
@@ -1,4 +1,4 @@
-$ fq -d ar v libbbb.a
+$ fq -d ar dv libbbb.a
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.a (ar) 0x0-0x4af.7 (1200)
 0x000|21 3c 61 72 63 68 3e 0a                        |!<arch>.        |  signature: "!<arch>\n" (valid) 0x0-0x7.7 (8)
      |                                               |                |  files[0:2]: 0x8-0x4af.7 (1192)

--- a/format/elf/testdata/linux_arm_v6/libbbb.so.fqtest
+++ b/format/elf/testdata/linux_arm_v6/libbbb.so.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v libbbb.so
+$ fq -d elf dv libbbb.so
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.so (elf) 0x0-0x1e9f.7 (7840)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v7/a_dynamic.fqtest
+++ b/format/elf/testdata/linux_arm_v7/a_dynamic.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_dynamic
+$ fq -d elf dv a_dynamic
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_dynamic (elf) 0x0-0x2593.7 (9620)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v7/a_static.fqtest
+++ b/format/elf/testdata/linux_arm_v7/a_static.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_static
+$ fq -d elf dv a_static
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_static (elf) 0x0-0x25db.7 (9692)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v7/a_stripped.fqtest
+++ b/format/elf/testdata/linux_arm_v7/a_stripped.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v a_stripped
+$ fq -d elf dv a_stripped
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: a_stripped (elf) 0x0-0x14b7.7 (5304)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/elf/testdata/linux_arm_v7/libbbb.a.fqtest
+++ b/format/elf/testdata/linux_arm_v7/libbbb.a.fqtest
@@ -1,4 +1,4 @@
-$ fq -d ar v libbbb.a
+$ fq -d ar dv libbbb.a
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.a (ar) 0x0-0x4af.7 (1200)
 0x000|21 3c 61 72 63 68 3e 0a                        |!<arch>.        |  signature: "!<arch>\n" (valid) 0x0-0x7.7 (8)
      |                                               |                |  files[0:2]: 0x8-0x4af.7 (1192)

--- a/format/elf/testdata/linux_arm_v7/libbbb.so.fqtest
+++ b/format/elf/testdata/linux_arm_v7/libbbb.so.fqtest
@@ -1,4 +1,4 @@
-$ fq -d elf v libbbb.so
+$ fq -d elf dv libbbb.so
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: libbbb.so (elf) 0x0-0x1e9f.7 (7840)
       |                                               |                |  header{}: 0x0-0x33.7 (52)
       |                                               |                |    ident{}: 0x0-0xf.7 (16)

--- a/format/flac/testdata/frame.fqtest
+++ b/format/flac/testdata/frame.fqtest
@@ -1,6 +1,6 @@
 # test decode separate frame
 # ffmpeg -f lavfi -i sine -t 0.01s -f flac pipe:1 | fq - '.frames[0]._bytes' > frame
-$ fq -d flac_frame verbose /frame
+$ fq -d flac_frame dv /frame
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /frame (flac_frame) 0x0-0x1ff.7 (512)
      |                                               |                |  header{}: 0x0-0x7.7 (8)
 0x000|ff f8                                          |..              |    sync: 0b11111111111110 (valid) 0x0-0x1.5 (1.6)

--- a/format/flac/testdata/mono16.fqtest
+++ b/format/flac/testdata/mono16.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /mono16.flac
+$ fq -d flac dv /mono16.flac
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mono16.flac (flac) 0x0-0x8597.7 (34200)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)

--- a/format/flac/testdata/mono24.fqtest
+++ b/format/flac/testdata/mono24.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /mono24.flac
+$ fq -d flac dv /mono24.flac
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mono24.flac (flac) 0x0-0xbcca.7 (48331)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x209b.7 (8344)

--- a/format/flac/testdata/mono8.fqtest
+++ b/format/flac/testdata/mono8.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /mono8.flac
+$ fq -d flac dv /mono8.flac
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mono8.flac (flac) 0x0-0x4cef.7 (19696)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)

--- a/format/flac/testdata/picture_seek_gain.fqtest
+++ b/format/flac/testdata/picture_seek_gain.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /picture_seek_gain.flac
+$ fq -d flac dv /picture_seek_gain.flac
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /picture_seek_gain.flac (flac) 0x0-0x225f.7 (8800)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:5]: (flac_metadatablocks) 0x4-0x205f.7 (8284)

--- a/format/flac/testdata/stereo16.fqtest
+++ b/format/flac/testdata/stereo16.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /stereo16.flac
+$ fq -d flac dv /stereo16.flac
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo16.flac (flac) 0x0-0xc54b.7 (50508)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)

--- a/format/flac/testdata/stereo24.fqtest
+++ b/format/flac/testdata/stereo24.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /stereo24.flac
+$ fq -d flac dv /stereo24.flac
        |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo24.flac (flac) 0x0-0x11bcb.7 (72652)
 0x00000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
        |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x209b.7 (8344)

--- a/format/flac/testdata/stereo8.fqtest
+++ b/format/flac/testdata/stereo8.fqtest
@@ -1,4 +1,4 @@
-$ fq -d flac verbose /stereo8.flac
+$ fq -d flac dv /stereo8.flac
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo8.flac (flac) 0x0-0x6d5c.7 (27997)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)

--- a/format/gif/testdata/4x4.fqtest
+++ b/format/gif/testdata/4x4.fqtest
@@ -1,5 +1,5 @@
 # gm convert -size 4x4 'xc:#000' 'xc:#fff' 4x4.gif
-$ fq -d gif verbose /4x4.gif
+$ fq -d gif dv /4x4.gif
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.gif (gif) 0x0-0x5e.7 (95)
 0x00|47 49 46 38 39 61                              |GIF89a          |  header: "GIF89a" (valid) 0x0-0x5.7 (6)
 0x00|                  04 00                        |      ..        |  width: 4 0x6-0x7.7 (2)

--- a/format/gzip/testdata/test.fqtest
+++ b/format/gzip/testdata/test.fqtest
@@ -1,5 +1,5 @@
 # echo test | gzip -N > test.gz
-$ fq -d gzip verbose /test.gz
+$ fq -d gzip dv /test.gz
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.gz (gzip) 0x0-0x18.7 (25)
 0x00|1f 8b                                          |..              |  identification: raw bits (valid) 0x0-0x1.7 (2)
 0x00|      08                                       |  .             |  compression_method: "deflate" (8) 0x2-0x2.7 (1)

--- a/format/icc/testdata/sRGB2014.fqtest
+++ b/format/icc/testdata/sRGB2014.fqtest
@@ -1,5 +1,5 @@
 # sRGB2014.icc is from https://www.color.org/srgbprofiles.xalter
-$ fq -d icc_profile verbose /sRGB2014.icc
+$ fq -d icc_profile dv /sRGB2014.icc
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /sRGB2014.icc (icc_profile) 0x0-0xbcf.7 (3024)
      |                                               |                |  header{}: 0x0-0x7f.7 (128)
 0x000|00 00 0b d0                                    |....            |    size: 3024 0x0-0x3.7 (4)

--- a/format/id3/testdata/apic.fqtest
+++ b/format/id3/testdata/apic.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i anullsrc=d=10ms -f lavfi -i testsrc=s=4x4:r=1:d=1 -map 0:0 -map 1:0 -f mp3 test.mp3
 # fq test.mp3 '.. | select(format == "id3v2")._bytes' > apic
-$ fq -d id3v2 verbose /apic
+$ fq -d id3v2 dv /apic
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /apic (id3v2) 0x0-0xb3.7 (180)
 0x00|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x00|         04                                    |   .            |  version: 4 0x3-0x3.7 (1)

--- a/format/id3/testdata/id3v1.fqtest
+++ b/format/id3/testdata/id3v1.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -write_id3v1 1 -metadata title=test -f mp3 pipe:1 | fq - '.footers[0]._bytes' > id3v1
-$ fq -d id3v1 verbose /id3v1
+$ fq -d id3v1 dv /id3v1
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /id3v1 (id3v1) 0x0-0x7f.7 (128)
 0x00|54 41 47                                       |TAG             |  magic: "TAG" (valid) 0x0-0x2.7 (3)
 0x00|         74 65 73 74 00 00 00 00 00 00 00 00 00|   test.........|  song_name: "test" 0x3-0x20.7 (30)

--- a/format/id3/testdata/id3v23.fqtest
+++ b/format/id3/testdata/id3v23.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 0s -id3v2_version 3 -f mp3 pipe:1 > id3v23
-$ fq -d id3v2 verbose /id3v23
+$ fq -d id3v2 dv /id3v23
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /id3v23 (id3v2) 0x0-0x2c.7 (45)
 0x00|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x00|         03                                    |   .            |  version: 3 0x3-0x3.7 (1)

--- a/format/id3/testdata/id3v24.fqtest
+++ b/format/id3/testdata/id3v24.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 0s -id3v2_version 4 -f mp3 pipe:1 > id3v24
-$ fq -d id3v2 verbose /id3v24
+$ fq -d id3v2 dv /id3v24
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /id3v24 (id3v2) 0x0-0x2c.7 (45)
 0x00|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x00|         04                                    |   .            |  version: 4 0x3-0x3.7 (1)

--- a/format/id3/testdata/utf16-apic.fqtest
+++ b/format/id3/testdata/utf16-apic.fqtest
@@ -2,7 +2,7 @@
 # convert -size 4x4 "xc:#000" 4x4.png
 # eyeD3 --encoding=utf16 --add-image=4x4.png:OTHER:test test.mp3
 # fq test.mp3 .headers[0]._bits > utf16-apic
-$ fq -d id3v2 verbose /utf16-apic
+$ fq -d id3v2 dv /utf16-apic
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /utf16-apic (id3v2) 0x0-0x255.7 (598)
 0x000|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x000|         04                                    |   .            |  version: 4 0x3-0x3.7 (1)

--- a/format/inet/testdata/ether8023_frame.fqtest
+++ b/format/inet/testdata/ether8023_frame.fqtest
@@ -1,5 +1,5 @@
 # fq 'first(.. | select(format=="ether8023")) | tobytes' many_interfaces.pcapng > ether8023_frame
-$ fq -d ether8023_frame verbose /ether8023_frame
+$ fq -d ether8023_frame dv /ether8023_frame
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /ether8023_frame (ether8023_frame) 0x0-0xb1.7 (178)
 0x00|ff ff ff ff ff ff                              |......          |  destination: "ff:ff:ff:ff:ff:ff" (0xffffffffffff) 0x0-0x5.7 (6)
 0x00|                  a4 5e 60 f1 7d 93            |      .^`.}.    |  source: "a4:5e:60:f1:7d:93" (0xa45e60f17d93) 0x6-0xb.7 (6)

--- a/format/inet/testdata/ipv4_packet.fqtest
+++ b/format/inet/testdata/ipv4_packet.fqtest
@@ -1,5 +1,5 @@
 # fq 'first(.. | select(format=="ipv4")) | tobytes' many_interfaces.pcapng > ipv4_packet
-$ fq -d ipv4_packet verbose /ipv4_packet
+$ fq -d ipv4_packet dv /ipv4_packet
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /ipv4_packet (ipv4_packet) 0x0-0x3e3.7 (996)
 0x000|45                                             |E               |  version: 4 0x0-0x0.3 (0.4)
 0x000|45                                             |E               |  ihl: 5 0x0.4-0x0.7 (0.4)

--- a/format/inet/testdata/tcp_segment.fqtest
+++ b/format/inet/testdata/tcp_segment.fqtest
@@ -1,5 +1,5 @@
 # fq 'first(.. | select(format=="tcp")) | tobytes' many_interfaces.pcapng > tcp_segment
-$ fq -d tcp_segment verbose /tcp_segment
+$ fq -d tcp_segment dv /tcp_segment
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /tcp_segment (tcp_segment) 0x0-0x2b.7 (44)
 0x00|c7 25                                          |.%              |  source_port: 50981 0x0-0x1.7 (2)
 0x00|      01 bb                                    |  ..            |  destination_port: "https" (443) (http protocol over TLS/SSL) 0x2-0x3.7 (2)

--- a/format/inet/testdata/udp_datagram.fqtest
+++ b/format/inet/testdata/udp_datagram.fqtest
@@ -1,5 +1,5 @@
 # fq 'first(.. | select(format=="udp")) | tobytes' many_interfaces.pcapng > udp_datagram
-$ fq -d udp_datagram verbose /udp_datagram
+$ fq -d udp_datagram dv /udp_datagram
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /udp_datagram (udp_datagram) 0x0-0x8f.7 (144)
 0x00|44 5c                                          |D\              |  source_port: 17500 0x0-0x1.7 (2)
 0x00|      44 5c                                    |  D\            |  destination_port: 17500 0x2-0x3.7 (2)

--- a/format/jpeg/testdata/4x4.fqtest
+++ b/format/jpeg/testdata/4x4.fqtest
@@ -1,5 +1,5 @@
 # gm convert -size 4x4 'xc:#000' 4x4.jpg
-$ fq -d jpeg verbose /4x4.jpg
+$ fq -d jpeg dv /4x4.jpg
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.jpg (jpeg) 0x0-0x9f.7 (160)
     |                                               |                |  segments[0:9]: 0x0-0x9f.7 (160)
     |                                               |                |    [0]{}: marker 0x0-0x1.7 (2)

--- a/format/matroska/testdata/aac.fqtest
+++ b/format/matroska/testdata/aac.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -c:a aac -f matroska -t 50ms aac.mkv
-$ fq -d matroska verbose /aac.mkv
+$ fq -d matroska dv /aac.mkv
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /aac.mkv (matroska) 0x0-0x4c3.7 (1220)
      |                                               |                |  elements[0:2]: 0x0-0x4c3.7 (1220)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/av1.fqtest
+++ b/format/matroska/testdata/av1.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -g 1 -c:v librav1e -t 50ms av1.mkv
-$ fq -d matroska verbose /av1.mkv
+$ fq -d matroska dv /av1.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /av1.mkv (matroska) 0x0-0x13e6.7 (5095)
       |                                               |                |  elements[0:2]: 0x0-0x13e6.7 (5095)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/avc.fqtest
+++ b/format/matroska/testdata/avc.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v h264 -f matroska -t 50ms avc.mkv
-$ fq -d matroska verbose /avc.mkv
+$ fq -d matroska dv /avc.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /avc.mkv (matroska) 0x0-0xd46.7 (3399)
       |                                               |                |  elements[0:2]: 0x0-0xd46.7 (3399)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/flac.fqtest
+++ b/format/matroska/testdata/flac.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -ac 2 -c:a flac -strict experimental -f matroska -t 50ms flac.mkv
-$ fq -d matroska verbose /flac.mkv
+$ fq -d matroska dv /flac.mkv
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /flac.mkv (matroska) 0x0-0x4ce.7 (1231)
      |                                               |                |  elements[0:2]: 0x0-0x4ce.7 (1231)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/hevc.fqtest
+++ b/format/matroska/testdata/hevc.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v hevc -f matroska -t 50ms hevc.mkv
-$ fq -d matroska verbose /hevc.mkv
+$ fq -d matroska dv /hevc.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /hevc.mkv (matroska) 0x0-0x13ea.7 (5099)
       |                                               |                |  elements[0:2]: 0x0-0x13ea.7 (5099)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/mp3.fqtest
+++ b/format/matroska/testdata/mp3.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -c:a mp3 -f matroska -t 50ms mp3.mkv
-$ fq -d matroska verbose /mp3.mkv
+$ fq -d matroska dv /mp3.mkv
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3.mkv (matroska) 0x0-0x4db.7 (1244)
      |                                               |                |  elements[0:2]: 0x0-0x4db.7 (1244)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/mpeg2.fqtest
+++ b/format/matroska/testdata/mpeg2.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v mpeg2video -f matroska -t 50ms mpeg2.mkv
-$ fq -d matroska verbose /mpeg2.mkv
+$ fq -d matroska dv /mpeg2.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mpeg2.mkv (matroska) 0x0-0x21c9.7 (8650)
       |                                               |                |  elements[0:2]: 0x0-0x21c9.7 (8650)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/opus.fqtest
+++ b/format/matroska/testdata/opus.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -strict experimental -c:a opus -f matroska -t 50ms opus.mkv
-$ fq -d matroska verbose /opus.mkv
+$ fq -d matroska dv /opus.mkv
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus.mkv (matroska) 0x0-0x3ec.7 (1005)
      |                                               |                |  elements[0:2]: 0x0-0x3ec.7 (1005)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/vorbis.fqtest
+++ b/format/matroska/testdata/vorbis.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -ac 2 -strict experimental -c:a vorbis -f matroska -t 50ms vorbis.mkv
-$ fq -d matroska verbose /vorbis.mkv
+$ fq -d matroska dv /vorbis.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis.mkv (matroska) 0x0-0x10fa.7 (4347)
       |                                               |                |  elements[0:2]: 0x0-0x10fa.7 (4347)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/vp8.fqtest
+++ b/format/matroska/testdata/vp8.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v vp8 -f matroska -t 50ms vp8.mkv
-$ fq -d matroska verbose /vp8.mkv
+$ fq -d matroska dv /vp8.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vp8.mkv (matroska) 0x0-0x148b.7 (5260)
       |                                               |                |  elements[0:2]: 0x0-0x148b.7 (5260)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/matroska/testdata/vp9.fqtest
+++ b/format/matroska/testdata/vp9.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v vp9 -f matroska -t 50ms vp9.mkv
-$ fq -d matroska verbose /vp9.mkv
+$ fq -d matroska dv /vp9.mkv
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vp9.mkv (matroska) 0x0-0x1785.7 (6022)
       |                                               |                |  elements[0:2]: 0x0-0x1785.7 (6022)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)

--- a/format/mp3/testdata/header-zeros-frames.fqtest
+++ b/format/mp3/testdata/header-zeros-frames.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f mp3 pipe:1 | fq - '.headers._bytes, ("\x00\x00\x00" | tobytes), .frames[0]._bytes' > header-zeros-frames.mp3
-$ fq -d mp3 verbose /header-zeros-frames.mp3
+$ fq -d mp3 dv /header-zeros-frames.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /header-zeros-frames.mp3 (mp3) 0x0-0xff.7 (256)
      |                                               |                |  headers[0:1]: 0x0-0x2c.7 (45)
      |                                               |                |    [0]{}: header (id3v2) 0x0-0x2c.7 (45)

--- a/format/mp3/testdata/headerfooter.fqtest
+++ b/format/mp3/testdata/headerfooter.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 1ms -write_xing 0 -write_id3v2 4 -write_id3v1 1 -metadata title=test -f mp3 headerfooter.mp3
-$ fq -d mp3 verbose /headerfooter.mp3
+$ fq -d mp3 dv /headerfooter.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /headerfooter.mp3 (mp3) 0x0-0x25d.7 (606)
      |                                               |                |  headers[0:1]: 0x0-0x3c.7 (61)
      |                                               |                |    [0]{}: header (id3v2) 0x0-0x3c.7 (61)

--- a/format/mp3/testdata/test.fqtest
+++ b/format/mp3/testdata/test.fqtest
@@ -1,8 +1,9 @@
 # ffmpeg -f lavfi -i sine -ac 2 -t 10ms -metadata title=test -write_xing 1 -write_id3v1 1 -f mp3 test.mp3
 $ fq -d mp3 '.headers[0].magic | verbose' /test.mp3
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|49 44 33                                       |ID3             |.headers[0].magic: "ID3" (valid) 0x0-0x2.7 (3)
-$ fq -d mp3 verbose /test.mp3
+exitcode: 3
+stderr:
+error: arg:1:0: function not defined: verbose/0
+$ fq -d mp3 dv /test.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3) 0x0-0x4cf.7 (1232)
      |                                               |                |  headers[0:1]: 0x0-0x3c.7 (61)
      |                                               |                |    [0]{}: header (id3v2) 0x0-0x3c.7 (61)

--- a/format/mp3/testdata/xing.fqtest
+++ b/format/mp3/testdata/xing.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i sine -ac 2 -t 10ms -f mp3 temp.mp3 && fq temp.mp3 '.frame[0].xing | tobits' > xing
-$ fq -d xing verbose /xing
+$ fq -d xing dv /xing
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /xing (xing) 0x0-0x9b.7 (156)
 0x00|49 6e 66 6f                                    |Info            |  header: "Info" 0x0-0x3.7 (4)
     |                                               |                |  present_flags{}: 0x4-0x7.7 (4)

--- a/format/mp4/testdata/aac.fqtest
+++ b/format/mp4/testdata/aac.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -c:a aac -f mp4 -t 50ms aac.mp4
-$ fq -d mp4 verbose /aac.mp4
+$ fq -d mp4 dv /aac.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /aac.mp4 (mp4) 0x0-0x59c.7 (1437)
      |                                               |                |  boxes[0:4]: 0x0-0x59c.7 (1437)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/av1.fqtest
+++ b/format/mp4/testdata/av1.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -v trace -f lavfi -i testsrc -c:v librav1e -t 50ms av1.mp4
-$ fq -d mp4 verbose /av1.mp4
+$ fq -d mp4 dv /av1.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /av1.mp4 (mp4) 0x0-0x14b1.7 (5298)
       |                                               |                |  boxes[0:4]: 0x0-0x14b1.7 (5298)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/avc.fqtest
+++ b/format/mp4/testdata/avc.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v h264 -f mp4 -t 100ms avc.mp4
-$ fq -d mp4 verbose /avc.mp4
+$ fq -d mp4 dv /avc.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /avc.mp4 (mp4) 0x0-0x10df.7 (4320)
       |                                               |                |  boxes[0:4]: 0x0-0x10df.7 (4320)
       |                                               |                |    [0]{}: box 0x0-0x1f.7 (32)

--- a/format/mp4/testdata/dash.fqtest
+++ b/format/mp4/testdata/dash.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -f lavfi -i sine -f lavfi -i testsrc -g 1 -c:a aac -c:v h264 -f mp4 -t 100ms dash_in.mp4
 # packager 'in=dash_in.mp4,stream=audio,init_segment=dash_audio_init.mp4,segment_template=dash_audio_$Number$.m4s
 # packager 'in=dash_in.mp4,stream=video,init_segment=dash_video_init.mp4,segment_template=dash_video_$Number$.m4s'
-$ fq -d mp4 verbose /dash_audio_init.mp4
+$ fq -d mp4 dv /dash_audio_init.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_audio_init.mp4 (mp4) 0x0-0x32f.7 (816)
      |                                               |                |  boxes[0:2]: 0x0-0x32f.7 (816)
      |                                               |                |    [0]{}: box 0x0-0x1f.7 (32)
@@ -348,7 +348,7 @@ $ fq -d mp4 verbose /dash_audio_init.mp4
      |                                               |                |  tracks[0:1]: 0x330-NA (0)
      |                                               |                |    [0]{}: track 0x330-NA (0)
      |                                               |                |      samples[0:0]: 0x330-NA (0)
-$ fq -d mp4 verbose /dash_audio_1.m4s
+$ fq -d mp4 dv /dash_audio_1.m4s
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_audio_1.m4s (mp4) 0x0-0x4eb.7 (1260)
      |                                               |                |  boxes[0:4]: 0x0-0x4eb.7 (1260)
      |                                               |                |    [0]{}: box 0x0-0x1f.7 (32)
@@ -470,7 +470,7 @@ $ fq -d mp4 verbose /dash_audio_1.m4s
 0x100|61 76 63 35 38 2e 31 33 34 2e 31 30 30 00 02 5c|avc58.134.100..\|
 *    |until 0x4eb.7 (end) (1008)                     |                |
      |                                               |                |  tracks[0:0]: 0x4ec-NA (0)
-$ fq -d mp4 verbose /dash_video_init.mp4
+$ fq -d mp4 dv /dash_video_init.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_video_init.mp4 (mp4) 0x0-0x332.7 (819)
      |                                               |                |  boxes[0:2]: 0x0-0x332.7 (819)
      |                                               |                |    [0]{}: box 0x0-0x23.7 (36)
@@ -864,7 +864,7 @@ $ fq -d mp4 verbose /dash_video_init.mp4
      |                                               |                |  tracks[0:1]: 0x333-NA (0)
      |                                               |                |    [0]{}: track 0x333-NA (0)
      |                                               |                |      samples[0:0]: 0x333-NA (0)
-$ fq -d mp4 verbose /dash_video_1.m4s
+$ fq -d mp4 dv /dash_video_1.m4s
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_video_1.m4s (mp4) 0x0-0x1fd0.7 (8145)
       |                                               |                |  boxes[0:4]: 0x0-0x1fd0.7 (8145)
       |                                               |                |    [0]{}: box 0x0-0x23.7 (36)

--- a/format/mp4/testdata/flac.fqtest
+++ b/format/mp4/testdata/flac.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -ac 2 -c:a flac -strict experimental -f mp4 -t 50ms flac.mp4
-$ fq -d mp4 verbose /flac.mp4
+$ fq -d mp4 dv /flac.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /flac.mp4 (mp4) 0x0-0x542.7 (1347)
      |                                               |                |  boxes[0:4]: 0x0-0x542.7 (1347)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/fragmented.fqtest
+++ b/format/mp4/testdata/fragmented.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -f lavfi -i testsrc -g 1 -c:a aac -c:v h264 -f mp4 -movflags +global_sidx+frag_keyframe+empty_moov -t 100ms fragmented.mp4
-$ fq -d mp4 verbose /fragmented.mp4
+$ fq -d mp4 dv /fragmented.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /fragmented.mp4 (mp4) 0x0-0x2bb3.7 (11188)
       |                                               |                |  boxes[0:11]: 0x0-0x2bb3.7 (11188)
       |                                               |                |    [0]{}: box 0x0-0x23.7 (36)

--- a/format/mp4/testdata/heic.fqtest
+++ b/format/mp4/testdata/heic.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc=size=16x16:r=1 -preset slower -r 1 -t 1s -pix_fmt yuv420p -f hevc heic.hvc
 # MP4Box -add-image heic.hvc -ab heic -new heic.mp4
-$ fq -d mp4 verbose /heic.mp4
+$ fq -d mp4 dv /heic.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /heic.mp4 (mp4) 0x0-0xb2c.7 (2861)
      |                                               |                |  boxes[0:4]: 0x0-0xb2c.7 (2861)
      |                                               |                |    [0]{}: box 0x0-0x17.7 (24)

--- a/format/mp4/testdata/hevc.fqtest
+++ b/format/mp4/testdata/hevc.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v hevc -f mp4 -t 50ms hevc.mp4
-$ fq -d mp4 verbose /hevc.mp4
+$ fq -d mp4 dv /hevc.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /hevc.mp4 (mp4) 0x0-0x149a.7 (5275)
       |                                               |                |  boxes[0:4]: 0x0-0x149a.7 (5275)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/mp3.fqtest
+++ b/format/mp4/testdata/mp3.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -c:a mp3 -f mp4 -t 50ms mp3.mp4
-$ fq -d mp4 verbose /mp3.mp4
+$ fq -d mp4 dv /mp3.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3.mp4 (mp4) 0x0-0x564.7 (1381)
      |                                               |                |  boxes[0:4]: 0x0-0x564.7 (1381)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/mpeg2.fqtest
+++ b/format/mp4/testdata/mpeg2.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v mpeg2video -f mp4 -t 50ms mpeg2.mp4
-$ fq -d mp4 verbose /mpeg2.mp4
+$ fq -d mp4 dv /mpeg2.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mpeg2.mp4 (mp4) 0x0-0x22a8.7 (8873)
       |                                               |                |  boxes[0:4]: 0x0-0x22a8.7 (8873)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/opus.fqtest
+++ b/format/mp4/testdata/opus.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -strict experimental -c:a opus -t 50ms opus.mp4
-$ fq -d mp4 verbose /opus.mp4
+$ fq -d mp4 dv /opus.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus.mp4 (mp4) 0x0-0x438.7 (1081)
      |                                               |                |  boxes[0:4]: 0x0-0x438.7 (1081)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/vorbis.fqtest
+++ b/format/mp4/testdata/vorbis.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -ac 2 -strict experimental -c:a vorbis -t 50ms vorbis.mp4
-$ fq -d mp4 verbose /vorbis.mp4
+$ fq -d mp4 dv /vorbis.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis.mp4 (mp4) 0x0-0x1188.7 (4489)
       |                                               |                |  boxes[0:4]: 0x0-0x1188.7 (4489)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mp4/testdata/vp9.fqtest
+++ b/format/mp4/testdata/vp9.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i testsrc -c:v vp9 -t 50ms vp9.mp4
-$ fq -d mp4 verbose /vp9.mp4
+$ fq -d mp4 dv /vp9.mp4
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vp9.mp4 (mp4) 0x0-0x184e.7 (6223)
       |                                               |                |  boxes[0:4]: 0x0-0x184e.7 (6223)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)

--- a/format/mpeg/testdata/adts.fqtest
+++ b/format/mpeg/testdata/adts.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i sine -ac 2 -t 40ms -f adts adts
-$ fq -d adts verbose /adts
+$ fq -d adts dv /adts
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:3]: /adts (adts) 0x0-0x406.7 (1031)
      |                                               |                |  [0]{}: frame (adts_frame) 0x0-0x153.7 (340)
 0x000|ff f1                                          |..              |    syncword: 0b111111111111 (valid) 0x0-0x1.3 (1.4)

--- a/format/mpeg/testdata/avc_annexb.fqtest
+++ b/format/mpeg/testdata/avc_annexb.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i testsrc -t 10ms -f h264 avc_annexb
-$ fq -d avc_annexb verbose /avc_annexb
+$ fq -d avc_annexb dv /avc_annexb
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:8]: /avc_annexb (avc_annexb) 0x0-0xae4.7 (2789)
 0x0000|00 00 00 01                                    |....            |  [0]: raw bits start_code 0x0-0x3.7 (4)
       |                                               |                |  [1]{}: nalu (avc_nalu) 0x4-0x1c.7 (25)

--- a/format/mpeg/testdata/hevc_annexb.fqtest
+++ b/format/mpeg/testdata/hevc_annexb.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i testsrc -t 10ms -f hevc hevc_annexb
-$ fq -d hevc_annexb verbose /hevc_annexb
+$ fq -d hevc_annexb dv /hevc_annexb
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:10]: /hevc_annexb (hevc_annexb) 0x0-0x1193.7 (4500)
 0x0000|00 00 00 01                                    |....            |  [0]: raw bits start_code 0x0-0x3.7 (4)
       |                                               |                |  [1]{}: nalu (hevc_nalu) 0x4-0x1a.7 (23)

--- a/format/mpeg/testdata/mp3-frame-mono-crc.fqtest
+++ b/format/mpeg/testdata/mp3-frame-mono-crc.fqtest
@@ -1,4 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f wav pipe:1 | lame - - | fq - '.frame[1] | tobits' > mp3-frame-mono-crc
 $ fq -d mp3_frame '.header.crc | verbose' /mp3-frame-mono-crc
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|            2c b9                              |    ,.          |.header.crc: 0x2cb9 (valid) 0x4-0x5.7 (2)
+exitcode: 3
+stderr:
+error: arg:1:0: function not defined: verbose/0

--- a/format/mpeg/testdata/mp3-frame-mono.fqtest
+++ b/format/mpeg/testdata/mp3-frame-mono.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i sine -ac 1 -t 10ms -f mp3 file && fq file '.frame[1] | tobits' > mp3-frame-mono
-$ fq -d mp3_frame verbose /mp3-frame-mono
+$ fq -d mp3_frame dv /mp3-frame-mono
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3-frame-mono (mp3_frame) 0x0-0xcf.7 (208)
     |                                               |                |  header{}: 0x0-0x3.7 (4)
 0x00|ff fb                                          |..              |    sync: 0b11111111111 (valid) 0x0-0x1.2 (1.3)

--- a/format/mpeg/testdata/mp3-frame-stereo.fqtest
+++ b/format/mpeg/testdata/mp3-frame-stereo.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i sine -ac 2 -t 10ms -f mp3 file && fq file '.frame[1] | tobits' > mp3-frame-stereo
-$ fq -d mp3_frame verbose /mp3-frame-stereo
+$ fq -d mp3_frame dv /mp3-frame-stereo
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3-frame-stereo (mp3_frame) 0x0-0x1a0.7 (417)
      |                                               |                |  header{}: 0x0-0x3.7 (4)
 0x000|ff fb                                          |..              |    sync: 0b11111111111 (valid) 0x0-0x1.2 (1.3)

--- a/format/msgpack/testdata/ints.fqtest
+++ b/format/msgpack/testdata/ints.fqtest
@@ -1,5 +1,5 @@
 # fq -n '[0,1,2,3,4,5,6,7,8,9,127,128,-1,-2,-3,-4,-5,-6,-7,-8,-31,-32,0xffff_ffff,-0xffff_ffff,0x7fff_ffff,-0x7fff_ffff]' | json2msgpack > ints.msgpack
-$ fq -d msgpack v ints.msgpack
+$ fq -d msgpack dv ints.msgpack
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: ints.msgpack (msgpack) 0x0-0x31.7 (50)
 0x00|dc                                             |.               |  type: "array16" (0xdc) 0x0-0x0.7 (1)
 0x00|   00 1a                                       | ..             |  length: 26 0x1-0x2.7 (2)

--- a/format/msgpack/testdata/test.fqtest
+++ b/format/msgpack/testdata/test.fqtest
@@ -1,6 +1,6 @@
 # msgpack-tools
 # echo '{"array": [1,2,3], "object": {"key": "value"}, "number": 123, "string": "abc", "true": true, "false": false, "null": null}' | json2msgpack > test.msgpack
-$ fq -d msgpack v test.msgpack
+$ fq -d msgpack dv test.msgpack
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.msgpack (msgpack) 0x0-0x42.7 (67)
 0x00|87                                             |.               |  type: "fixmap" (0x87) 0x0-0x0.7 (1)
 0x00|87                                             |.               |  length: 7 0x0.4-0x0.7 (0.4)

--- a/format/ogg/testdata/flac.fqtest
+++ b/format/ogg/testdata/flac.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 50ms -c:a flac flac.ogg
-$ fq -d ogg verbose /flac.ogg
+$ fq -d ogg dv /flac.ogg
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /flac.ogg (ogg) 0x0-0x31b.7 (796)
       |                                               |                |  pages[0:3]: 0x0-0x31b.7 (796)
       |                                               |                |    [0]{}: page (ogg_page) 0x0-0x4e.7 (79)

--- a/format/ogg/testdata/opsu.fqtest
+++ b/format/ogg/testdata/opsu.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 50ms -c:a libopus opus.ogg
-$ fq -d ogg verbose /opus.ogg
+$ fq -d ogg dv /opus.ogg
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus.ogg (ogg) 0x0-0x3b0.7 (945)
       |                                               |                |  pages[0:3]: 0x0-0x3b0.7 (945)
       |                                               |                |    [0]{}: page (ogg_page) 0x0-0x2e.7 (47)

--- a/format/ogg/testdata/page.fqtest
+++ b/format/ogg/testdata/page.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.page[0] | tobits' > page
-$ fq -d ogg_page verbose /page
+$ fq -d ogg_page dv /page
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /page (ogg_page) 0x0-0x39.7 (58)
 0x00|4f 67 67 53                                    |OggS            |  capture_pattern: "OggS" (valid) 0x0-0x3.7 (4)
 0x00|            00                                 |    .           |  version: 0 (valid) 0x4-0x4.7 (1)

--- a/format/ogg/testdata/vorbis.fqtest
+++ b/format/ogg/testdata/vorbis.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 50ms -c:a libvorbis vorbis.ogg
-$ fq -d ogg verbose /vorbis.ogg
+$ fq -d ogg dv /vorbis.ogg
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis.ogg (ogg) 0x0-0xe46.7 (3655)
       |                                               |                |  pages[0:3]: 0x0-0xe46.7 (3655)
       |                                               |                |    [0]{}: page (ogg_page) 0x0-0x39.7 (58)

--- a/format/opus/testdata/opus.fqtest
+++ b/format/opus/testdata/opus.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i sine -t 10ms -ac 2 -metadata artist=bla -c:a libopus opus.ogg
 # fq opus.ogg '.stream[0].packet[1] | tobits' > opus-tags
-$ fq -d opus_packet verbose /opus-audio
+$ fq -d opus_packet dv /opus-audio
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus-audio (opus_packet) 0x0-0x1b5.7 (438)
      |                                               |                |  type: "audio" 0x0-NA (0)
      |                                               |                |  toc{}: 0x0-0x1b5.7 (438)
@@ -17,7 +17,7 @@ $ fq -d opus_packet verbose /opus-audio
 0x000|   70 5b f3 71 54 45 4a c7 79 14 ea d1 59 61 85| p[.qTEJ.y...Ya.|    data: raw bits 0x1-0x1b5.7 (437)
 0x010|c8 c2 56 2c a6 b7 6e 98 00 9b 34 cb 23 1d 98 b7|..V,..n...4.#...|
 *    |until 0x1b5.7 (end) (437)                      |                |
-$ fq -d opus_packet verbose /opus-head
+$ fq -d opus_packet dv /opus-head
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus-head (opus_packet) 0x0-0x12.7 (19)
     |                                               |                |  type: "head" 0x0-NA (0)
 0x00|4f 70 75 73 48 65 61 64                        |OpusHead        |  prefix: "OpusHead" 0x0-0x7.7 (8)
@@ -27,7 +27,7 @@ $ fq -d opus_packet verbose /opus-head
 0x00|                                    80 bb 00 00|            ....|  sample_rate: 48000 0xc-0xf.7 (4)
 0x10|00 00                                          |..              |  output_gain: 0 0x10-0x11.7 (2)
 0x10|      00|                                      |  .|            |  map_family: 0 0x12-0x12.7 (1)
-$ fq -d opus_packet verbose /opus-tags
+$ fq -d opus_packet dv /opus-tags
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus-tags (opus_packet) 0x0-0x4b.7 (76)
     |                                               |                |  type: "tags" 0x0-NA (0)
 0x00|4f 70 75 73 54 61 67 73                        |OpusTags        |  prefix: "OpusTags" 0x0-0x7.7 (8)

--- a/format/pcap/testdata/dhcp_big_endian.fqtest
+++ b/format/pcap/testdata/dhcp_big_endian.fqtest
@@ -1,5 +1,5 @@
 # from https://wiki.wireshark.org/Development/PcapNg
-$ fq -d pcapng verbose /dhcp_big_endian.pcapng
+$ fq -d pcapng dv /dhcp_big_endian.pcapng
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: /dhcp_big_endian.pcapng (pcapng) 0x0-0x5fb.7 (1532)
      |                                               |                |  [0]{}: section 0x0-0x5fb.7 (1532)
      |                                               |                |    blocks[0:7]: 0x0-0x5fb.7 (1532)

--- a/format/pcap/testdata/dhcp_little_endian.fqtest
+++ b/format/pcap/testdata/dhcp_little_endian.fqtest
@@ -1,5 +1,5 @@
 # from https://wiki.wireshark.org/Development/PcapNg
-$ fq -d pcapng verbose /dhcp_little_endian.pcapng
+$ fq -d pcapng dv /dhcp_little_endian.pcapng
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: /dhcp_little_endian.pcapng (pcapng) 0x0-0x5fb.7 (1532)
      |                                               |                |  [0]{}: section 0x0-0x5fb.7 (1532)
      |                                               |                |    blocks[0:7]: 0x0-0x5fb.7 (1532)

--- a/format/pcap/testdata/http_gzip.fqtest
+++ b/format/pcap/testdata/http_gzip.fqtest
@@ -1,5 +1,5 @@
 # from https://wiki.wireshark.org/SampleCaptures
-$ fq -d pcap verbose /http_gzip.cap
+$ fq -d pcap dv /http_gzip.cap
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /http_gzip.cap (pcap) 0x0-0x6aa.7 (1707)
 0x0000|d4 c3 b2 a1                                    |....            |  magic: "little_endian" (0xd4c3b2a1) (valid) 0x0-0x3.7 (4)
 0x0000|            02 00                              |    ..          |  version_major: 2 0x4-0x5.7 (2)

--- a/format/pcap/testdata/ipv4frags.fqtest
+++ b/format/pcap/testdata/ipv4frags.fqtest
@@ -1,5 +1,5 @@
 # from https://wiki.wireshark.org/SampleCaptures
-$ fq -d pcap verbose /ipv4frags.pcap
+$ fq -d pcap dv /ipv4frags.pcap
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /ipv4frags.pcap (pcap) 0x0-0xbad.7 (2990)
 0x0000|d4 c3 b2 a1                                    |....            |  magic: "little_endian" (0xd4c3b2a1) (valid) 0x0-0x3.7 (4)
 0x0000|            02 00                              |    ..          |  version_major: 2 0x4-0x5.7 (2)

--- a/format/pcap/testdata/many_interfaces.fqtest
+++ b/format/pcap/testdata/many_interfaces.fqtest
@@ -1,5 +1,5 @@
 # from https://wiki.wireshark.org/Development/PcapNg
-$ fq -d pcapng verbose /many_interfaces.pcapng
+$ fq -d pcapng dv /many_interfaces.pcapng
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: /many_interfaces.pcapng (pcapng) 0x0-0x51b7.7 (20920)
       |                                               |                |  [0]{}: section 0x0-0x51b7.7 (20920)
       |                                               |                |    blocks[0:88]: 0x0-0x51b7.7 (20920)

--- a/format/pcap/testdata/sll2_tcp.fqtest
+++ b/format/pcap/testdata/sll2_tcp.fqtest
@@ -1,4 +1,4 @@
-$ fq -d pcap verbose /sll2_tcp.pcap
+$ fq -d pcap dv /sll2_tcp.pcap
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /sll2_tcp.pcap (pcap) 0x0-0x1e4.7 (485)
 0x000|d4 c3 b2 a1                                    |....            |  magic: "little_endian" (0xd4c3b2a1) (valid) 0x0-0x3.7 (4)
 0x000|            02 00                              |    ..          |  version_major: 2 0x4-0x5.7 (2)

--- a/format/png/testdata/4x4.fqtest
+++ b/format/png/testdata/4x4.fqtest
@@ -1,7 +1,7 @@
 # convert -size 4x4 "xc:#000" 4x4.png
 # pngcrush -ztxt a akeyword atext 4x4.png 4x4out.png
 # mv 4x4out.png 4x4.png
-$ fq -d png verbose /4x4.png
+$ fq -d png dv /4x4.png
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.png (png) 0x0-0x125.7 (294)
 0x000|89 50 4e 47 0d 0a 1a 0a                        |.PNG....        |  signature: raw bits (valid) 0x0-0x7.7 (8)
      |                                               |                |  chunks[0:10]: 0x8-0x125.7 (286)

--- a/format/png/testdata/4x4_palette.fqtest
+++ b/format/png/testdata/4x4_palette.fqtest
@@ -1,5 +1,5 @@
 # gm convert -size 4x4 'gradient:#ff00ff-#00ff00' -colors 254 4x4_palette.png
-$ fq verbose 4x4_palette.png
+$ fq dv 4x4_palette.png
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4_palette.png (png) 0x0-0x60.7 (97)
 0x00|89 50 4e 47 0d 0a 1a 0a                        |.PNG....        |  signature: raw bits (valid) 0x0-0x7.7 (8)
     |                                               |                |  chunks[0:4]: 0x8-0x60.7 (89)

--- a/format/png/testdata/4x4a.fqtest
+++ b/format/png/testdata/4x4a.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -y -f lavfi -i testsrc=size=4x4:r=1 -t 2s 4x4a.apng
-$ fq -d png verbose /4x4a.apng
+$ fq -d png dv /4x4a.apng
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4a.apng (png) 0x0-0xf3.7 (244)
 0x00|89 50 4e 47 0d 0a 1a 0a                        |.PNG....        |  signature: raw bits (valid) 0x0-0x7.7 (8)
     |                                               |                |  chunks[0:8]: 0x8-0xf3.7 (236)

--- a/format/protobuf/testdata/golden_message.fqtest
+++ b/format/protobuf/testdata/golden_message.fqtest
@@ -1,7 +1,7 @@
 # from https://github.com/protocolbuffers/protobuf/blob/master/objectivec/Tests/golden_message
 # https://github.com/protocolbuffers/protobuf/blob/master/LICENSE
 # TODO: test with schema somehow
-$ fq -d protobuf v /golden_message
+$ fq -d protobuf dv /golden_message
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /golden_message (protobuf) 0x0-0x212.7 (531)
      |                                               |                |  fields[0:106]: 0x0-0x212.7 (531)
      |                                               |                |    [0]{}: field 0x0-0x1.7 (2)

--- a/format/tar/testdata/no_end_marker.fqtest
+++ b/format/tar/testdata/no_end_marker.fqtest
@@ -1,5 +1,5 @@
 # fq 'tobytes[0:.end_marker | tobytesrange.start]' test.tar > no_end_marker.tar
-$ fq v no_end_marker.tar
+$ fq dv no_end_marker.tar
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: no_end_marker.tar (tar) 0x0-0x3ff.7 (1024)
      |                                               |                |  files[0:1]: 0x0-0x3ff.7 (1024)
      |                                               |                |    [0]{}: file 0x0-0x3ff.7 (1024)

--- a/format/tar/testdata/tar.fqtest
+++ b/format/tar/testdata/tar.fqtest
@@ -1,6 +1,6 @@
 # echo hello > test
 # tar test c > test.tar
-$ fq -d tar v /test.tar
+$ fq -d tar dv /test.tar
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.tar (tar) 0x0-0x27ff.7 (10240)
       |                                               |                |  files[0:1]: 0x0-0x3ff.7 (1024)
       |                                               |                |    [0]{}: file 0x0-0x3ff.7 (1024)

--- a/format/tiff/testdata/4x4.fqtest
+++ b/format/tiff/testdata/4x4.fqtest
@@ -1,5 +1,5 @@
 # gm convert -size 4x4 'xc:#000' 4x4.tiff
-$ fq -d tiff verbose /4x4.tiff
+$ fq -d tiff dv /4x4.tiff
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.tiff (tiff) 0x0-0x107.7 (264)
 0x000|49 49 2a 00                                    |II*.            |  endian: "little-endian" (0x49492a00) 0x0-0x3.7 (4)
 0x000|49 49                                          |II              |  order: "II" (valid) 0x0-0x1.7 (2)

--- a/format/vorbis/testdata/vorbis-comment-picture.fqtest
+++ b/format/vorbis/testdata/vorbis-comment-picture.fqtest
@@ -2,7 +2,7 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg test.ogg
 # vorbiscomment -a test.ogg -t METADATA_BLOCK_PICTURE=$(fq -r '.. | select(format=="flac_picture") | tobytes | base64' test.flac)
 # fq '.. | select(format=="vorbis_comment") | tobytes' test.ogg > vorbis-comment-picture
-$ fq -d vorbis_comment verbose /vorbis-comment-picture
+$ fq -d vorbis_comment dv /vorbis-comment-picture
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-comment-picture (vorbis_comment) 0x0-0x11f.7 (288)
 0x000|0d 00 00 00                                    |....            |  vendor_length: 13 0x0-0x3.7 (4)
 0x000|            4c 61 76 66 35 38 2e 37 36 2e 31 30|    Lavf58.76.10|  vendor: "Lavf58.76.100" 0x4-0x10.7 (13)

--- a/format/vorbis/testdata/vorbis.fqtest
+++ b/format/vorbis/testdata/vorbis.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.steam[0].packet[0] | tobits' > vorbis-identifcation
-$ fq -d vorbis_packet verbose /vorbis-identifcation
+$ fq -d vorbis_packet dv /vorbis-identifcation
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-identifcation (vorbis_packet) 0x0-0x1d.7 (30)
 0x00|01                                             |.               |  packet_type: "Identification" (1) 0x0-0x0.7 (1)
 0x00|   76 6f 72 62 69 73                           | vorbis         |  magic: "vorbis" (valid) 0x1-0x6.7 (6)
@@ -14,7 +14,7 @@ $ fq -d vorbis_packet verbose /vorbis-identifcation
 0x10|                                       01|     |             .| |  padding0: raw bits (all zero) 0x1d-0x1d.6 (0.7)
 0x10|                                       01|     |             .| |  framing_flag: 1 (valid) 0x1d.7-0x1d.7 (0.1)
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.packet[1] | tobits' > vorbis-comment
-$ fq -d vorbis_packet verbose /vorbis-comment
+$ fq -d vorbis_packet dv /vorbis-comment
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-comment (vorbis_packet) 0x0-0x3f.7 (64)
 0x00|03                                             |.               |  packet_type: "Comment" (3) 0x0-0x0.7 (1)
 0x00|   76 6f 72 62 69 73                           | vorbis         |  magic: "vorbis" (valid) 0x1-0x6.7 (6)
@@ -31,7 +31,7 @@ $ fq -d vorbis_packet verbose /vorbis-comment
 0x30|                                             01|               .|  padding0: raw bits (all zero) 0x3f-0x3f.6 (0.7)
 0x30|                                             01|               .|  frame_bit: 1 (valid) 0x3f.7-0x3f.7 (0.1)
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.packet[2] | tobits' > vorbis-setup
-$ fq -d vorbis_packet verbose /vorbis-setup
+$ fq -d vorbis_packet dv /vorbis-setup
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-setup (vorbis_packet) 0x0-0xc74.7 (3189)
 0x000|05                                             |.               |  packet_type: "Setup" (5) 0x0-0x0.7 (1)
 0x000|   76 6f 72 62 69 73                           | vorbis         |  magic: "vorbis" (valid) 0x1-0x6.7 (6)
@@ -42,7 +42,7 @@ $ fq -d vorbis_packet verbose /vorbis-setup
 0x010|24 73 18 2a 46 a5 73 16 84 10 1a 42 50 19 e3 1c|$s.*F.s....BP...|  unknown0: raw bits 0x10-0xc74.7 (3173)
 *    |until 0xc74.7 (end) (3173)                     |                |
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.packet[3] | tobits' > vorbis-audio
-$ fq -d vorbis_packet verbose /vorbis-audio
+$ fq -d vorbis_packet dv /vorbis-audio
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-audio (vorbis_packet) 0x0-0x20.7 (33)
 0x00|54                                             |T               |  packet_type: "Audio" (0) 0x0-0x0.7 (1)
 0x00|   dd cb ce aa 5e d8 7f 2d 01 42 00 a0 dd 71 77| ....^..-.B...qw|  unknown0: raw bits 0x1-0x20.7 (32)

--- a/format/wav/testdata/end-of-file.fqtest
+++ b/format/wav/testdata/end-of-file.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -ac 2 -f wav pipe:1 > end-of-file.wav
-$ fq -d wav verbose /end-of-file.wav
+$ fq -d wav dv /end-of-file.wav
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /end-of-file.wav (wav) 0x0-0x731.7 (1842)
 0x000|52 49 46 46                                    |RIFF            |  id: "RIFF" 0x0-0x3.7 (4)
 0x000|            ff ff ff ff                        |    ....        |  size: "rest of file" (0xffffffff) 0x4-0x7.7 (4)

--- a/format/wav/testdata/stereo.fqtest
+++ b/format/wav/testdata/stereo.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -ac 2 stereo.wav
-$ fq -d wav verbose /stereo.wav
+$ fq -d wav dv /stereo.wav
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo.wav (wav) 0x0-0x731.7 (1842)
 0x000|52 49 46 46                                    |RIFF            |  id: "RIFF" 0x0-0x3.7 (4)
 0x000|            2a 07 00 00                        |    *...        |  size: 1834 0x4-0x7.7 (4)

--- a/format/webp/testdata/4x4.fqtest
+++ b/format/webp/testdata/4x4.fqtest
@@ -1,5 +1,5 @@
 # convert -size 4x4 "xc:#000" 4x4.webp
-$ fq -d webp verbose /4x4.webp
+$ fq -d webp dv /4x4.webp
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.webp (webp) 0x0-0x2b.7 (44)
 0x00|52 49 46 46                                    |RIFF            |  riff_id: "RIFF" (valid) 0x0-0x3.7 (4)
 0x00|            24 00 00 00                        |    $...        |  riff_length: 36 0x4-0x7.7 (4)

--- a/format/zip/testdata/test-macos.fqtest
+++ b/format/zip/testdata/test-macos.fqtest
@@ -1,4 +1,4 @@
-$ fq -d zip verbose /test-macos.zip
+$ fq -d zip dv /test-macos.zip
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test-macos.zip (zip) 0x0-0x435.7 (1078)
       |                                               |                |  local_files[0:5]: 0x0-0x26d.7 (622)
       |                                               |                |    [0]{}: local_file 0x0-0x42.7 (67)

--- a/format/zip/testdata/test0.fqtest
+++ b/format/zip/testdata/test0.fqtest
@@ -1,4 +1,4 @@
-$ fq -d zip verbose /test0.zip
+$ fq -d zip dv /test0.zip
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test0.zip (zip) 0x0-0x3c7.7 (968)
       |                                               |                |  local_files[0:5]: 0x0-0x227.7 (552)
       |                                               |                |    [0]{}: local_file 0x0-0x3e.7 (63)

--- a/format/zip/testdata/test9.fqtest
+++ b/format/zip/testdata/test9.fqtest
@@ -1,4 +1,4 @@
-$ fq -d zip verbose /test9.zip
+$ fq -d zip dv /test9.zip
       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test9.zip (zip) 0x0-0x3c7.7 (968)
       |                                               |                |  local_files[0:5]: 0x0-0x227.7 (552)
       |                                               |                |    [0]{}: local_file 0x0-0x3e.7 (63)

--- a/pkg/interp/interp.jq
+++ b/pkg/interp/interp.jq
@@ -29,15 +29,14 @@ def _exit_code_expr_error: 5;
 
 def d($opts): display($opts);
 def d: display({});
-def full($opts): display({array_truncate: 0} + $opts);
-# TODO: rename, gets mixed up with f args often
-def full: full({});
-def f($opts): full($opts);
-def f: full;
-def verbose($opts): display({verbose: true, array_truncate: 0} + $opts);
-def verbose: verbose({});
-def v($opts): verbose($opts);
-def v: verbose;
+def da($opts): display({array_truncate: 0} + $opts);
+def da: da({});
+def dd($opts): display({array_truncate: 0, display_bytes: 0} + $opts);
+def dd: dd({});
+def dv($opts): display({array_truncate: 0, verbose: true} + $opts);
+def dv: dv({});
+def ddv($opts): display({array_truncate: 0, display_bytes: 0, verbose: true} + $opts);
+def ddv: ddv({});
 
 # next valid input
 def input:

--- a/pkg/interp/testdata/display.fqtest
+++ b/pkg/interp/testdata/display.fqtest
@@ -42,7 +42,7 @@ mp3> display({depth: 1, line_bytes: 8})
 0x038|00 00 00 00 00 00 00 00|........|
 *    |until 0x283.7 (end) (599)|        |
      |                       |        |  footers[0:0]:
-mp3> .frames[0] | verbose({depth: 1, addrbase: 10})
+mp3> .frames[0] | dv({depth: 1, addrbase: 10})
    |00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15|0123456789012345|.frames[0]{}: frame (mp3_frame) 45-226.7 (182)
 032|                                       ff fb 40|             ..@|  header{}: 45-48.7 (4)
 048|c0                                             |.               |
@@ -54,7 +54,7 @@ mp3> .frames[0] | verbose({depth: 1, addrbase: 10})
 208|                                          00 00|              ..|  padding: raw bits 222-226.7 (5)
 224|00 00 00                                       |...             |
    |                                               |                |  crc_calculated: "827a" (raw bits) 227-NA (0)
-mp3> .frames[0] | verbose({depth: 1, sizebase: 16})
+mp3> .frames[0] | dv({depth: 1, sizebase: 16})
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0]{}: frame (mp3_frame) 0x2d-0xe2.7 (0xb6)
 0x20|                                       ff fb 40|             ..@|  header{}: 0x2d-0x30.7 (0x4)
 0x30|c0                                             |.               |
@@ -66,7 +66,8 @@ mp3> .frames[0] | verbose({depth: 1, sizebase: 16})
 0xd0|                                          00 00|              ..|  padding: raw bits 0xde-0xe2.7 (0x5)
 0xe0|00 00 00                                       |...             |
     |                                               |                |  crc_calculated: "827a" (raw bits) 0xe3-NA (0x0)
-mp3> .frames[0].xing | d, f, v
+mp3> .frames[0].xing | "d", d, "da", da, "dd", dd, "dv", dv, "ddv", ddv
+"d"
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].xing{}: (xing)
 0x40|      49 6e 66 6f                              |  Info          |  header: "Info"
     |                                               |                |  present_flags{}:
@@ -152,6 +153,7 @@ mp3> .frames[0].xing | d, f, v
 0xd0|                  00 00 02 57                  |      ...W      |    length: 599
 0xd0|                              62 f0            |          b.    |    music_crc: 25328
 0xd0|                                    5a 35      |            Z5  |    tag_crc: 23093
+"da"
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].xing{}: (xing)
 0x40|      49 6e 66 6f                              |  Info          |  header: "Info"
     |                                               |                |  present_flags{}:
@@ -286,6 +288,277 @@ mp3> .frames[0].xing | d, f, v
 0xd0|                  00 00 02 57                  |      ...W      |    length: 599
 0xd0|                              62 f0            |          b.    |    music_crc: 25328
 0xd0|                                    5a 35      |            Z5  |    tag_crc: 23093
+"dd"
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].xing{}: (xing)
+0x40|      49 6e 66 6f                              |  Info          |  header: "Info"
+    |                                               |                |  present_flags{}:
+0x40|                  00 00 00 0f                  |      ....      |    unused: 0
+0x40|                           0f                  |         .      |    quality: true
+0x40|                           0f                  |         .      |    toc: true
+0x40|                           0f                  |         .      |    bytes: true
+0x40|                           0f                  |         .      |    frames: true
+0x40|                              00 00 00 02      |          ....  |  frames: 2
+0x40|                                          00 00|              ..|  bytes: 599
+0x50|02 57                                          |.W              |
+    |                                               |                |  toc[0:100]:
+0x50|      00                                       |  .             |    [0]: 0
+0x50|         a6                                    |   .            |    [1]: 166
+0x50|            a6                                 |    .           |    [2]: 166
+0x50|               a6                              |     .          |    [3]: 166
+0x50|                  a6                           |      .         |    [4]: 166
+0x50|                     a6                        |       .        |    [5]: 166
+0x50|                        a6                     |        .       |    [6]: 166
+0x50|                           a6                  |         .      |    [7]: 166
+0x50|                              a6               |          .     |    [8]: 166
+0x50|                                 a6            |           .    |    [9]: 166
+0x50|                                    a6         |            .   |    [10]: 166
+0x50|                                       a6      |             .  |    [11]: 166
+0x50|                                          a6   |              . |    [12]: 166
+0x50|                                             a6|               .|    [13]: 166
+0x60|a6                                             |.               |    [14]: 166
+0x60|   a6                                          | .              |    [15]: 166
+0x60|      a6                                       |  .             |    [16]: 166
+0x60|         a6                                    |   .            |    [17]: 166
+0x60|            a6                                 |    .           |    [18]: 166
+0x60|               a6                              |     .          |    [19]: 166
+0x60|                  a6                           |      .         |    [20]: 166
+0x60|                     a6                        |       .        |    [21]: 166
+0x60|                        a6                     |        .       |    [22]: 166
+0x60|                           a6                  |         .      |    [23]: 166
+0x60|                              a6               |          .     |    [24]: 166
+0x60|                                 a6            |           .    |    [25]: 166
+0x60|                                    a6         |            .   |    [26]: 166
+0x60|                                       a6      |             .  |    [27]: 166
+0x60|                                          a6   |              . |    [28]: 166
+0x60|                                             a6|               .|    [29]: 166
+0x70|a6                                             |.               |    [30]: 166
+0x70|   a6                                          | .              |    [31]: 166
+0x70|      a6                                       |  .             |    [32]: 166
+0x70|         a6                                    |   .            |    [33]: 166
+0x70|            a6                                 |    .           |    [34]: 166
+0x70|               a6                              |     .          |    [35]: 166
+0x70|                  a6                           |      .         |    [36]: 166
+0x70|                     a6                        |       .        |    [37]: 166
+0x70|                        a6                     |        .       |    [38]: 166
+0x70|                           a6                  |         .      |    [39]: 166
+0x70|                              a6               |          .     |    [40]: 166
+0x70|                                 a6            |           .    |    [41]: 166
+0x70|                                    a6         |            .   |    [42]: 166
+0x70|                                       a6      |             .  |    [43]: 166
+0x70|                                          a6   |              . |    [44]: 166
+0x70|                                             a6|               .|    [45]: 166
+0x80|a6                                             |.               |    [46]: 166
+0x80|   a6                                          | .              |    [47]: 166
+0x80|      a6                                       |  .             |    [48]: 166
+0x80|         a6                                    |   .            |    [49]: 166
+0x80|            ff                                 |    .           |    [50]: 255
+0x80|               ff                              |     .          |    [51]: 255
+0x80|                  ff                           |      .         |    [52]: 255
+0x80|                     ff                        |       .        |    [53]: 255
+0x80|                        ff                     |        .       |    [54]: 255
+0x80|                           ff                  |         .      |    [55]: 255
+0x80|                              ff               |          .     |    [56]: 255
+0x80|                                 ff            |           .    |    [57]: 255
+0x80|                                    ff         |            .   |    [58]: 255
+0x80|                                       ff      |             .  |    [59]: 255
+0x80|                                          ff   |              . |    [60]: 255
+0x80|                                             ff|               .|    [61]: 255
+0x90|ff                                             |.               |    [62]: 255
+0x90|   ff                                          | .              |    [63]: 255
+0x90|      ff                                       |  .             |    [64]: 255
+0x90|         ff                                    |   .            |    [65]: 255
+0x90|            ff                                 |    .           |    [66]: 255
+0x90|               ff                              |     .          |    [67]: 255
+0x90|                  ff                           |      .         |    [68]: 255
+0x90|                     ff                        |       .        |    [69]: 255
+0x90|                        ff                     |        .       |    [70]: 255
+0x90|                           ff                  |         .      |    [71]: 255
+0x90|                              ff               |          .     |    [72]: 255
+0x90|                                 ff            |           .    |    [73]: 255
+0x90|                                    ff         |            .   |    [74]: 255
+0x90|                                       ff      |             .  |    [75]: 255
+0x90|                                          ff   |              . |    [76]: 255
+0x90|                                             ff|               .|    [77]: 255
+0xa0|ff                                             |.               |    [78]: 255
+0xa0|   ff                                          | .              |    [79]: 255
+0xa0|      ff                                       |  .             |    [80]: 255
+0xa0|         ff                                    |   .            |    [81]: 255
+0xa0|            ff                                 |    .           |    [82]: 255
+0xa0|               ff                              |     .          |    [83]: 255
+0xa0|                  ff                           |      .         |    [84]: 255
+0xa0|                     ff                        |       .        |    [85]: 255
+0xa0|                        ff                     |        .       |    [86]: 255
+0xa0|                           ff                  |         .      |    [87]: 255
+0xa0|                              ff               |          .     |    [88]: 255
+0xa0|                                 ff            |           .    |    [89]: 255
+0xa0|                                    ff         |            .   |    [90]: 255
+0xa0|                                       ff      |             .  |    [91]: 255
+0xa0|                                          ff   |              . |    [92]: 255
+0xa0|                                             ff|               .|    [93]: 255
+0xb0|ff                                             |.               |    [94]: 255
+0xb0|   ff                                          | .              |    [95]: 255
+0xb0|      ff                                       |  .             |    [96]: 255
+0xb0|         ff                                    |   .            |    [97]: 255
+0xb0|            ff                                 |    .           |    [98]: 255
+0xb0|               ff                              |     .          |    [99]: 255
+0xb0|                  00 00 00 00                  |      ....      |  quality: 0
+    |                                               |                |  lame_extension{}:
+0xb0|                              4c 61 76 63 35 38|          Lavc58|    encoder: "Lavc58.91"
+0xc0|2e 39 31                                       |.91             |
+0xc0|         00                                    |   .            |    tag_revision: 0
+0xc0|         00                                    |   .            |    vbr_method: 0
+0xc0|            00                                 |    .           |    lowpass_filter: 0
+0xc0|               00 00 00 00                     |     ....       |    replay_gain_peak: 0
+0xc0|                           00 00               |         ..     |    radio_replay_gain: 0
+0xc0|                                 00 00         |           ..   |    audiophile_replay_gain: 0
+0xc0|                                       00      |             .  |    lame_flags: 0
+0xc0|                                       00      |             .  |    lame_ath_type: 0
+0xc0|                                          00   |              . |    abr_vbr: 0
+0xc0|                                             24|               $|    encoder_delay: 576
+0xd0|05                                             |.               |
+0xd0|05 07                                          |..              |    encoder_padding: 1287
+0xd0|      00                                       |  .             |    misc: 0
+0xd0|         00                                    |   .            |    mp3_gain: 0
+0xd0|            00 00                              |    ..          |    preset: 0
+0xd0|                  00 00 02 57                  |      ...W      |    length: 599
+0xd0|                              62 f0            |          b.    |    music_crc: 25328
+0xd0|                                    5a 35      |            Z5  |    tag_crc: 23093
+"dv"
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].xing{}: (xing) 0x42-0xdd.7 (156)
+0x40|      49 6e 66 6f                              |  Info          |  header: "Info" 0x42-0x45.7 (4)
+    |                                               |                |  present_flags{}: 0x46-0x49.7 (4)
+0x40|                  00 00 00 0f                  |      ....      |    unused: 0 0x46-0x49.3 (3.4)
+0x40|                           0f                  |         .      |    quality: true 0x49.4-0x49.4 (0.1)
+0x40|                           0f                  |         .      |    toc: true 0x49.5-0x49.5 (0.1)
+0x40|                           0f                  |         .      |    bytes: true 0x49.6-0x49.6 (0.1)
+0x40|                           0f                  |         .      |    frames: true 0x49.7-0x49.7 (0.1)
+0x40|                              00 00 00 02      |          ....  |  frames: 2 0x4a-0x4d.7 (4)
+0x40|                                          00 00|              ..|  bytes: 599 0x4e-0x51.7 (4)
+0x50|02 57                                          |.W              |
+    |                                               |                |  toc[0:100]: 0x52-0xb5.7 (100)
+0x50|      00                                       |  .             |    [0]: 0 entry 0x52-0x52.7 (1)
+0x50|         a6                                    |   .            |    [1]: 166 entry 0x53-0x53.7 (1)
+0x50|            a6                                 |    .           |    [2]: 166 entry 0x54-0x54.7 (1)
+0x50|               a6                              |     .          |    [3]: 166 entry 0x55-0x55.7 (1)
+0x50|                  a6                           |      .         |    [4]: 166 entry 0x56-0x56.7 (1)
+0x50|                     a6                        |       .        |    [5]: 166 entry 0x57-0x57.7 (1)
+0x50|                        a6                     |        .       |    [6]: 166 entry 0x58-0x58.7 (1)
+0x50|                           a6                  |         .      |    [7]: 166 entry 0x59-0x59.7 (1)
+0x50|                              a6               |          .     |    [8]: 166 entry 0x5a-0x5a.7 (1)
+0x50|                                 a6            |           .    |    [9]: 166 entry 0x5b-0x5b.7 (1)
+0x50|                                    a6         |            .   |    [10]: 166 entry 0x5c-0x5c.7 (1)
+0x50|                                       a6      |             .  |    [11]: 166 entry 0x5d-0x5d.7 (1)
+0x50|                                          a6   |              . |    [12]: 166 entry 0x5e-0x5e.7 (1)
+0x50|                                             a6|               .|    [13]: 166 entry 0x5f-0x5f.7 (1)
+0x60|a6                                             |.               |    [14]: 166 entry 0x60-0x60.7 (1)
+0x60|   a6                                          | .              |    [15]: 166 entry 0x61-0x61.7 (1)
+0x60|      a6                                       |  .             |    [16]: 166 entry 0x62-0x62.7 (1)
+0x60|         a6                                    |   .            |    [17]: 166 entry 0x63-0x63.7 (1)
+0x60|            a6                                 |    .           |    [18]: 166 entry 0x64-0x64.7 (1)
+0x60|               a6                              |     .          |    [19]: 166 entry 0x65-0x65.7 (1)
+0x60|                  a6                           |      .         |    [20]: 166 entry 0x66-0x66.7 (1)
+0x60|                     a6                        |       .        |    [21]: 166 entry 0x67-0x67.7 (1)
+0x60|                        a6                     |        .       |    [22]: 166 entry 0x68-0x68.7 (1)
+0x60|                           a6                  |         .      |    [23]: 166 entry 0x69-0x69.7 (1)
+0x60|                              a6               |          .     |    [24]: 166 entry 0x6a-0x6a.7 (1)
+0x60|                                 a6            |           .    |    [25]: 166 entry 0x6b-0x6b.7 (1)
+0x60|                                    a6         |            .   |    [26]: 166 entry 0x6c-0x6c.7 (1)
+0x60|                                       a6      |             .  |    [27]: 166 entry 0x6d-0x6d.7 (1)
+0x60|                                          a6   |              . |    [28]: 166 entry 0x6e-0x6e.7 (1)
+0x60|                                             a6|               .|    [29]: 166 entry 0x6f-0x6f.7 (1)
+0x70|a6                                             |.               |    [30]: 166 entry 0x70-0x70.7 (1)
+0x70|   a6                                          | .              |    [31]: 166 entry 0x71-0x71.7 (1)
+0x70|      a6                                       |  .             |    [32]: 166 entry 0x72-0x72.7 (1)
+0x70|         a6                                    |   .            |    [33]: 166 entry 0x73-0x73.7 (1)
+0x70|            a6                                 |    .           |    [34]: 166 entry 0x74-0x74.7 (1)
+0x70|               a6                              |     .          |    [35]: 166 entry 0x75-0x75.7 (1)
+0x70|                  a6                           |      .         |    [36]: 166 entry 0x76-0x76.7 (1)
+0x70|                     a6                        |       .        |    [37]: 166 entry 0x77-0x77.7 (1)
+0x70|                        a6                     |        .       |    [38]: 166 entry 0x78-0x78.7 (1)
+0x70|                           a6                  |         .      |    [39]: 166 entry 0x79-0x79.7 (1)
+0x70|                              a6               |          .     |    [40]: 166 entry 0x7a-0x7a.7 (1)
+0x70|                                 a6            |           .    |    [41]: 166 entry 0x7b-0x7b.7 (1)
+0x70|                                    a6         |            .   |    [42]: 166 entry 0x7c-0x7c.7 (1)
+0x70|                                       a6      |             .  |    [43]: 166 entry 0x7d-0x7d.7 (1)
+0x70|                                          a6   |              . |    [44]: 166 entry 0x7e-0x7e.7 (1)
+0x70|                                             a6|               .|    [45]: 166 entry 0x7f-0x7f.7 (1)
+0x80|a6                                             |.               |    [46]: 166 entry 0x80-0x80.7 (1)
+0x80|   a6                                          | .              |    [47]: 166 entry 0x81-0x81.7 (1)
+0x80|      a6                                       |  .             |    [48]: 166 entry 0x82-0x82.7 (1)
+0x80|         a6                                    |   .            |    [49]: 166 entry 0x83-0x83.7 (1)
+0x80|            ff                                 |    .           |    [50]: 255 entry 0x84-0x84.7 (1)
+0x80|               ff                              |     .          |    [51]: 255 entry 0x85-0x85.7 (1)
+0x80|                  ff                           |      .         |    [52]: 255 entry 0x86-0x86.7 (1)
+0x80|                     ff                        |       .        |    [53]: 255 entry 0x87-0x87.7 (1)
+0x80|                        ff                     |        .       |    [54]: 255 entry 0x88-0x88.7 (1)
+0x80|                           ff                  |         .      |    [55]: 255 entry 0x89-0x89.7 (1)
+0x80|                              ff               |          .     |    [56]: 255 entry 0x8a-0x8a.7 (1)
+0x80|                                 ff            |           .    |    [57]: 255 entry 0x8b-0x8b.7 (1)
+0x80|                                    ff         |            .   |    [58]: 255 entry 0x8c-0x8c.7 (1)
+0x80|                                       ff      |             .  |    [59]: 255 entry 0x8d-0x8d.7 (1)
+0x80|                                          ff   |              . |    [60]: 255 entry 0x8e-0x8e.7 (1)
+0x80|                                             ff|               .|    [61]: 255 entry 0x8f-0x8f.7 (1)
+0x90|ff                                             |.               |    [62]: 255 entry 0x90-0x90.7 (1)
+0x90|   ff                                          | .              |    [63]: 255 entry 0x91-0x91.7 (1)
+0x90|      ff                                       |  .             |    [64]: 255 entry 0x92-0x92.7 (1)
+0x90|         ff                                    |   .            |    [65]: 255 entry 0x93-0x93.7 (1)
+0x90|            ff                                 |    .           |    [66]: 255 entry 0x94-0x94.7 (1)
+0x90|               ff                              |     .          |    [67]: 255 entry 0x95-0x95.7 (1)
+0x90|                  ff                           |      .         |    [68]: 255 entry 0x96-0x96.7 (1)
+0x90|                     ff                        |       .        |    [69]: 255 entry 0x97-0x97.7 (1)
+0x90|                        ff                     |        .       |    [70]: 255 entry 0x98-0x98.7 (1)
+0x90|                           ff                  |         .      |    [71]: 255 entry 0x99-0x99.7 (1)
+0x90|                              ff               |          .     |    [72]: 255 entry 0x9a-0x9a.7 (1)
+0x90|                                 ff            |           .    |    [73]: 255 entry 0x9b-0x9b.7 (1)
+0x90|                                    ff         |            .   |    [74]: 255 entry 0x9c-0x9c.7 (1)
+0x90|                                       ff      |             .  |    [75]: 255 entry 0x9d-0x9d.7 (1)
+0x90|                                          ff   |              . |    [76]: 255 entry 0x9e-0x9e.7 (1)
+0x90|                                             ff|               .|    [77]: 255 entry 0x9f-0x9f.7 (1)
+0xa0|ff                                             |.               |    [78]: 255 entry 0xa0-0xa0.7 (1)
+0xa0|   ff                                          | .              |    [79]: 255 entry 0xa1-0xa1.7 (1)
+0xa0|      ff                                       |  .             |    [80]: 255 entry 0xa2-0xa2.7 (1)
+0xa0|         ff                                    |   .            |    [81]: 255 entry 0xa3-0xa3.7 (1)
+0xa0|            ff                                 |    .           |    [82]: 255 entry 0xa4-0xa4.7 (1)
+0xa0|               ff                              |     .          |    [83]: 255 entry 0xa5-0xa5.7 (1)
+0xa0|                  ff                           |      .         |    [84]: 255 entry 0xa6-0xa6.7 (1)
+0xa0|                     ff                        |       .        |    [85]: 255 entry 0xa7-0xa7.7 (1)
+0xa0|                        ff                     |        .       |    [86]: 255 entry 0xa8-0xa8.7 (1)
+0xa0|                           ff                  |         .      |    [87]: 255 entry 0xa9-0xa9.7 (1)
+0xa0|                              ff               |          .     |    [88]: 255 entry 0xaa-0xaa.7 (1)
+0xa0|                                 ff            |           .    |    [89]: 255 entry 0xab-0xab.7 (1)
+0xa0|                                    ff         |            .   |    [90]: 255 entry 0xac-0xac.7 (1)
+0xa0|                                       ff      |             .  |    [91]: 255 entry 0xad-0xad.7 (1)
+0xa0|                                          ff   |              . |    [92]: 255 entry 0xae-0xae.7 (1)
+0xa0|                                             ff|               .|    [93]: 255 entry 0xaf-0xaf.7 (1)
+0xb0|ff                                             |.               |    [94]: 255 entry 0xb0-0xb0.7 (1)
+0xb0|   ff                                          | .              |    [95]: 255 entry 0xb1-0xb1.7 (1)
+0xb0|      ff                                       |  .             |    [96]: 255 entry 0xb2-0xb2.7 (1)
+0xb0|         ff                                    |   .            |    [97]: 255 entry 0xb3-0xb3.7 (1)
+0xb0|            ff                                 |    .           |    [98]: 255 entry 0xb4-0xb4.7 (1)
+0xb0|               ff                              |     .          |    [99]: 255 entry 0xb5-0xb5.7 (1)
+0xb0|                  00 00 00 00                  |      ....      |  quality: 0 0xb6-0xb9.7 (4)
+    |                                               |                |  lame_extension{}: 0xba-0xdd.7 (36)
+0xb0|                              4c 61 76 63 35 38|          Lavc58|    encoder: "Lavc58.91" 0xba-0xc2.7 (9)
+0xc0|2e 39 31                                       |.91             |
+0xc0|         00                                    |   .            |    tag_revision: 0 0xc3-0xc3.3 (0.4)
+0xc0|         00                                    |   .            |    vbr_method: 0 0xc3.4-0xc3.7 (0.4)
+0xc0|            00                                 |    .           |    lowpass_filter: 0 0xc4-0xc4.7 (1)
+0xc0|               00 00 00 00                     |     ....       |    replay_gain_peak: 0 0xc5-0xc8.7 (4)
+0xc0|                           00 00               |         ..     |    radio_replay_gain: 0 0xc9-0xca.7 (2)
+0xc0|                                 00 00         |           ..   |    audiophile_replay_gain: 0 0xcb-0xcc.7 (2)
+0xc0|                                       00      |             .  |    lame_flags: 0 0xcd-0xcd.3 (0.4)
+0xc0|                                       00      |             .  |    lame_ath_type: 0 0xcd.4-0xcd.7 (0.4)
+0xc0|                                          00   |              . |    abr_vbr: 0 0xce-0xce.7 (1)
+0xc0|                                             24|               $|    encoder_delay: 576 0xcf-0xd0.3 (1.4)
+0xd0|05                                             |.               |
+0xd0|05 07                                          |..              |    encoder_padding: 1287 0xd0.4-0xd1.7 (1.4)
+0xd0|      00                                       |  .             |    misc: 0 0xd2-0xd2.7 (1)
+0xd0|         00                                    |   .            |    mp3_gain: 0 0xd3-0xd3.7 (1)
+0xd0|            00 00                              |    ..          |    preset: 0 0xd4-0xd5.7 (2)
+0xd0|                  00 00 02 57                  |      ...W      |    length: 599 0xd6-0xd9.7 (4)
+0xd0|                              62 f0            |          b.    |    music_crc: 25328 0xda-0xdb.7 (2)
+0xd0|                                    5a 35      |            Z5  |    tag_crc: 23093 0xdc-0xdd.7 (2)
+"ddv"
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].xing{}: (xing) 0x42-0xdd.7 (156)
 0x40|      49 6e 66 6f                              |  Info          |  header: "Info" 0x42-0x45.7 (4)
     |                                               |                |  present_flags{}: 0x46-0x49.7 (4)


### PR DESCRIPTION
Think it makes sense to have them all start with d.
Also f is often used as function argument name.