### PR TITLE
aac_frame: Only try decode object types we know about

### DIFF
--- a/format/matroska/matroska.go
+++ b/format/matroska/matroska.go
@@ -350,7 +350,13 @@ func matroskaDecode(d *decode.D, in interface{}) interface{} {
 				})
 			})
 		case "A_AAC":
-			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, mpegASCFrameFormat, nil)
+			dv, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, mpegASCFrameFormat, nil)
+			mpegASCOut, ok := v.(format.MPEGASCOut)
+			if dv != nil && !ok {
+				panic(fmt.Sprintf("expected mpegASCOut got %#+v", v))
+			}
+			//nolint:gosimple
+			t.formatInArg = format.AACFrameIn{ObjectType: mpegASCOut.ObjectType}
 		case "A_OPUS":
 			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, opusPacketFrameFormat, nil)
 		case "A_FLAC":

--- a/format/media.go
+++ b/format/media.go
@@ -138,6 +138,7 @@ const (
 	MPEGAudioObjectTypeLTP       = 4
 	MPEGAudioObjectTypeSBR       = 5
 	MPEGAudioObjectTypeER_AAC_LD = 23
+	MPEGAudioObjectTypePS        = 29
 )
 
 var MPEGAudioObjectTypeNames = scalar.UToScalar{
@@ -170,7 +171,7 @@ var MPEGAudioObjectTypeNames = scalar.UToScalar{
 	26:                           {Sym: "er_hiln", Description: "ER HILN Harmonic and Individual Lines plus Noise"},
 	27:                           {Sym: "er_parametric", Description: "ER Parametric"},
 	28:                           {Sym: "ssc", Description: "SinuSoidal Coding"},
-	29:                           {Sym: "ps", Description: "Parametric Stereo"},
+	MPEGAudioObjectTypePS:        {Sym: "ps", Description: "Parametric Stereo"},
 	30:                           {Sym: "mpeg_surround", Description: "MPEG Surround"},
 	31:                           {Sym: "(escape value)", Description: "(Escape value)"},
 	32:                           {Sym: "layer_1", Description: "MPEG Layer-1"},

--- a/format/mpeg/aac_frame.go
+++ b/format/mpeg/aac_frame.go
@@ -4,6 +4,7 @@ package mpeg
 
 // ISO/IEC 13818-7 Part 7: Advanced Audio Coding (AAC)
 // ISO/IEC 14496-3
+// TODO: currently only does very basic main, lc, ssr and ltp
 
 import (
 	"github.com/wader/fq/format"
@@ -273,40 +274,52 @@ func aacDecode(d *decode.D, in interface{}) interface{} {
 	if afi, ok := in.(format.AACFrameIn); ok {
 		objectType = afi.ObjectType
 	}
-	// objectType = 2
 
 	// TODO: seems tricky to know length of blocks
 	// TODO: currently break when length is unknown
-	seenTerm := false
-	for !seenTerm {
-		d.FieldStruct("element", func(d *decode.D) {
-			se := d.FieldU3("syntax_element", syntaxElementNames)
 
-			switch se {
-			case FIL:
-				aacFillElement(d)
+	switch objectType {
+	case format.MPEGAudioObjectTypeMain,
+		format.MPEGAudioObjectTypeLC,
+		format.MPEGAudioObjectTypeSSR,
+		format.MPEGAudioObjectTypeLTP,
+		format.MPEGAudioObjectTypeSBR,
+		format.MPEGAudioObjectTypeER_AAC_LD,
+		format.MPEGAudioObjectTypePS:
+		seenTerm := false
+		for !seenTerm {
+			d.FieldStruct("element", func(d *decode.D) {
+				se := d.FieldU3("syntax_element", syntaxElementNames)
 
-			case SCE:
-				aacSingleChannelElement(d, objectType)
-				seenTerm = true
+				switch se {
+				case FIL:
+					aacFillElement(d)
 
-			case PCE:
-				aacProgramConfigElement(d, 0)
-				seenTerm = true
+				case SCE:
+					aacSingleChannelElement(d, objectType)
+					seenTerm = true
 
-			default:
-				fallthrough
-			case TERM:
-				seenTerm = true
-			}
-		})
+				case PCE:
+					aacProgramConfigElement(d, 0)
+					seenTerm = true
+
+				default:
+					fallthrough
+				case TERM:
+					seenTerm = true
+				}
+			})
+		}
+
+		if d.ByteAlignBits() > 0 {
+			d.FieldRawLen("byte_align", int64(d.ByteAlignBits()))
+		}
+
+		d.FieldRawLen("data", d.BitsLeft())
+	default:
+		// not supported
+		d.FieldRawLen("data", d.BitsLeft())
 	}
-
-	if d.ByteAlignBits() > 0 {
-		d.FieldRawLen("byte_align", int64(d.ByteAlignBits()))
-	}
-
-	d.FieldRawLen("data", d.BitsLeft())
 
 	return nil
 }


### PR DESCRIPTION
Fixes issue failing on unknown or future aac standards
Also add missing object type passing for matroska