### PR TITLE
binary,decode,doc: Rename buffer to binary and add some documentation

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -1,8 +1,7 @@
 ### Known bugs to fix
 
-- `fq -n '"aabbccdd" | hex | tobytes[1:] | raw | tobytes'` create buffer `aabbcc` should be `bbccdd`. I think decode (raw in this case) is confused by root value buffer.
-- Buffers/string duality is confusing, most string functions should be wrapped to understand buffers.
-- `fq -n '[([0xab] | tobits[:4]), ([0xdc] | tobits[:4]), 0] | tobytes'` should create a `ad` buffer, now `a0`. Probably because use of `io.Copy` that will ends up padding on byte boundaries. Should use `bitio.Copy` and create a `bitio.Writer` that can transform to a `io.Writer`.
+- `fq -n '"aabbccdd" | hex | tobytes[1:] | raw | tobytes'` create binary `aabbcc` should be `bbccdd`. I think decode (raw in this case) is confused by root value buffer.
+- Buffers/string duality is confusing, most string functions should be wrapped to understand binary.
 - REPL cancel seems to sometimes exit a sub-REPl without properly cleanup options.
 - Value errors, can only be accessed with `._error`.
 - Framed (add unknown in gaps) decode should be on struct level not format?

--- a/internal/bitioextra/zeroreadatseeker.go
+++ b/internal/bitioextra/zeroreadatseeker.go
@@ -1,0 +1,58 @@
+package bitioextra
+
+import (
+	"io"
+
+	"github.com/wader/fq/pkg/bitio"
+)
+
+type ZeroReadAtSeeker struct {
+	pos   int64
+	nBits int64
+}
+
+func NewZeroAtSeeker(nBits int64) *ZeroReadAtSeeker {
+	return &ZeroReadAtSeeker{nBits: nBits}
+}
+
+func (z *ZeroReadAtSeeker) SeekBits(bitOffset int64, whence int) (int64, error) {
+	p := z.pos
+	switch whence {
+	case io.SeekStart:
+		p = bitOffset
+	case io.SeekCurrent:
+		p += bitOffset
+	case io.SeekEnd:
+		p = z.nBits + bitOffset
+	default:
+		panic("unknown whence")
+	}
+
+	if p < 0 || p > z.nBits {
+		return z.pos, bitio.ErrOffset
+	}
+	z.pos = p
+
+	return p, nil
+}
+
+func (z *ZeroReadAtSeeker) ReadBitsAt(p []byte, nBits int64, bitOff int64) (n int64, err error) {
+	if bitOff < 0 || bitOff > z.nBits {
+		return 0, bitio.ErrOffset
+	}
+	if bitOff == z.nBits {
+		return 0, io.EOF
+	}
+
+	lBits := z.nBits - bitOff
+	rBits := nBits
+	if rBits > lBits {
+		rBits = lBits
+	}
+	rBytes := bitio.BitsByteCount(rBits)
+	for i := int64(0); i < rBytes; i++ {
+		p[i] = 0
+	}
+
+	return rBits, nil
+}

--- a/pkg/bitio/bitio.go
+++ b/pkg/bitio/bitio.go
@@ -110,7 +110,7 @@ func BitStringFromBytes(buf []byte, nBits int64) string {
 	return sb.String()
 }
 
-// CopyBuffer bits from src to dst using provided buffer
+// CopyBuffer bits from src to dst using provided byte buffer
 // Similar to io.CopyBuffer
 func CopyBuffer(dst Writer, src Reader, buf []byte) (n int64, err error) {
 	// same default size as io.Copy

--- a/pkg/bitio/ioreader.go
+++ b/pkg/bitio/ioreader.go
@@ -62,7 +62,7 @@ func (r *IOReader) Read(p []byte) (n int, err error) {
 				if err != nil {
 					return 0, err
 				}
-				return 1, nil
+				return 1, r.rErr
 			}
 			return 0, r.rErr
 		}

--- a/pkg/bitio/ioreadseeker_test.go
+++ b/pkg/bitio/ioreadseeker_test.go
@@ -108,7 +108,7 @@ func Test(t *testing.T) {
 		for _, p := range bsParts {
 			bsBRs = append(bsBRs, sb(p))
 		}
-		bsBR, err := bitio.NewMultiBitReader(bsBRs...)
+		bsBR, err := bitio.NewMultiReader(bsBRs...)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/bitio/multireader.go
+++ b/pkg/bitio/multireader.go
@@ -31,7 +31,7 @@ type MultiReader struct {
 	readerEnds []int64
 }
 
-func NewMultiBitReader(rs ...ReadAtSeeker) (*MultiReader, error) {
+func NewMultiReader(rs ...ReadAtSeeker) (*MultiReader, error) {
 	readerEnds := make([]int64, len(rs))
 	var esSum int64
 	for i, r := range rs {

--- a/pkg/decode/value.go
+++ b/pkg/decode/value.go
@@ -27,7 +27,7 @@ type Value struct {
 	V          interface{} // scalar.S or Compound (array/struct)
 	Index      int         // index in parent array/struct
 	Range      ranges.Range
-	RootBitBuf bitio.ReaderAtSeeker
+	RootReader bitio.ReaderAtSeeker
 	IsRoot     bool // TODO: rework?
 }
 

--- a/pkg/interp/binary.go
+++ b/pkg/interp/binary.go
@@ -21,24 +21,37 @@ import (
 func init() {
 	functionRegisterFns = append(functionRegisterFns, func(i *Interp) []Function {
 		return []Function{
-			{"_tobitsrange", 0, 2, i._toBitsRange, nil},
+			{"_tobits", 3, 3, i._toBits, nil},
 			{"open", 0, 0, i._open, nil},
 		}
 	})
 }
 
-type ToBuffer interface {
-	ToBuffer() (Buffer, error)
+type ToBinary interface {
+	ToBinary() (Binary, error)
 }
 
-func toBitBuf(v interface{}) (bitio.ReaderAtSeeker, error) {
-	return toBitBufEx(v, false)
-}
-
-func toBitBufEx(v interface{}, inArray bool) (bitio.ReaderAtSeeker, error) {
+func toBinary(v interface{}) (Binary, error) {
 	switch vv := v.(type) {
-	case ToBuffer:
-		bv, err := vv.ToBuffer()
+	case ToBinary:
+		return vv.ToBinary()
+	default:
+		br, err := toBitReader(v)
+		if err != nil {
+			return Binary{}, err
+		}
+		return newBinaryFromBitReader(br, 8, 0)
+	}
+}
+
+func toBitReader(v interface{}) (bitio.ReaderAtSeeker, error) {
+	return toBitReaderEx(v, false)
+}
+
+func toBitReaderEx(v interface{}, inArray bool) (bitio.ReaderAtSeeker, error) {
+	switch vv := v.(type) {
+	case ToBinary:
+		bv, err := vv.ToBinary()
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +66,7 @@ func toBitBufEx(v interface{}, inArray bool) (bitio.ReaderAtSeeker, error) {
 
 		if inArray {
 			if bi.Cmp(big.NewInt(255)) > 0 || bi.Cmp(big.NewInt(0)) < 0 {
-				return nil, fmt.Errorf("buffer byte list must be bytes (0-255) got %v", bi)
+				return nil, fmt.Errorf("byte in binary list must be bytes (0-255) got %v", bi)
 			}
 			n := bi.Uint64()
 			b := [1]byte{byte(n)}
@@ -78,103 +91,88 @@ func toBitBufEx(v interface{}, inArray bool) (bitio.ReaderAtSeeker, error) {
 		rr := make([]bitio.ReadAtSeeker, 0, len(vv))
 		// TODO: optimize byte array case, flatten into one slice
 		for _, e := range vv {
-			eBR, eErr := toBitBufEx(e, true)
+			eBR, eErr := toBitReaderEx(e, true)
 			if eErr != nil {
 				return nil, eErr
 			}
 			rr = append(rr, eBR)
 		}
 
-		mb, err := bitio.NewMultiBitReader(rr...)
+		mb, err := bitio.NewMultiReader(rr...)
 		if err != nil {
 			return nil, err
 		}
 
 		return mb, nil
 	default:
-		return nil, fmt.Errorf("value can't be a buffer")
+		return nil, fmt.Errorf("value can't be a binary")
 	}
 }
 
-func toBuffer(v interface{}) (Buffer, error) {
-	switch vv := v.(type) {
-	case ToBuffer:
-		return vv.ToBuffer()
-	default:
-		br, err := toBitBuf(v)
-		if err != nil {
-			return Buffer{}, err
-		}
-		return newBufferFromBuffer(br, 8)
+// note is used to implement tobytes* also
+func (i *Interp) _toBits(c interface{}, a []interface{}) interface{} {
+	unit, ok := gojqextra.ToInt(a[0])
+	if !ok {
+		return gojqextra.FuncTypeError{Name: "_tobits", V: a[0]}
 	}
-}
-
-// note is used to implement tobytes*/0 also
-func (i *Interp) _toBitsRange(c interface{}, a []interface{}) interface{} {
-	var unit int
-	var r bool
-	var ok bool
-
-	if len(a) >= 1 {
-		unit, ok = gojqextra.ToInt(a[0])
-		if !ok {
-			return gojqextra.FuncTypeError{Name: "_tobitsrange", V: a[0]}
-		}
-	} else {
-		unit = 1
+	keepRange, ok := gojqextra.ToBoolean(a[1])
+	if !ok {
+		return gojqextra.FuncTypeError{Name: "_tobits", V: a[1]}
 	}
-
-	if len(a) >= 2 {
-		r, ok = gojqextra.ToBoolean(a[1])
-		if !ok {
-			return gojqextra.FuncTypeError{Name: "_tobitsrange", V: a[1]}
-		}
-	} else {
-		r = true
+	padToUnits, ok := gojqextra.ToInt(a[2])
+	if !ok {
+		return gojqextra.FuncTypeError{Name: "_tobits", V: a[2]}
 	}
 
 	// TODO: unit > 8?
 
-	bv, err := toBuffer(c)
+	bv, err := toBinary(c)
 	if err != nil {
 		return err
 	}
-	bv.unit = unit
 
-	if !r {
-		br, err := bv.toBuffer()
-		if err != nil {
-			return err
-		}
-		bb, err := newBufferFromBuffer(br, unit)
-		if err != nil {
-			return err
-		}
-		return bb
+	pad := int64(unit * padToUnits)
+	if pad == 0 {
+		pad = int64(unit)
 	}
 
-	return bv
+	bv.unit = unit
+	bv.pad = (pad - bv.r.Len%pad) % pad
+
+	if keepRange {
+		return bv
+	}
+
+	br, err := bv.toReader()
+	if err != nil {
+		return err
+	}
+	bb, err := newBinaryFromBitReader(br, bv.unit, bv.pad)
+	if err != nil {
+		return err
+	}
+	return bb
 }
 
 type openFile struct {
-	Buffer
+	Binary
 	filename   string
 	progressFn progressreadseeker.ProgressFn
 }
 
 var _ Value = (*openFile)(nil)
-var _ ToBuffer = (*openFile)(nil)
+var _ ToBinary = (*openFile)(nil)
 
 func (of *openFile) Display(w io.Writer, opts Options) error {
 	_, err := fmt.Fprintf(w, "<openfile %q>\n", of.filename)
 	return err
 }
 
-func (of *openFile) ToBuffer() (Buffer, error) {
-	return newBufferFromBuffer(of.br, 8)
+func (of *openFile) ToBinary() (Binary, error) {
+	return newBinaryFromBitReader(of.br, 8, 0)
 }
 
-// def open: #:: string| => buffer
+// def open: #:: string| => binary
 // opens a file for reading from filesystem
 // TODO: when to close? when br loses all refs? need to use finalizer somehow?
 func (i *Interp) _open(c interface{}, a []interface{}) interface{} {
@@ -254,29 +252,31 @@ func (i *Interp) _open(c interface{}, a []interface{}) interface{} {
 	return bbf
 }
 
-var _ Value = Buffer{}
-var _ ToBuffer = Buffer{}
+var _ Value = Binary{}
+var _ ToBinary = Binary{}
 
-type Buffer struct {
+type Binary struct {
 	br   bitio.ReaderAtSeeker
 	r    ranges.Range
 	unit int
+	pad  int64
 }
 
-func newBufferFromBuffer(br bitio.ReaderAtSeeker, unit int) (Buffer, error) {
+func newBinaryFromBitReader(br bitio.ReaderAtSeeker, unit int, pad int64) (Binary, error) {
 	l, err := bitioextra.Len(br)
 	if err != nil {
-		return Buffer{}, err
+		return Binary{}, err
 	}
 
-	return Buffer{
+	return Binary{
 		br:   br,
 		r:    ranges.Range{Start: 0, Len: l},
 		unit: unit,
+		pad:  pad,
 	}, nil
 }
 
-func (b Buffer) toBytesBuffer(r ranges.Range) (*bytes.Buffer, error) {
+func (b Binary) toBytesBuffer(r ranges.Range) (*bytes.Buffer, error) {
 	br, err := bitioextra.Range(b.br, r.Start, r.Len)
 	if err != nil {
 		return nil, err
@@ -289,9 +289,9 @@ func (b Buffer) toBytesBuffer(r ranges.Range) (*bytes.Buffer, error) {
 	return buf, nil
 }
 
-func (Buffer) ExtType() string { return "buffer" }
+func (Binary) ExtType() string { return "binary" }
 
-func (Buffer) ExtKeys() []string {
+func (Binary) ExtKeys() []string {
 	return []string{
 		"size",
 		"start",
@@ -301,18 +301,18 @@ func (Buffer) ExtKeys() []string {
 	}
 }
 
-func (b Buffer) ToBuffer() (Buffer, error) {
+func (b Binary) ToBinary() (Binary, error) {
 	return b, nil
 }
 
-func (b Buffer) JQValueLength() interface{} {
+func (b Binary) JQValueLength() interface{} {
 	return int(b.r.Len / int64(b.unit))
 }
-func (b Buffer) JQValueSliceLen() interface{} {
+func (b Binary) JQValueSliceLen() interface{} {
 	return b.JQValueLength()
 }
 
-func (b Buffer) JQValueIndex(index int) interface{} {
+func (b Binary) JQValueIndex(index int) interface{} {
 	if index < 0 {
 		return nil
 	}
@@ -326,17 +326,17 @@ func (b Buffer) JQValueIndex(index int) interface{} {
 
 	return new(big.Int).Rsh(new(big.Int).SetBytes(buf.Bytes()), extraBits)
 }
-func (b Buffer) JQValueSlice(start int, end int) interface{} {
+func (b Binary) JQValueSlice(start int, end int) interface{} {
 	rStart := int64(start * b.unit)
 	rLen := int64((end - start) * b.unit)
 
-	return Buffer{
+	return Binary{
 		br:   b.br,
 		r:    ranges.Range{Start: b.r.Start + rStart, Len: rLen},
 		unit: b.unit,
 	}
 }
-func (b Buffer) JQValueKey(name string) interface{} {
+func (b Binary) JQValueKey(name string) interface{} {
 	switch name {
 	case "size":
 		return new(big.Int).SetInt64(b.r.Len / int64(b.unit))
@@ -353,28 +353,28 @@ func (b Buffer) JQValueKey(name string) interface{} {
 		if b.unit == 1 {
 			return b
 		}
-		return Buffer{br: b.br, r: b.r, unit: 1}
+		return Binary{br: b.br, r: b.r, unit: 1}
 	case "bytes":
 		if b.unit == 8 {
 			return b
 		}
-		return Buffer{br: b.br, r: b.r, unit: 8}
+		return Binary{br: b.br, r: b.r, unit: 8}
 	}
 	return nil
 }
-func (b Buffer) JQValueEach() interface{} {
+func (b Binary) JQValueEach() interface{} {
 	return nil
 }
-func (b Buffer) JQValueType() string {
-	return "buffer"
+func (b Binary) JQValueType() string {
+	return "binary"
 }
-func (b Buffer) JQValueKeys() interface{} {
-	return gojqextra.FuncTypeNameError{Name: "keys", Typ: "buffer"}
+func (b Binary) JQValueKeys() interface{} {
+	return gojqextra.FuncTypeNameError{Name: "keys", Typ: "binary"}
 }
-func (b Buffer) JQValueHas(key interface{}) interface{} {
-	return gojqextra.HasKeyTypeError{L: "buffer", R: fmt.Sprintf("%v", key)}
+func (b Binary) JQValueHas(key interface{}) interface{} {
+	return gojqextra.HasKeyTypeError{L: "binary", R: fmt.Sprintf("%v", key)}
 }
-func (b Buffer) JQValueToNumber() interface{} {
+func (b Binary) JQValueToNumber() interface{} {
 	buf, err := b.toBytesBuffer(b.r)
 	if err != nil {
 		return err
@@ -382,23 +382,23 @@ func (b Buffer) JQValueToNumber() interface{} {
 	extraBits := uint((8 - b.r.Len%8) % 8)
 	return new(big.Int).Rsh(new(big.Int).SetBytes(buf.Bytes()), extraBits)
 }
-func (b Buffer) JQValueToString() interface{} {
+func (b Binary) JQValueToString() interface{} {
 	return b.JQValueToGoJQ()
 }
-func (b Buffer) JQValueToGoJQ() interface{} {
+func (b Binary) JQValueToGoJQ() interface{} {
 	buf, err := b.toBytesBuffer(b.r)
 	if err != nil {
 		return err
 	}
 	return buf.String()
 }
-func (b Buffer) JQValueUpdate(key interface{}, u interface{}, delpath bool) interface{} {
-	return gojqextra.NonUpdatableTypeError{Key: fmt.Sprintf("%v", key), Typ: "buffer"}
+func (b Binary) JQValueUpdate(key interface{}, u interface{}, delpath bool) interface{} {
+	return gojqextra.NonUpdatableTypeError{Key: fmt.Sprintf("%v", key), Typ: "binary"}
 }
 
-func (b Buffer) Display(w io.Writer, opts Options) error {
+func (b Binary) Display(w io.Writer, opts Options) error {
 	if opts.RawOutput {
-		br, err := b.toBuffer()
+		br, err := b.toReader()
 		if err != nil {
 			return err
 		}
@@ -413,6 +413,13 @@ func (b Buffer) Display(w io.Writer, opts Options) error {
 	return hexdump(w, b, opts)
 }
 
-func (b Buffer) toBuffer() (bitio.ReaderAtSeeker, error) {
-	return bitioextra.Range(b.br, b.r.Start, b.r.Len)
+func (b Binary) toReader() (bitio.ReaderAtSeeker, error) {
+	br, err := bitioextra.Range(b.br, b.r.Start, b.r.Len)
+	if err != nil {
+		return nil, err
+	}
+	if b.pad == 0 {
+		return br, nil
+	}
+	return bitio.NewMultiReader(bitioextra.NewZeroAtSeeker(b.pad), br)
 }

--- a/pkg/interp/binary.jq
+++ b/pkg/interp/binary.jq
@@ -1,0 +1,8 @@
+def tobits: _tobits(1; false; 0);
+def tobytes: _tobits(8; false; 0);
+def tobitsrange: _tobits(1; true; 0);
+def tobytesrange: _tobits(8; true; 0);
+def tobits($pad): _tobits(1; false; $pad);
+def tobytes($pad): _tobits(8; false; $pad);
+def tobitsrange($pad): _tobits(1; true; $pad);
+def tobytesrange($pad): _tobits(8; true; $pad);

--- a/pkg/interp/buffer.jq
+++ b/pkg/interp/buffer.jq
@@ -1,4 +1,0 @@
-def tobitsrange: _tobitsrange;
-def tobytesrange: _tobitsrange(8);
-def tobits: _tobitsrange(1; false);
-def tobytes: _tobitsrange(8; false);

--- a/pkg/interp/decode.go
+++ b/pkg/interp/decode.go
@@ -44,7 +44,7 @@ func (err expectedExtkeyError) Error() string {
 // used by _isDecodeValue
 type DecodeValue interface {
 	Value
-	ToBuffer
+	ToBinary
 
 	DecodeValue() *decode.Value
 }
@@ -188,7 +188,7 @@ func (i *Interp) _decode(c interface{}, a []interface{}) interface{} {
 		}
 	}
 
-	bv, err := toBuffer(c)
+	bv, err := toBinary(c)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func makeDecodeValue(dv *decode.Value) interface{} {
 		switch vv := vv.Value().(type) {
 		case bitio.ReaderAtSeeker:
 			// is lazy so that in situations where the decode value is only used to
-			// create another buffer we don't have to read and create a string, ex:
+			// create another binary we don't have to read and create a string, ex:
 			// .unknown0 | tobytes[1:] | ...
 			return decodeValue{
 				JQValue: &gojqextra.Lazy{
@@ -364,8 +364,8 @@ func (dvb decodeValueBase) DecodeValue() *decode.Value {
 }
 
 func (dvb decodeValueBase) Display(w io.Writer, opts Options) error { return dump(dvb.dv, w, opts) }
-func (dvb decodeValueBase) ToBuffer() (Buffer, error) {
-	return Buffer{br: dvb.dv.RootBitBuf, r: dvb.dv.InnerRange(), unit: 8}, nil
+func (dvb decodeValueBase) ToBinary() (Binary, error) {
+	return Binary{br: dvb.dv.RootReader, r: dvb.dv.InnerRange(), unit: 8}, nil
 }
 func (decodeValueBase) ExtType() string { return "decode_value" }
 func (dvb decodeValueBase) ExtKeys() []string {
@@ -479,14 +479,14 @@ func (dvb decodeValueBase) JQValueKey(name string) interface{} {
 			return nil
 		}
 	case "_bits":
-		return Buffer{
-			br:   dv.RootBitBuf,
+		return Binary{
+			br:   dv.RootReader,
 			r:    dv.Range,
 			unit: 1,
 		}
 	case "_bytes":
-		return Buffer{
-			br:   dv.RootBitBuf,
+		return Binary{
+			br:   dv.RootReader,
 			r:    dv.Range,
 			unit: 8,
 		}
@@ -543,11 +543,11 @@ func (v decodeValue) JQValueToGoJQEx(optsFn func() Options) interface{} {
 		return v.JQValueToGoJQ()
 	}
 
-	bv, err := v.decodeValueBase.ToBuffer()
+	bv, err := v.decodeValueBase.ToBinary()
 	if err != nil {
 		return err
 	}
-	br, err := bv.toBuffer()
+	br, err := bv.toReader()
 	if err != nil {
 		return err
 	}

--- a/pkg/interp/dump.go
+++ b/pkg/interp/dump.go
@@ -219,7 +219,7 @@ func dumpEx(v *decode.Value, buf []byte, cw *columnwriter.Writer, depth int, roo
 		printErrs(depth, valueErr)
 	}
 
-	rootBitLen, err := bitioextra.Len(rootV.RootBitBuf)
+	rootBitLen, err := bitioextra.Len(rootV.RootReader)
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func dumpEx(v *decode.Value, buf []byte, cw *columnwriter.Writer, depth int, roo
 		cfmt(colAddr, "%s%s\n",
 			rootIndent, deco.DumpAddr.F(mathextra.PadFormatInt(startLineByte, opts.AddrBase, true, addrWidth)))
 
-		vBR, err := bitioextra.Range(rootV.RootBitBuf, startByte*8, displaySizeBits)
+		vBR, err := bitioextra.Range(rootV.RootReader, startByte*8, displaySizeBits)
 		if err != nil {
 			return err
 		}
@@ -364,8 +364,8 @@ func dump(v *decode.Value, w io.Writer, opts Options) error {
 	}))
 }
 
-func hexdump(w io.Writer, bv Buffer, opts Options) error {
-	br, err := bv.toBuffer()
+func hexdump(w io.Writer, bv Binary, opts Options) error {
+	br, err := bv.toReader()
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func hexdump(w io.Writer, bv Buffer, opts Options) error {
 			// TODO: hack
 			V:          &scalar.S{Actual: br},
 			Range:      bv.r,
-			RootBitBuf: biib,
+			RootReader: biib,
 		},
 		w,
 		opts,

--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -35,7 +35,7 @@ import (
 //go:embed interp.jq
 //go:embed internal.jq
 //go:embed options.jq
-//go:embed buffer.jq
+//go:embed binary.jq
 //go:embed decode.jq
 //go:embed match.jq
 //go:embed funcs.jq
@@ -270,7 +270,7 @@ func toBigInt(v interface{}) (*big.Int, error) {
 func toBytes(v interface{}) ([]byte, error) {
 	switch v := v.(type) {
 	default:
-		br, err := toBitBuf(v)
+		br, err := toBitReader(v)
 		if err != nil {
 			return nil, fmt.Errorf("value is not bytes")
 		}

--- a/pkg/interp/interp.jq
+++ b/pkg/interp/interp.jq
@@ -1,6 +1,6 @@
 include "internal";
 include "options";
-include "buffer";
+include "binary";
 include "decode";
 include "match";
 include "funcs";

--- a/pkg/interp/match.go
+++ b/pkg/interp/match.go
@@ -15,15 +15,15 @@ import (
 func init() {
 	functionRegisterFns = append(functionRegisterFns, func(i *Interp) []Function {
 		return []Function{
-			{"_match_buffer", 1, 2, nil, i._bufferMatch},
+			{"_match_binary", 1, 2, nil, i._binaryMatch},
 		}
 	})
 }
 
-func (i *Interp) _bufferMatch(c interface{}, a []interface{}) gojq.Iter {
+func (i *Interp) _binaryMatch(c interface{}, a []interface{}) gojq.Iter {
 	var ok bool
 
-	bv, err := toBuffer(c)
+	bv, err := toBinary(c)
 	if err != nil {
 		return gojq.NewIter(err)
 	}
@@ -70,7 +70,7 @@ func (i *Interp) _bufferMatch(c interface{}, a []interface{}) gojq.Iter {
 	}
 	sreNames := sre.SubexpNames()
 
-	br, err := bv.toBuffer()
+	br, err := bv.toReader()
 	if err != nil {
 		return gojq.NewIter(err)
 	}
@@ -92,7 +92,7 @@ func (i *Interp) _bufferMatch(c interface{}, a []interface{}) gojq.Iter {
 	var off int64
 	prevOff := int64(-1)
 	return iterFn(func() (interface{}, bool) {
-		// TODO: correct way to handle empty match for buffer, move one byte forward?
+		// TODO: correct way to handle empty match for binary, move one byte forward?
 		// > "asdasd" | [match(""; "g")], [(tobytes | match(""; "g"))] | length
 		// 7
 		// 1
@@ -127,7 +127,7 @@ func (i *Interp) _bufferMatch(c interface{}, a []interface{}) gojq.Iter {
 			if start != -1 {
 				matchBitOff := (off + int64(start)) * 8
 				matchLength := int64(end-start) * 8
-				bbo := Buffer{
+				bbo := Binary{
 					br: bv.br,
 					r: ranges.Range{
 						Start: bv.r.Start + matchBitOff,

--- a/pkg/interp/match.jq
+++ b/pkg/interp/match.jq
@@ -1,10 +1,10 @@
-def _buffer_fn(f):
+def _binary_fn(f):
   ( . as $c
   | tobytesrange
   | f
   );
 
-def _buffer_try_orig(bfn; fn):
+def _binary_try_orig(bfn; fn):
   ( . as $c
   | if type == "string" then fn
     else
@@ -15,27 +15,27 @@ def _buffer_try_orig(bfn; fn):
     end
   );
 
-# overloads to support buffer
+# overloads to support binary
 
 def _orig_test($val): test($val);
 def _orig_test($regex; $flags): test($regex; $flags);
-def _test_buffer($regex; $flags):
-  ( isempty(_match_buffer($regex; $flags))
+def _test_binary($regex; $flags):
+  ( isempty(_match_binary($regex; $flags))
   | not
   );
-def test($val): _buffer_try_orig(_test_buffer($val; ""); _orig_test($val));
-def test($regex; $flags): _buffer_try_orig(_test_buffer($regex; $flags); _orig_test($regex; $flags));
+def test($val): _binary_try_orig(_test_binary($val; ""); _orig_test($val));
+def test($regex; $flags): _binary_try_orig(_test_binary($regex; $flags); _orig_test($regex; $flags));
 
 def _orig_match($val): match($val);
 def _orig_match($regex; $flags): match($regex; $flags);
-def match($val): _buffer_try_orig(_match_buffer($val); _orig_match($val));
-def match($regex; $flags): _buffer_try_orig(_match_buffer($regex; $flags); _orig_match($regex; $flags));
+def match($val): _binary_try_orig(_match_binary($val); _orig_match($val));
+def match($regex; $flags): _binary_try_orig(_match_binary($regex; $flags); _orig_match($regex; $flags));
 
 def _orig_capture($val): capture($val);
 def _orig_capture($regex; $flags): capture($regex; $flags);
-def _capture_buffer($regex; $flags):
+def _capture_binary($regex; $flags):
   ( . as $b
-  | _match_buffer($regex; $flags)
+  | _match_binary($regex; $flags)
   | .captures
   | map(
       ( select(.name)
@@ -44,25 +44,25 @@ def _capture_buffer($regex; $flags):
     )
   | from_entries
   );
-def capture($val): _buffer_try_orig(_capture_buffer($val; ""); _orig_capture($val));
-def capture($regex; $flags): _buffer_try_orig(_capture_buffer($regex; $flags); _orig_capture($regex; $flags));
+def capture($val): _binary_try_orig(_capture_binary($val; ""); _orig_capture($val));
+def capture($regex; $flags): _binary_try_orig(_capture_binary($regex; $flags); _orig_capture($regex; $flags));
 
 def _orig_scan($val): scan($val);
 def _orig_scan($regex; $flags): scan($regex; $flags);
-def _scan_buffer($regex; $flags):
+def _scan_binary($regex; $flags):
   ( . as $b
-  | _match_buffer($regex; $flags)
+  | _match_binary($regex; $flags)
   | $b[.offset:.offset+.length]
   );
-def scan($val): _buffer_try_orig(_scan_buffer($val; "g"); _orig_scan($val));
-def scan($regex; $flags): _buffer_try_orig(_scan_buffer($regex; "g"+$flags); _orig_scan($regex; $flags));
+def scan($val): _binary_try_orig(_scan_binary($val; "g"); _orig_scan($val));
+def scan($regex; $flags): _binary_try_orig(_scan_binary($regex; "g"+$flags); _orig_scan($regex; $flags));
 
 def _orig_splits($val): splits($val);
 def _orig_splits($regex; $flags): splits($regex; $flags);
-def _splits_buffer($regex; $flags):
+def _splits_binary($regex; $flags):
   ( . as $b
-  # last null output is to do a last iteration that output from end of last match to end of buffer
-  | foreach (_match_buffer($regex; $flags), null) as $m (
+  # last null output is to do a last iteration that output from end of last match to end of binary
+  | foreach (_match_binary($regex; $flags), null) as $m (
       {prev: null, curr: null};
       ( .prev = .curr
       | .curr = $m
@@ -73,8 +73,8 @@ def _splits_buffer($regex; $flags):
       end
     )
   );
-def splits($val): _buffer_try_orig(_splits_buffer($val; "g"); _orig_splits($val));
-def splits($regex; $flags): _buffer_try_orig(_splits_buffer($regex; "g"+$flags); _orig_splits($regex; $flags));
+def splits($val): _binary_try_orig(_splits_binary($val; "g"); _orig_splits($val));
+def splits($regex; $flags): _binary_try_orig(_splits_binary($regex; "g"+$flags); _orig_splits($regex; $flags));
 
 # same as regexp.QuoteMeta
 def _quote_meta:
@@ -87,11 +87,11 @@ def split($val): [splits($val | _quote_meta)];
 def split($regex; $flags): [splits($regex; $flags)];
 
 # TODO: rename
-# same as scan but outputs buffer from start of match to end of buffer
+# same as scan but outputs binary from start of match to end of binary
 def _scan_toend($regex; $flags):
   ( . as $b
-  | _match_buffer($regex; $flags)
+  | _match_binary($regex; $flags)
   | $b[.offset:]
   );
-def scan_toend($val): _buffer_fn(_scan_toend($val; "g"));
-def scan_toend($regex; $flags):  _buffer_fn(_scan_toend($regex; "g"+$flags));
+def scan_toend($val): _binary_fn(_scan_toend($val; "g"));
+def scan_toend($regex; $flags):  _binary_fn(_scan_toend($regex; "g"+$flags));

--- a/pkg/interp/testdata/buffer.fqtest
+++ b/pkg/interp/testdata/buffer.fqtest
@@ -51,9 +51,9 @@ mp3> [1, 2, 3, [1, 2, 3], .headers[0].magic] | tobytes
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|01 02 03 01 02 03 49 44 33|                    |......ID3|      |.: raw bits 0x0-0x8.7 (9)
 mp3> [-1] | tobytes
-error: buffer byte list must be bytes (0-255) got -1
+error: byte in binary list must be bytes (0-255) got -1
 mp3> [256] | tobytes
-error: buffer byte list must be bytes (0-255) got 256
+error: byte in binary list must be bytes (0-255) got 256
 mp3> ^D
 $ fq -d mp3 -i . /test.mp3
 mp3> .frames[1] | tobits       | ., .start, .stop, .size, .[4:17], (tobits, tobytes, tobitsrange, tobytesrange | ., .start, .stop, .size, .[4:17])
@@ -256,41 +256,59 @@ mp3> "fq" | tobits | chunk(range(17)+1) | tobytes | tostring
 "fq"
 "fq"
 "fq"
-mp3> range(17) | [range(.) | 1 | tobits] | tobytes
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-   |                                               |                |.: raw bits 0x0-NA (0)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|80|                                            |.|              |.: raw bits 0x0-0x0 (0.1)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|c0|                                            |.|              |.: raw bits 0x0-0x0.1 (0.2)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|e0|                                            |.|              |.: raw bits 0x0-0x0.2 (0.3)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|f0|                                            |.|              |.: raw bits 0x0-0x0.3 (0.4)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|f8|                                            |.|              |.: raw bits 0x0-0x0.4 (0.5)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|fc|                                            |.|              |.: raw bits 0x0-0x0.5 (0.6)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|fe|                                            |.|              |.: raw bits 0x0-0x0.6 (0.7)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff|                                            |.|              |.: raw bits 0x0-0x0.7 (1)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff 80|                                         |..|             |.: raw bits 0x0-0x1 (1.1)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff c0|                                         |..|             |.: raw bits 0x0-0x1.1 (1.2)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff e0|                                         |..|             |.: raw bits 0x0-0x1.2 (1.3)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff f0|                                         |..|             |.: raw bits 0x0-0x1.3 (1.4)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff f8|                                         |..|             |.: raw bits 0x0-0x1.4 (1.5)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff fc|                                         |..|             |.: raw bits 0x0-0x1.5 (1.6)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff fe|                                         |..|             |.: raw bits 0x0-0x1.6 (1.7)
-   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x0|ff ff|                                         |..|             |.: raw bits 0x0-0x1.7 (2)
+mp3> 1 | tobits(range(10)) | hex
+"80"
+"80"
+"40"
+"20"
+"10"
+"08"
+"04"
+"02"
+"01"
+"0080"
+mp3> 1 | tobytes(range(5)) | hex
+"01"
+"01"
+"0001"
+"000001"
+"00000001"
+mp3> range(17) | [range(.) | 1 | tobits] | tobits | hex
+""
+"80"
+"c0"
+"e0"
+"f0"
+"f8"
+"fc"
+"fe"
+"ff"
+"ff80"
+"ffc0"
+"ffe0"
+"fff0"
+"fff8"
+"fffc"
+"fffe"
+"ffff"
+mp3> range(17) | [range(.) | 1 | tobits] | tobytes | hex
+""
+"01"
+"03"
+"07"
+"0f"
+"1f"
+"3f"
+"7f"
+"ff"
+"01ff"
+"03ff"
+"07ff"
+"0fff"
+"1fff"
+"3fff"
+"7fff"
+"ffff"
 mp3> "c9dfdac2f6ef68e5db666b6fbeee66d9c7deda66bebfbfe860bfbfbfe9d1636bbfbebf" | hex | tobits | reduce chunk(8)[] as $c ({h:[],g:[]}; .h += [(0|tobits), $c[0:7]] | .g |= . + [if length % 8 == 0 then (0|tobits) else empty end, $c[7:8]]) | .h, .g  | tobytes
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|64 6f 6d 61 7b 77 34 72 6d 33 35 37 5f 77 33 6c|doma{w4rm357_w3l|.: raw bits 0x0-0x22.7 (35)

--- a/pkg/interp/testdata/value_array.fqtest
+++ b/pkg/interp/testdata/value_array.fqtest
@@ -166,14 +166,14 @@ mp3> .headers._bits | ., type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|.: raw bits 0x0-0x2c.7 (45)
 *   |until 0x2c.7 (45)                              |                |
-"buffer"
+"binary"
 360
 mp3> 
 mp3> .headers._bytes | ., type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|.: raw bits 0x0-0x2c.7 (45)
 *   |until 0x2c.7 (45)                              |                |
-"buffer"
+"binary"
 45
 mp3> 
 mp3> .headers._error | ., type, length?

--- a/pkg/interp/testdata/value_boolean.fqtest
+++ b/pkg/interp/testdata/value_boolean.fqtest
@@ -72,13 +72,13 @@ mp3> .headers[0].flags.unsynchronisation._path | ., type, length?
 mp3> .headers[0].flags.unsynchronisation._bits | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|               00                              |     .          |.: raw bits 0x5-0x5 (0.1)
-"buffer"
+"binary"
 1
 mp3> 
 mp3> .headers[0].flags.unsynchronisation._bytes | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|               00                              |     .          |.: raw bits 0x5-0x5 (0.1)
-"buffer"
+"binary"
 0
 mp3> 
 mp3> .headers[0].flags.unsynchronisation._error | ., type, length?

--- a/pkg/interp/testdata/value_json_array.fqtest
+++ b/pkg/interp/testdata/value_json_array.fqtest
@@ -81,13 +81,13 @@ json> (.)._path | ., type, length?
 json> (.)._bits | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|5b 5d|                                         |[]|             |.: raw bits 0x0-0x1.7 (2)
-"buffer"
+"binary"
 16
 json> 
 json> (.)._bytes | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|5b 5d|                                         |[]|             |.: raw bits 0x0-0x1.7 (2)
-"buffer"
+"binary"
 2
 json> 
 json> (.)._error | ., type, length?

--- a/pkg/interp/testdata/value_json_object.fqtest
+++ b/pkg/interp/testdata/value_json_object.fqtest
@@ -71,13 +71,13 @@ json> (.)._path | ., type, length?
 json> (.)._bits | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|7b 7d|                                         |{}|             |.: raw bits 0x0-0x1.7 (2)
-"buffer"
+"binary"
 16
 json> 
 json> (.)._bytes | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|7b 7d|                                         |{}|             |.: raw bits 0x0-0x1.7 (2)
-"buffer"
+"binary"
 2
 json> 
 json> (.)._error | ., type, length?

--- a/pkg/interp/testdata/value_null.fqtest
+++ b/pkg/interp/testdata/value_null.fqtest
@@ -84,13 +84,13 @@ mp3> .headers[0].padding._path | ., type, length?
 mp3> .headers[0].padding._bits | ., type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|         00 00 00 00 00 00 00 00 00 00         |   ..........   |.: raw bits 0x23-0x2c.7 (10)
-"buffer"
+"binary"
 80
 mp3> 
 mp3> .headers[0].padding._bytes | ., type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|         00 00 00 00 00 00 00 00 00 00         |   ..........   |.: raw bits 0x23-0x2c.7 (10)
-"buffer"
+"binary"
 10
 mp3> 
 mp3> .headers[0].padding._error | ., type, length?

--- a/pkg/interp/testdata/value_number.fqtest
+++ b/pkg/interp/testdata/value_number.fqtest
@@ -72,13 +72,13 @@ mp3> .headers[0].version._path | ., type, length?
 mp3> .headers[0].version._bits | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|         04                                    |   .            |.: raw bits 0x3-0x3.7 (1)
-"buffer"
+"binary"
 8
 mp3> 
 mp3> .headers[0].version._bytes | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|         04                                    |   .            |.: raw bits 0x3-0x3.7 (1)
-"buffer"
+"binary"
 1
 mp3> 
 mp3> .headers[0].version._error | ., type, length?

--- a/pkg/interp/testdata/value_object.fqtest
+++ b/pkg/interp/testdata/value_object.fqtest
@@ -88,13 +88,13 @@ mp3> .headers[0].flags._path | ., type, length?
 mp3> .headers[0].flags._bits | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|               00                              |     .          |.: raw bits 0x5-0x5.7 (1)
-"buffer"
+"binary"
 8
 mp3> 
 mp3> .headers[0].flags._bytes | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|               00                              |     .          |.: raw bits 0x5-0x5.7 (1)
-"buffer"
+"binary"
 1
 mp3> 
 mp3> .headers[0].flags._error | ., type, length?

--- a/pkg/interp/testdata/value_string.fqtest
+++ b/pkg/interp/testdata/value_string.fqtest
@@ -84,13 +84,13 @@ mp3> .headers[0].magic._path | ., type, length?
 mp3> .headers[0].magic._bits | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|49 44 33                                       |ID3             |.: raw bits 0x0-0x2.7 (3)
-"buffer"
+"binary"
 24
 mp3> 
 mp3> .headers[0].magic._bytes | ., type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|49 44 33                                       |ID3             |.: raw bits 0x0-0x2.7 (3)
-"buffer"
+"binary"
 3
 mp3> 
 mp3> .headers[0].magic._error | ., type, length?


### PR DESCRIPTION
Rename buffer to binary. Still some work left what to call buffer/binary in decode code.
Document decode value and binary type
Fix proper unit padding for tobytes and add still undocumenated extra padding argument.
Add some additional binary tests