### PR TITLE
Adds Windows Scoop instructions for fq in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ xattr -d com.apple.quarantine fq && spctl --add fq
 brew install wader/tap/fq
 ```
 
+### Windows
+
+`fq` can be installed via [scoop](https://scoop.sh/).
+
+```powershell
+scoop install fq
+```
+
 ### Arch Linux
 
 `fq` can be installed from the [community repository](https://archlinux.org/packages/community/x86_64/fq/) using [pacman](https://wiki.archlinux.org/title/Pacman):


### PR DESCRIPTION
Adds instructions to installing `fq` from scoop which I [added recently](https://github.com/ScoopInstaller/Main/pull/3295).

![image](https://user-images.githubusercontent.com/68254/153396812-8b4f840f-8908-499d-ba11-940514d406f8.png)
(ignore the warnings, this is a fresh install of Windows)

We had some difficulty with licenses as `fq` isn't officially marked as MIT (even though the LICENSE file text is MIT).