### PR TITLE
repl: Speedup multi input to sub-repl

### DIFF
--- a/format/mp3/testdata/test.fqtest
+++ b/format/mp3/testdata/test.fqtest
@@ -2,7 +2,7 @@
 $ fq -d mp3 '.headers[0].magic | verbose' /test.mp3
 exitcode: 3
 stderr:
-error: arg:1:0: function not defined: verbose/0
+error: arg: function not defined: verbose/0
 $ fq -d mp3 dv /test.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3) 0x0-0x4cf.7 (1232)
      |                                               |                |  headers[0:1]: 0x0-0x3c.7 (61)

--- a/format/mpeg/testdata/mp3-frame-mono-crc.fqtest
+++ b/format/mpeg/testdata/mp3-frame-mono-crc.fqtest
@@ -2,4 +2,4 @@
 $ fq -d mp3_frame '.header.crc | verbose' /mp3-frame-mono-crc
 exitcode: 3
 stderr:
-error: arg:1:0: function not defined: verbose/0
+error: arg: function not defined: verbose/0

--- a/pkg/interp/internal.jq
+++ b/pkg/interp/internal.jq
@@ -116,7 +116,10 @@ def _recurse_break(f):
 # TODO: better way? what about nested eval errors?
 def _eval_is_compile_error: type == "object" and .error != null and .what != null;
 def _eval_compile_error_tostring:
-  "\(.filename // "src"):\(.line):\(.column): \(.error)";
+  [ (.filename | if . == "" then "expr" end)
+  , if .line != 1 or .column != 0 then "\(.line):\(.column)" else empty end
+  , " \(.error)"
+  ] | join(":");
 def _eval($expr; $filename; f; on_error; on_compile_error):
   try
     eval($expr; $filename) | f

--- a/pkg/interp/query.jq
+++ b/pkg/interp/query.jq
@@ -9,6 +9,10 @@ def _query_pipe(r):
     right: r
   };
 
+# . -> .[]
+def _query_iter:
+  .term.suffix_list = [{iter: true}];
+
 def _query_ident:
   {term: {type: "TermTypeIdentity"}};
 
@@ -194,4 +198,12 @@ def _query_slurp_wrap(f):
   | _query_pipe($lq | f)
   | .meta = $meta
   | .imports = $imports
+  );
+
+# filter -> .[] | filter
+def _query_iter_wrap:
+  ( . as $q
+  | _query_ident
+  | _query_iter
+  | _query_pipe($q)
   );

--- a/pkg/interp/testdata/bitops.fqtest
+++ b/pkg/interp/testdata/bitops.fqtest
@@ -7,13 +7,13 @@ null> 0, -1, 1208925819614629174706175, -1208925819614629174706176 | bnot
 null> null | bnot
 error: cannot bnot: null
 null> bnot(1)
-error: repl:1:0: function not defined: bnot/1
+error: expr: function not defined: bnot/1
 null> [0,0], [8,1], [0xffff_ffff_ffff_ffff,1] | bsl(.[0]; .[1])
 0
 16
 36893488147419103230
 null> bsl(1)
-error: repl:1:0: function not defined: bsl/1
+error: expr: function not defined: bsl/1
 null> bsl(null; 1)
 error: cannot bsl: null and number
 null> [0,0], [8,1], [0x1_ffff_ffff_ffff_fffe,1] | bsr(.[0]; .[1])
@@ -21,7 +21,7 @@ null> [0,0], [8,1], [0x1_ffff_ffff_ffff_fffe,1] | bsr(.[0]; .[1])
 4
 18446744073709551615
 null> bsr(1)
-error: repl:1:0: function not defined: bsr/1
+error: expr: function not defined: bsr/1
 null> bsr(null; 1)
 error: cannot bsr: null and number
 null> [0,0], [0xffff_ffff_ffff_ffff_ffff,0x1234], [0x1234,0xffff_ffff_ffff_ffff_ffff,0x1234] | band(.[0]; .[1])
@@ -29,7 +29,7 @@ null> [0,0], [0xffff_ffff_ffff_ffff_ffff,0x1234], [0x1234,0xffff_ffff_ffff_ffff_
 4660
 4660
 null> band(1)
-error: repl:1:0: function not defined: band/1
+error: expr: function not defined: band/1
 null> band(null; 1)
 error: cannot band: null and number
 null> [0,0], [0xffff_ffff_ffff_ffff_0000,0x1234], [0x1234,0xffff_ffff_ffff_ffff_0000,0x1234] | bor(.[0]; .[1])
@@ -37,7 +37,7 @@ null> [0,0], [0xffff_ffff_ffff_ffff_0000,0x1234], [0x1234,0xffff_ffff_ffff_ffff_
 1208925819614629174645300
 1208925819614629174645300
 null> bor(1)
-error: repl:1:0: function not defined: bor/1
+error: expr: function not defined: bor/1
 null> bor(null; 1)
 error: cannot bor: null and number
 null> [0,0], [0xffff_ffff_ffff_ffff_ffff,0x1234], [0x1234,0xffff_ffff_ffff_ffff_ffff,0x1234] | bxor(.[0]; .[1])
@@ -45,7 +45,7 @@ null> [0,0], [0xffff_ffff_ffff_ffff_ffff,0x1234], [0x1234,0xffff_ffff_ffff_ffff_
 1208925819614629174701515
 1208925819614629174701515
 null> bxor(1)
-error: repl:1:0: function not defined: bxor/1
+error: expr: function not defined: bxor/1
 null> bxor(null; 1)
 error: cannot bxor: null and number
 null> ^D

--- a/pkg/interp/testdata/exitcode.fqtest
+++ b/pkg/interp/testdata/exitcode.fqtest
@@ -15,7 +15,7 @@ exitcode: 123
 $ fq -n invalid
 exitcode: 3
 stderr:
-error: arg:1:0: function not defined: invalid/0
+error: arg: function not defined: invalid/0
 $ fq -n "("
 exitcode: 3
 stderr:

--- a/pkg/interp/testdata/incudepath.fqtest
+++ b/pkg/interp/testdata/incudepath.fqtest
@@ -13,14 +13,14 @@ $ fq -n 'include "/library/a"; a'
 $ fq -L /wrong -n 'include "a"; a'
 exitcode: 3
 stderr:
-error: arg:1:0: open a.jq: file does not exist
+error: arg: open a.jq: file does not exist
 $ fq -n 'include "@config/a";'
 exitcode: 3
 stderr:
-error: arg:1:0: open testdata/config/a.jq: no such file or directory
+error: arg: open testdata/config/a.jq: no such file or directory
 $ fq -n 'include "@config/missing?";'
 null
 $ fq -n 'include "@config/has_error?";'
 exitcode: 3
 stderr:
-error: arg:1:0: /config/has_error.jq:1:1: parse: unexpected token ")"
+error: arg: /config/has_error.jq:1:1: parse: unexpected token ")"

--- a/pkg/interp/testdata/inputs.fqtest
+++ b/pkg/interp/testdata/inputs.fqtest
@@ -62,7 +62,7 @@ error: arg:1:2: unexpected token <EOF>
 $ fq -d raw bla /a /b /c
 exitcode: 3
 stderr:
-error: arg:1:0: function not defined: bla/0
+error: arg: function not defined: bla/0
 $ fq -d raw '1+"a"' /a /b /c
 exitcode: 5
 stderr:

--- a/pkg/interp/testdata/repl.fqtest
+++ b/pkg/interp/testdata/repl.fqtest
@@ -5,9 +5,9 @@ null
 null> 1+1
 2
 null> (
-error: repl:1:2: unexpected token <EOF>
+error: expr:1:2: unexpected token <EOF>
 null> abc
-error: repl:1:0: function not defined: abc/0
+error: expr: function not defined: abc/0
 null> 1+"a"
 error: cannot add: number (1) and string ("a")
 null> 1 | repl

--- a/pkg/interp/testdata/var.fqtest
+++ b/pkg/interp/testdata/var.fqtest
@@ -18,7 +18,7 @@ null> $a
 "aa"
 null> var("a"; empty)
 null> $a
-error: repl:1:0: variable not defined: $a
+error: expr: variable not defined: $a
 null> var
 {
   "bb": "bb"


### PR DESCRIPTION
Rewrite non-sub-repl queries as "q" -> ".[] | q" and pass in inputs as array.
Before each input did an eval.

Also fixup error message a bit, skip line:column when they dont make sense.