### PR TITLE
interp: Skip redundant includes

### DIFF
--- a/pkg/interp/binary.go
+++ b/pkg/interp/binary.go
@@ -177,7 +177,7 @@ func (of *openFile) ToBinary() (Binary, error) {
 // opens a file for reading from filesystem
 // TODO: when to close? when br loses all refs? need to use finalizer somehow?
 func (i *Interp) _open(c interface{}, a []interface{}) gojq.Iter {
-	if i.evalContext.isCompleting {
+	if i.evalInstance.isCompleting {
 		return gojq.NewIter()
 	}
 
@@ -215,13 +215,13 @@ func (i *Interp) _open(c interface{}, a []interface{}) gojq.Iter {
 	// a regular file should be seekable but fallback below to read whole file if not
 	if fFI.Mode().IsRegular() {
 		if rs, ok := f.(io.ReadSeeker); ok {
-			fRS = ctxreadseeker.New(i.evalContext.ctx, rs)
+			fRS = ctxreadseeker.New(i.evalInstance.ctx, rs)
 			bEnd = fFI.Size()
 		}
 	}
 
 	if fRS == nil {
-		buf, err := ioutil.ReadAll(ctxreadseeker.New(i.evalContext.ctx, &ioextra.ReadErrSeeker{Reader: f}))
+		buf, err := ioutil.ReadAll(ctxreadseeker.New(i.evalInstance.ctx, &ioextra.ReadErrSeeker{Reader: f}))
 		if err != nil {
 			f.Close()
 			return gojq.NewIter(err)

--- a/pkg/interp/decode.go
+++ b/pkg/interp/decode.go
@@ -157,11 +157,11 @@ func (i *Interp) _decode(c interface{}, a []interface{}) interface{} {
 			evalProgress := func(c interface{}) {
 				// {approx_read_bytes: 123, total_size: 123} | opts.Progress
 				_, _ = i.EvalFuncValues(
-					i.evalContext.ctx,
+					i.evalInstance.ctx,
 					c,
 					opts.Progress,
 					nil,
-					EvalOpts{output: ioextra.DiscardCtxWriter{Ctx: i.evalContext.ctx}},
+					EvalOpts{output: ioextra.DiscardCtxWriter{Ctx: i.evalInstance.ctx}},
 				)
 			}
 			lastProgress := time.Now()
@@ -201,7 +201,7 @@ func (i *Interp) _decode(c interface{}, a []interface{}) interface{} {
 		return err
 	}
 
-	dv, _, err := decode.Decode(i.evalContext.ctx, bv.br, decodeFormat,
+	dv, _, err := decode.Decode(i.evalInstance.ctx, bv.br, decodeFormat,
 		decode.Options{
 			IsRoot:        true,
 			FillGaps:      true,

--- a/pkg/interp/funcs.go
+++ b/pkg/interp/funcs.go
@@ -258,7 +258,7 @@ func (i *Interp) _hexdump(c interface{}, a []interface{}) gojq.Iter {
 	if err != nil {
 		return gojq.NewIter(err)
 	}
-	if err := hexdump(i.evalContext.output, bv, opts); err != nil {
+	if err := hexdump(i.evalInstance.output, bv, opts); err != nil {
 		return gojq.NewIter(err)
 	}
 


### PR DESCRIPTION
Speeds up interp quite a bit.
Also good as i've start to use more includes to make code easier to follow
where thigns come from and also makes jq-lsp happier.

Also rename evalContext to evalInstace to make it less confused with context.