### PR TITLE
test: Make expect cli test more robust

### DIFF
--- a/pkg/cli/test.exp
+++ b/pkg/cli/test.exp
@@ -22,6 +22,7 @@ send ".frames | mp3_fr\t"
 expect "mp3_frame"
 send "\n"
 expect "side_info"
+expect "mp3> "
 
 # ctrl-d
 send "\x04"


### PR DESCRIPTION
Wait for prompt before sending ^D. Seems to fix issue with expect on ubuntu focal.

Thanks @KristianKarl for report