### PR TITLE
interp,repl: Improved eval and output interrupt

### DIFF
--- a/internal/colorjson/encoder.go
+++ b/internal/colorjson/encoder.go
@@ -205,6 +205,10 @@ func (e *Encoder) encodeArray(vs []interface{}) {
 	e.writeByte('[', e.colors.Array)
 	e.depth += e.indent
 	for i, v := range vs {
+		if e.wErr != nil {
+			return
+		}
+
 		if i > 0 {
 			e.writeByte(',', e.colors.Array)
 		}
@@ -237,6 +241,10 @@ func (e *Encoder) encodeMap(vs map[string]interface{}) {
 		return kvs[i].key < kvs[j].key
 	})
 	for i, kv := range kvs {
+		if e.wErr != nil {
+			return
+		}
+
 		if i > 0 {
 			e.writeByte(',', e.colors.Object)
 		}

--- a/pkg/cli/test.exp
+++ b/pkg/cli/test.exp
@@ -31,8 +31,22 @@ expect "123"
 send "\x03"
 expect "mp3> "
 
+# test interrupt multiple outputs implicit display
+send "range(100000)\n"
+expect "123"
+# ctrl-c
+send "\x03"
+expect "mp3> "
+
 # test interrupt big json output
 send "\[range(100000)\] | d\n"
+expect "123"
+# ctrl-c
+send "\x03"
+expect "mp3> "
+
+# test interrupt big json output implicit display
+send "\[range(100000)\]\n"
 expect "123"
 # ctrl-c
 send "\x03"

--- a/pkg/interp/help.jq
+++ b/pkg/interp/help.jq
@@ -194,5 +194,6 @@ def _help($arg0; $topic):
     ( _repl_slurp_eval($query.rewrite) as $outputs
     | "value help"
     , $outputs
+    | display
     )
   end;

--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -918,6 +918,8 @@ func (i *Interp) Eval(ctx context.Context, c interface{}, expr string, opts Eval
 		// gojq ctx cancel will not return ok=false, just cancelled error
 		if !ok {
 			runCtxCancelFn()
+		} else if _, ok := v.(error); ok {
+			runCtxCancelFn()
 		}
 		return v, ok
 	})


### PR DESCRIPTION
repl now rewrites query to do implicit display inside the sub eval.
This makes it possible to interrupt eval and output in a better and faster way.

Make JSON encoder fail early on errors.

Add more interrupt tests.