### PR TITLE
interp: Remove to*range pad argument and fix stdout padding issue

### DIFF
--- a/pkg/interp/binary.go
+++ b/pkg/interp/binary.go
@@ -149,7 +149,7 @@ func (i *Interp) _toBits(c interface{}, a []interface{}) interface{} {
 	if err != nil {
 		return err
 	}
-	bb, err := newBinaryFromBitReader(br, bv.unit, bv.pad)
+	bb, err := newBinaryFromBitReader(br, bv.unit, 0)
 	if err != nil {
 		return err
 	}
@@ -272,6 +272,7 @@ type Binary struct {
 	pad  int64
 }
 
+//nolint:unparam
 func newBinaryFromBitReader(br bitio.ReaderAtSeeker, unit int, pad int64) (Binary, error) {
 	l, err := bitioextra.Len(br)
 	if err != nil {

--- a/pkg/interp/binary.jq
+++ b/pkg/interp/binary.jq
@@ -4,8 +4,6 @@ def tobitsrange: _tobits(1; true; 0);
 def tobytesrange: _tobits(8; true; 0);
 def tobits($pad): _tobits(1; false; $pad);
 def tobytes($pad): _tobits(8; false; $pad);
-def tobitsrange($pad): _tobits(1; true; $pad);
-def tobytesrange($pad): _tobits(8; true; $pad);
 
 # same as regexp.QuoteMeta
 def _re_quote_meta:

--- a/pkg/interp/testdata/binary_stdout.fqtest
+++ b/pkg/interp/testdata/binary_stdout.fqtest
@@ -1,0 +1,8 @@
+$ _STDOUT_ISTERMINAL=0 _STDOUT_HEX=1 NO_COLOR=1 fq -n '[1,1,1 | tobits] | tobytes'
+07\
+$ _STDOUT_ISTERMINAL=0 _STDOUT_HEX=1 NO_COLOR=1 fq -n '[1,1,1 | tobits] | tobytes(3)'
+000007\
+$ _STDOUT_ISTERMINAL=0 _STDOUT_HEX=1 NO_COLOR=1 fq -n '[1,1,1 | tobits] | tobits(9)'
+0380\
+$ _STDOUT_ISTERMINAL=0 _STDOUT_HEX=1 NO_COLOR=1 fq -n '[5 | tobits(12)], [3 | tobytes(3)] | tobytes'
+0005000003\


### PR DESCRIPTION
Padding could end up double.
Remove to*range($pad) as it probably just confusing to be able
to pad an existing range, what to show in hexdump etc? zero bits
that do not actuall exist at that range?

Add tests and binary stdout support to tests