### PR TITLE
Update github-golangci-lint from 1.44.2 to 1.45.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: 1.44.2
+  GOLANGCILINT_VERSION: 1.45.0
 
 jobs:
   lint:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v1.45.0)  
