### PR TITLE
interp: Don't truncate last display column

### DIFF
--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -155,9 +155,9 @@ func (cr *CaseRun) InterruptChan() chan struct{} { return nil }
 
 func (cr *CaseRun) Environ() []string {
 	env := []string{
-		"_STDIN_WIDTH=0",
+		"_STDIN_WIDTH=135",
 		"_STDIN_HEIGHT=25",
-		"_STDOUT_WIDTH=0",
+		"_STDOUT_WIDTH=135",
 		"_STDOUT_HEIGHT=25",
 		"_STDOUT_IS_TERMINAL=1",
 		"NO_COLOR=1",

--- a/pkg/interp/dump.go
+++ b/pkg/interp/dump.go
@@ -363,18 +363,6 @@ func dump(v *decode.Value, w io.Writer, opts Options) error {
 		return nil
 	}))
 
-	maxTreeWidth := -1
-	if opts.Width > 0 {
-		maxTreeWidth = opts.Width - (0 +
-			maxAddrIndentWidth +
-			1 +
-			(opts.LineBytes*3 - 1) +
-			1 +
-			opts.LineBytes +
-			1 +
-			0)
-	}
-
 	cw := columnwriter.New(
 		w,
 		[]int{
@@ -384,7 +372,7 @@ func dump(v *decode.Value, w io.Writer, opts Options) error {
 			1,
 			opts.LineBytes,
 			1,
-			maxTreeWidth,
+			-1,
 		})
 	buf := make([]byte, 32*1024)
 

--- a/pkg/interp/testdata/args.fqtest
+++ b/pkg/interp/testdata/args.fqtest
@@ -92,7 +92,7 @@ slurp               false
 string_input        false
 unicode             false
 verbose             false
-width               0
+width               135
 $ fq --help formats
 aac_frame            Advanced Audio Coding frame
 adts                 Audio Data Transport Stream

--- a/pkg/interp/testdata/display.fqtest
+++ b/pkg/interp/testdata/display.fqtest
@@ -43,13 +43,13 @@ mp3> display({depth: 1, line_bytes: 8})
 *    |until 0x283.7 (end) (59|        |
      |                       |        |  footers[0:0]:
 mp3> display({width: 30, depth: 1})
-     |00 01 02 03|0123|.{}: /t
-0x000|49 44 33 04|ID3.|  heade
+     |00 01 02 03|0123|.{}: /test.mp3 (mp3)
+0x000|49 44 33 04|ID3.|  headers[0:1]:
 *    |until 0x2c.|    |
-0x02c|   ff fb 40| ..@|  frame
+0x02c|   ff fb 40| ..@|  frames[0:3]:
 0x030|c0 00 00 00|....|
 *    |until 0x283|    |
-     |           |    |  foote
+     |           |    |  footers[0:0]:
 mp3> .frames[0] | dv({depth: 1, addrbase: 10})
    |00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15|0123456789012345|.frames[0]{}: frame (mp3_frame) 45-226.7 (182)
 032|                                       ff fb 40|             ..@|  header{}: 45-48.7 (4)

--- a/pkg/interp/testdata/options.fqtest
+++ b/pkg/interp/testdata/options.fqtest
@@ -84,7 +84,7 @@ $ fq -n options
   "string_input": false,
   "unicode": false,
   "verbose": false,
-  "width": 0
+  "width": 135
 }
 $ fq -o addrbase=10 -n options.addrbase
 10


### PR DESCRIPTION
Wrapping lines might be annoying but not seeing things even worse i think.
Hopefully once column config is in jq it could be an option.