### PR TITLE
fq: Use go 1.18

### DIFF
--- a/dev/tmpl.go
+++ b/dev/tmpl.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 )
 
-func toInt(v interface{}) int {
+func toInt(v any) int {
 	switch v := v.(type) {
 	case float64:
 		return int(v)
@@ -22,7 +22,7 @@ func toInt(v interface{}) int {
 	}
 }
 
-func toString(v interface{}) string {
+func toString(v any) string {
 	switch v := v.(type) {
 	case string:
 		return v
@@ -35,7 +35,7 @@ func toString(v interface{}) string {
 
 func main() {
 	funcMap := template.FuncMap{
-		"xrange": func(args ...interface{}) (interface{}, error) {
+		"xrange": func(args ...any) (any, error) {
 			if len(args) < 2 {
 				return nil, errors.New("need min and max argument")
 			}
@@ -49,7 +49,7 @@ func main() {
 
 			return v, nil
 		},
-		"replace": func(args ...interface{}) (interface{}, error) {
+		"replace": func(args ...any) (any, error) {
 			if len(args) < 3 {
 				return nil, errors.New("need tmpl, old and new argument")
 			}
@@ -62,7 +62,7 @@ func main() {
 		},
 	}
 
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	if len(os.Args) > 1 {
 		r, err := os.Open(os.Args[1])
 		if err != nil {

--- a/doc/presentations/bts2022/mp3.go
+++ b/doc/presentations/bts2022/mp3.go
@@ -1,4 +1,4 @@
-func decode(d *decode.D, in interface{}) interface{} {
+func decode(d *decode.D, in any) any {
 	d.FieldArray("headers", func(d *decode.D) {
 		for !d.End() {
 			d.TryFieldFormat("header", headerGroup)

--- a/format/ape/apev2.go
+++ b/format/ape/apev2.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func apev2Decode(d *decode.D, in interface{}) interface{} {
+func apev2Decode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	headerFooterFn := func(d *decode.D, name string) uint64 {

--- a/format/ar/ar.go
+++ b/format/ar/ar.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func decodeAr(d *decode.D, in interface{}) interface{} {
+func decodeAr(d *decode.D, in any) any {
 	d.FieldUTF8("signature", 8, d.AssertStr("!<arch>\n"))
 	d.FieldArray("files", func(d *decode.D) {
 		for !d.End() {

--- a/format/asn1/asn1_ber.go
+++ b/format/asn1/asn1_ber.go
@@ -414,7 +414,7 @@ func decodeASN1BERValue(d *decode.D, bib *bitio.Buffer, sb *strings.Builder, par
 	})
 }
 
-func decodeASN1BER(d *decode.D, in interface{}) interface{} {
+func decodeASN1BER(d *decode.D, in any) any {
 	decodeASN1BERValue(d, nil, nil, formConstructed, universalTypeSequence)
 	return nil
 }

--- a/format/av1/av1_ccr.go
+++ b/format/av1/av1_ccr.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func ccrDecode(d *decode.D, in interface{}) interface{} {
+func ccrDecode(d *decode.D, in any) any {
 	d.FieldU1("marker")
 	d.FieldU7("version")
 	d.FieldU3("seq_profile")

--- a/format/av1/av1_frame.go
+++ b/format/av1/av1_frame.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func frameDecode(d *decode.D, in interface{}) interface{} {
+func frameDecode(d *decode.D, in any) any {
 	for d.NotEnd() {
 		d.FieldFormat("obu", obuFormat, nil)
 	}

--- a/format/av1/av1_obu.go
+++ b/format/av1/av1_obu.go
@@ -52,7 +52,7 @@ func decodeLeb128(d *decode.D) uint64 {
 	return v
 }
 
-func obuDecode(d *decode.D, in interface{}) interface{} {
+func obuDecode(d *decode.D, in any) any {
 	var obuType uint64
 	var obuSize int64
 	hasExtension := false

--- a/format/avro/avro_ocf.go
+++ b/format/avro/avro_ocf.go
@@ -61,11 +61,11 @@ func decodeHeader(d *decode.D) HeaderData {
 	}
 
 	header := decodeHeaderFn("header", d)
-	headerRecord, ok := header.(map[string]interface{})
+	headerRecord, ok := header.(map[string]any)
 	if !ok {
 		d.Fatalf("header is not a map")
 	}
-	meta, ok := headerRecord["meta"].(map[string]interface{})
+	meta, ok := headerRecord["meta"].(map[string]any)
 	if !ok {
 		d.Fatalf("header.meta is not a map")
 	}
@@ -124,7 +124,7 @@ func decodeBlockCodec(d *decode.D, dataSize int64, codec string) *bytes.Buffer {
 	return bb
 }
 
-func decodeAvroOCF(d *decode.D, in interface{}) interface{} {
+func decodeAvroOCF(d *decode.D, in any) any {
 	header := decodeHeader(d)
 
 	decodeFn, err := decoders.DecodeFnForSchema(header.Schema)

--- a/format/avro/decoders/array.go
+++ b/format/avro/decoders/array.go
@@ -28,8 +28,8 @@ func decodeArrayFn(schema schema.SimplifiedSchema) (DecodeFn, error) {
 	// followed by long values 3 and 27 (encoded as hex 06 36) terminated by zero:
 	// 04 06 36 00
 
-	return func(name string, d *decode.D) interface{} {
-		var values []interface{}
+	return func(name string, d *decode.D) any {
+		var values []any
 		d.FieldArray(name, func(d *decode.D) {
 			count := int64(-1)
 			for count != 0 {

--- a/format/avro/decoders/bool.go
+++ b/format/avro/decoders/bool.go
@@ -7,7 +7,7 @@ import (
 
 func decodeBoolFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// A boolean is written as a single byte whose value is either 0 (false) or 1 (true).
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		return d.FieldBoolFn(name, func(d *decode.D) bool {
 			return d.U8() >= 1
 		}, sms...)

--- a/format/avro/decoders/bytes.go
+++ b/format/avro/decoders/bytes.go
@@ -10,7 +10,7 @@ type BytesCodec struct{}
 
 func decodeBytesFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// Bytes are encoded as a long followed by that many bytes of data.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		var val []byte
 
 		d.FieldStruct(name, func(d *decode.D) {

--- a/format/avro/decoders/decoders.go
+++ b/format/avro/decoders/decoders.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-type DecodeFn func(string, *decode.D) interface{}
+type DecodeFn func(string, *decode.D) any
 
 func DecodeFnForSchema(s schema.SimplifiedSchema) (DecodeFn, error) {
 	var sms []scalar.Mapper

--- a/format/avro/decoders/double.go
+++ b/format/avro/decoders/double.go
@@ -8,7 +8,7 @@ import (
 func decodeDoubleFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// A double is written as 8 bytes. The double is converted into a 64-bit integer using a method equivalent to Java's
 	// doubleToLongBits and then encoded in little-endian format.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		return d.FieldF64(name, sms...)
 	}, nil
 }

--- a/format/avro/decoders/fixed.go
+++ b/format/avro/decoders/fixed.go
@@ -15,7 +15,7 @@ func decodeFixedFn(schema schema.SimplifiedSchema, sms ...scalar.Mapper) (Decode
 	}
 	size := int64(schema.Size)
 	// Fixed instances are encoded using the number of bytes declared in the schema.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		r := d.FieldRawLen(name, size*8, sms...)
 		val := make([]byte, size)
 		if _, err := r.ReadBits(val, size*8); err != nil {

--- a/format/avro/decoders/float.go
+++ b/format/avro/decoders/float.go
@@ -8,7 +8,7 @@ import (
 func decodeFloatFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// A float is written as 4 bytes. The float is converted into a 32-bit integer using a method equivalent to Java's
 	// floatToIntBits and then encoded in little-endian format.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		return d.FieldF32(name, sms...)
 	}, nil
 }

--- a/format/avro/decoders/int.go
+++ b/format/avro/decoders/int.go
@@ -7,7 +7,7 @@ import (
 
 func decodeIntFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// Int and long values are written using variable-length zig-zag coding.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		return d.FieldSFn(name, VarZigZag, sms...)
 	}, nil
 }

--- a/format/avro/decoders/long.go
+++ b/format/avro/decoders/long.go
@@ -31,7 +31,7 @@ func VarZigZag(d *decode.D) int64 {
 
 func decodeLongFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// Int and long values are written using variable-length zig-zag coding.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		return d.FieldSFn(name, VarZigZag, sms...)
 	}, nil
 }

--- a/format/avro/decoders/map.go
+++ b/format/avro/decoders/map.go
@@ -43,17 +43,17 @@ func decodeMapFn(s schema.SimplifiedSchema) (DecodeFn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode map: %w", err)
 	}
-	return func(s string, d *decode.D) interface{} {
-		val := make(map[string]interface{})
+	return func(s string, d *decode.D) any {
+		val := make(map[string]any)
 
 		rawV := subFn(s, d)
-		rawSlice, ok := rawV.([]interface{})
+		rawSlice, ok := rawV.([]any)
 		if !ok {
 			d.Fatalf("decode map: expected array of interfaces, got %v", rawV)
 			return nil
 		}
 		for _, rawEntry := range rawSlice {
-			entry, ok := rawEntry.(map[string]interface{})
+			entry, ok := rawEntry.(map[string]any)
 			if !ok {
 				d.Fatalf("decode map: expected map, got %T", rawEntry)
 			}

--- a/format/avro/decoders/null.go
+++ b/format/avro/decoders/null.go
@@ -7,7 +7,7 @@ import (
 
 func decodeNullFn(sms ...scalar.Mapper) (DecodeFn, error) {
 	// null is written as zero bytes.
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		d.FieldValueNil(name, sms...)
 		return nil
 	}, nil

--- a/format/avro/decoders/record.go
+++ b/format/avro/decoders/record.go
@@ -12,7 +12,7 @@ func decodeRecordFn(schema schema.SimplifiedSchema) (DecodeFn, error) {
 		return nil, fmt.Errorf("record must have fields")
 	}
 	var fieldNames []string
-	var fieldDecoders []func(string, *decode.D) interface{}
+	var fieldDecoders []func(string, *decode.D) any
 
 	for _, f := range schema.Fields {
 		fieldNames = append(fieldNames, f.Name)
@@ -39,8 +39,8 @@ func decodeRecordFn(schema schema.SimplifiedSchema) (DecodeFn, error) {
 	// the hex byte sequence:
 	// 36 06 66 6f 6f
 
-	return func(name string, d *decode.D) interface{} {
-		val := make(map[string]interface{})
+	return func(name string, d *decode.D) any {
+		val := make(map[string]any)
 		d.FieldStruct(name, func(d *decode.D) {
 			for i, f := range fieldNames {
 				val[f] = fieldDecoders[i](f, d)

--- a/format/avro/decoders/string.go
+++ b/format/avro/decoders/string.go
@@ -11,7 +11,7 @@ func decodeStringFn(schema schema.SimplifiedSchema, sms ...scalar.Mapper) (Decod
 	// For example, the three-character string "foo" would be encoded as the long value 3 (encoded as hex 06) followed
 	// by the UTF-8 encoding of 'f', 'o', and 'o' (the hex bytes 66 6f 6f):
 	// 06 66 6f 6f
-	return func(name string, d *decode.D) interface{} {
+	return func(name string, d *decode.D) any {
 		var val string
 		d.FieldStruct(name, func(d *decode.D) {
 			length := d.FieldSFn("length", VarZigZag)

--- a/format/avro/decoders/union.go
+++ b/format/avro/decoders/union.go
@@ -13,7 +13,7 @@ func decodeUnionFn(schema schema.SimplifiedSchema) (DecodeFn, error) {
 		return nil, errors.New("union must have types")
 	}
 
-	var decoders []func(string, *decode.D) interface{}
+	var decoders []func(string, *decode.D) any
 	for i, t := range schema.UnionTypes {
 		decodeFn, err := DecodeFnForSchema(t)
 		if err != nil {
@@ -24,8 +24,8 @@ func decodeUnionFn(schema schema.SimplifiedSchema) (DecodeFn, error) {
 
 	// A union is encoded by first writing an int value indicating the zero-based position within the union of the
 	// schema of its value. The value is then encoded per the indicated schema within the union.
-	return func(name string, d *decode.D) interface{} {
-		var val interface{}
+	return func(name string, d *decode.D) any {
+		var val any
 		d.FieldStruct(name, func(d *decode.D) {
 			v := int(d.FieldSFn("type", VarZigZag))
 			if v < 0 || v >= len(decoders) {

--- a/format/avro/schema/schema.go
+++ b/format/avro/schema/schema.go
@@ -46,7 +46,7 @@ type Field struct {
 }
 
 func FromSchemaString(schemaString string) (SimplifiedSchema, error) {
-	var jsonSchema interface{}
+	var jsonSchema any
 	if err := json.Unmarshal([]byte(schemaString), &jsonSchema); err != nil {
 		return SimplifiedSchema{}, fmt.Errorf("failed to unmarshal header schema: %w", err)
 	}
@@ -54,13 +54,13 @@ func FromSchemaString(schemaString string) (SimplifiedSchema, error) {
 	return From(jsonSchema)
 }
 
-func From(schema interface{}) (SimplifiedSchema, error) {
+func From(schema any) (SimplifiedSchema, error) {
 	if schema == nil {
 		return SimplifiedSchema{}, errors.New("schema cannot be nil")
 	}
 	var s SimplifiedSchema
 	switch v := schema.(type) {
-	case []interface{}:
+	case []any:
 		s.Type = UNION
 		for _, i := range v {
 			unionType, err := From(i)
@@ -74,7 +74,7 @@ func From(schema interface{}) (SimplifiedSchema, error) {
 		}
 	case string:
 		s.Type = v
-	case map[string]interface{}:
+	case map[string]any:
 		var err error
 		if s.Type, err = getString(v, "type", true); err != nil {
 			return s, err
@@ -117,7 +117,7 @@ func From(schema interface{}) (SimplifiedSchema, error) {
 	return s, nil
 }
 
-func getSchema(m map[string]interface{}, key string) (*SimplifiedSchema, error) {
+func getSchema(m map[string]any, key string) (*SimplifiedSchema, error) {
 	vI, ok := m[key]
 	if !ok {
 		return nil, fmt.Errorf("%s not found", key)
@@ -129,12 +129,12 @@ func getSchema(m map[string]interface{}, key string) (*SimplifiedSchema, error) 
 	return &v, nil
 }
 
-func getSymbols(m map[string]interface{}) ([]string, error) {
+func getSymbols(m map[string]any) ([]string, error) {
 	vI, ok := m["symbols"]
 	if !ok {
 		return nil, errors.New("symbols required for enum")
 	}
-	vA, ok := vI.([]interface{})
+	vA, ok := vI.([]any)
 	if !ok {
 		return nil, errors.New("symbols must be an array")
 	}
@@ -149,7 +149,7 @@ func getSymbols(m map[string]interface{}) ([]string, error) {
 	return symbols, nil
 }
 
-func getFields(m map[string]interface{}) ([]Field, error) {
+func getFields(m map[string]any) ([]Field, error) {
 	var fields []Field
 	var err error
 
@@ -157,13 +157,13 @@ func getFields(m map[string]interface{}) ([]Field, error) {
 	if !ok {
 		return fields, errors.New("no fields")
 	}
-	fieldsAI, ok := fieldsI.([]interface{})
+	fieldsAI, ok := fieldsI.([]any)
 	if !ok {
 		return fields, errors.New("fields is not an array")
 	}
 
 	for _, fieldI := range fieldsAI {
-		field, ok := fieldI.(map[string]interface{})
+		field, ok := fieldI.(map[string]any)
 		if !ok {
 			return fields, errors.New("field is not a json object")
 		}
@@ -185,7 +185,7 @@ func getFields(m map[string]interface{}) ([]Field, error) {
 	return fields, nil
 }
 
-func getString(m map[string]interface{}, key string, required bool) (string, error) {
+func getString(m map[string]any, key string, required bool) (string, error) {
 	v, ok := m[key]
 	if !ok {
 		if required {
@@ -200,7 +200,7 @@ func getString(m map[string]interface{}, key string, required bool) (string, err
 	return s, nil
 }
 
-func getInt(m map[string]interface{}, key string, required bool) (int, error) {
+func getInt(m map[string]any, key string, required bool) (int, error) {
 	v, ok := m[key]
 	if !ok {
 		if required {

--- a/format/bencode/bencode.go
+++ b/format/bencode/bencode.go
@@ -90,7 +90,7 @@ func decodeBencodeValue(d *decode.D) {
 	}
 }
 
-func decodeBencode(d *decode.D, in interface{}) interface{} {
+func decodeBencode(d *decode.D, in any) any {
 	decodeBencodeValue(d)
 	return nil
 }

--- a/format/bson/bson.go
+++ b/format/bson/bson.go
@@ -110,7 +110,7 @@ func decodeBSONDocument(d *decode.D) {
 	})
 }
 
-func decodeBSON(d *decode.D, in interface{}) interface{} {
+func decodeBSON(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	decodeBSONDocument(d)

--- a/format/bzip2/bzip2.go
+++ b/format/bzip2/bzip2.go
@@ -48,7 +48,7 @@ func (bfr bitFlipReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func bzip2Decode(d *decode.D, in interface{}) interface{} {
+func bzip2Decode(d *decode.D, in any) any {
 	// moreStreams := true
 
 	// d.FieldArray("streams", func(d *decode.D) {

--- a/format/cbor/cbor.go
+++ b/format/cbor/cbor.go
@@ -35,7 +35,7 @@ func init() {
 
 type majorTypeEntry struct {
 	s scalar.S
-	d func(d *decode.D, shortCount uint64, count uint64) interface{}
+	d func(d *decode.D, shortCount uint64, count uint64) any
 }
 
 type majorTypeEntries map[uint64]majorTypeEntry
@@ -107,19 +107,19 @@ const (
 	breakMarker = 0xff
 )
 
-func decodeCBORValue(d *decode.D) interface{} {
+func decodeCBORValue(d *decode.D) any {
 	majorTypeMap := majorTypeEntries{
-		majorTypePositiveInt: {s: scalar.S{Sym: "positive_int"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypePositiveInt: {s: scalar.S{Sym: "positive_int"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			d.FieldValueU("value", count)
 			return nil
 		}},
-		majorTypeNegativeInt: {s: scalar.S{Sym: "negative_int"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeNegativeInt: {s: scalar.S{Sym: "negative_int"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			n := new(big.Int)
 			n.SetUint64(count).Neg(n).Sub(n, mathextra.BigIntOne)
 			d.FieldValueBigInt("value", n)
 			return nil
 		}},
-		majorTypeBytes: {s: scalar.S{Sym: "bytes"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeBytes: {s: scalar.S{Sym: "bytes"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			if shortCount == shortCountIndefinite {
 				bb := &bytes.Buffer{}
 				d.FieldArray("items", func(d *decode.D) {
@@ -144,7 +144,7 @@ func decodeCBORValue(d *decode.D) interface{} {
 
 			return buf
 		}},
-		majorTypeUTF8: {s: scalar.S{Sym: "utf8"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeUTF8: {s: scalar.S{Sym: "utf8"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			if shortCount == shortCountIndefinite {
 				sb := &strings.Builder{}
 				d.FieldArray("items", func(d *decode.D) {
@@ -167,7 +167,7 @@ func decodeCBORValue(d *decode.D) interface{} {
 
 			return d.FieldUTF8("value", int(count))
 		}},
-		majorTypeArray: {s: scalar.S{Sym: "array"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeArray: {s: scalar.S{Sym: "array"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			d.FieldArray("elements", func(d *decode.D) {
 				for i := uint64(0); true; i++ {
 					if shortCount == shortCountIndefinite && d.PeekBits(8) == breakMarker {
@@ -183,7 +183,7 @@ func decodeCBORValue(d *decode.D) interface{} {
 			}
 			return nil
 		}},
-		majorTypeMap: {s: scalar.S{Sym: "map"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeMap: {s: scalar.S{Sym: "map"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			d.FieldArray("pairs", func(d *decode.D) {
 				for i := uint64(0); true; i++ {
 					if shortCount == shortCountIndefinite && d.PeekBits(8) == breakMarker {
@@ -202,12 +202,12 @@ func decodeCBORValue(d *decode.D) interface{} {
 			}
 			return nil
 		}},
-		majorTypeSematic: {s: scalar.S{Sym: "semantic"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeSematic: {s: scalar.S{Sym: "semantic"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			d.FieldValueU("tag", count, tagMap)
 			d.FieldStruct("value", func(d *decode.D) { decodeCBORValue(d) })
 			return nil
 		}},
-		majorTypeSpecialFloat: {s: scalar.S{Sym: "special_float"}, d: func(d *decode.D, shortCount uint64, count uint64) interface{} {
+		majorTypeSpecialFloat: {s: scalar.S{Sym: "special_float"}, d: func(d *decode.D, shortCount uint64, count uint64) any {
 			switch shortCount {
 			// TODO: 0-19
 			case shortCountSpecialFalse:
@@ -262,7 +262,7 @@ func decodeCBORValue(d *decode.D) interface{} {
 	panic("unreachable")
 }
 
-func decodeCBOR(d *decode.D, in interface{}) interface{} {
+func decodeCBOR(d *decode.D, in any) any {
 	decodeCBORValue(d)
 	return nil
 }

--- a/format/dns/dns.go
+++ b/format/dns/dns.go
@@ -229,7 +229,7 @@ func dnsDecodeRR(d *decode.D, pointerOffset int64, resp bool, count uint64, name
 	})
 }
 
-func dnsDecode(d *decode.D, isTCP bool) interface{} {
+func dnsDecode(d *decode.D, isTCP bool) any {
 	pointerOffset := int64(0)
 	d.FieldStruct("header", func(d *decode.D) {
 		if isTCP {
@@ -268,7 +268,7 @@ func dnsDecode(d *decode.D, isTCP bool) interface{} {
 	return nil
 }
 
-func dnsUDPDecode(d *decode.D, in interface{}) interface{} {
+func dnsUDPDecode(d *decode.D, in any) any {
 	if upi, ok := in.(format.UDPPayloadIn); ok {
 		upi.MustIsPort(d.Fatalf, format.UDPPortDomain, format.UDPPortMDNS)
 	}

--- a/format/dns/dns_tcp.go
+++ b/format/dns/dns_tcp.go
@@ -14,7 +14,7 @@ func init() {
 	})
 }
 
-func dnsTCPDecode(d *decode.D, in interface{}) interface{} {
+func dnsTCPDecode(d *decode.D, in any) any {
 	if tsi, ok := in.(format.TCPStreamIn); ok {
 		tsi.MustIsPort(d.Fatalf, format.TCPPortDomain, format.TCPPortDomain)
 	}

--- a/format/elf/elf.go
+++ b/format/elf/elf.go
@@ -887,7 +887,7 @@ func elfDecodeSectionHeaders(d *decode.D, ec elfContext) {
 	}
 }
 
-func elfDecode(d *decode.D, in interface{}) interface{} {
+func elfDecode(d *decode.D, in any) any {
 	var ec elfContext
 
 	d.FieldStruct("header", func(d *decode.D) { elfDecodeHeader(d, &ec) })

--- a/format/flac/flac.go
+++ b/format/flac/flac.go
@@ -35,7 +35,7 @@ func init() {
 	})
 }
 
-func flacDecode(d *decode.D, in interface{}) interface{} {
+func flacDecode(d *decode.D, in any) any {
 	d.FieldUTF8("magic", 4, d.AssertStr("fLaC"))
 
 	var streamInfo format.FlacStreamInfo

--- a/format/flac/flac_frame.go
+++ b/format/flac/flac_frame.go
@@ -100,7 +100,7 @@ func utf8Uint(d *decode.D) uint64 {
 }
 
 // in argument is an optional FlacFrameIn struct with stream info
-func frameDecode(d *decode.D, in interface{}) interface{} {
+func frameDecode(d *decode.D, in any) any {
 	frameStart := d.Pos()
 	blockSize := 0
 	channelAssignment := uint64(0)

--- a/format/flac/flac_metadatablock.go
+++ b/format/flac/flac_metadatablock.go
@@ -49,7 +49,7 @@ var metadataBlockNames = scalar.UToSymStr{
 	MetadataBlockPicture:       "picture",
 }
 
-func metadatablockDecode(d *decode.D, in interface{}) interface{} {
+func metadatablockDecode(d *decode.D, in any) any {
 	var hasStreamInfo bool
 	var streamInfo format.FlacStreamInfo
 

--- a/format/flac/flac_metadatablocks.go
+++ b/format/flac/flac_metadatablocks.go
@@ -23,7 +23,7 @@ func init() {
 	})
 }
 
-func metadatablocksDecode(d *decode.D, in interface{}) interface{} {
+func metadatablocksDecode(d *decode.D, in any) any {
 	flacMetadatablocksOut := format.FlacMetadatablocksOut{}
 
 	isLastBlock := false

--- a/format/flac/flac_picture.go
+++ b/format/flac/flac_picture.go
@@ -44,8 +44,8 @@ func init() {
 	})
 }
 
-func pictureDecode(d *decode.D, in interface{}) interface{} {
-	lenStr := func(name string) string { //nolint:unparam
+func pictureDecode(d *decode.D, in any) any {
+	lenStr := func(name string) string {
 		l := d.FieldU32(name + "_length")
 		return d.FieldUTF8(name, int(l))
 	}

--- a/format/flac/flac_streaminfo.go
+++ b/format/flac/flac_streaminfo.go
@@ -15,7 +15,7 @@ func init() {
 	})
 }
 
-func streaminfoDecode(d *decode.D, in interface{}) interface{} {
+func streaminfoDecode(d *decode.D, in any) any {
 	d.FieldU16("minimum_block_size")
 	d.FieldU16("maximum_block_size")
 	d.FieldU24("minimum_frame_size")

--- a/format/flv/flv.go
+++ b/format/flv/flv.go
@@ -65,7 +65,7 @@ var typeNames = scalar.UToSymStr{
 	typeLongString:  "LongString",
 }
 
-func flvDecode(d *decode.D, in interface{}) interface{} {
+func flvDecode(d *decode.D, in any) any {
 	var fieldScriptDataObject func()
 	var fieldScriptDataVariable func(d *decode.D, name string)
 

--- a/format/format.go
+++ b/format/format.go
@@ -230,7 +230,7 @@ func (u UDPPayloadIn) IsPort(ports ...int) bool {
 	return false
 }
 
-func (u UDPPayloadIn) MustIsPort(fn func(format string, a ...interface{}), ports ...int) {
+func (u UDPPayloadIn) MustIsPort(fn func(format string, a ...any), ports ...int) {
 	if !u.IsPort(ports...) {
 		fn("incorrect udp port %t src:%d dst:%d", u.DestinationPort, u.SourcePort)
 	}
@@ -255,7 +255,7 @@ func (t TCPStreamIn) IsPort(ports ...int) bool {
 	return false
 }
 
-func (t TCPStreamIn) MustIsPort(fn func(format string, a ...interface{}), ports ...int) {
+func (t TCPStreamIn) MustIsPort(fn func(format string, a ...any), ports ...int) {
 	if !t.IsPort(ports...) {
 		fn("incorrect tcp port client %t src:%d dst:%d", t.IsClient, t.DestinationPort, t.SourcePort)
 	}

--- a/format/gif/gif.go
+++ b/format/gif/gif.go
@@ -51,7 +51,7 @@ func fieldColorMap(d *decode.D, name string, bitDepth int) {
 	})
 }
 
-func gifDecode(d *decode.D, in interface{}) interface{} {
+func gifDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldUTF8("header", 6, d.AssertStr("GIF87a", "GIF89a"))

--- a/format/gzip/gzip.go
+++ b/format/gzip/gzip.go
@@ -57,7 +57,7 @@ var deflateExtraFlagsNames = scalar.UToSymStr{
 	4: "fast",
 }
 
-func gzDecode(d *decode.D, in interface{}) interface{} {
+func gzDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldRawLen("identification", 2*8, d.AssertBitBuf([]byte("\x1f\x8b")))

--- a/format/icc/icc_profile.go
+++ b/format/icc/icc_profile.go
@@ -81,7 +81,7 @@ func decodeBCDU8(d *decode.D) uint64 {
 	return (n>>4)*10 + n&0xf
 }
 
-func iccProfileDecode(d *decode.D, in interface{}) interface{} {
+func iccProfileDecode(d *decode.D, in any) any {
 	/*
 	   0..3 Profile size uInt32Number
 	   4..7 CMM Type signature see below

--- a/format/id3/id3v1.go
+++ b/format/id3/id3v1.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 // Decode ID3v1 tag
-func id3v1Decode(d *decode.D, in interface{}) interface{} {
+func id3v1Decode(d *decode.D, in any) any {
 	d.AssertAtLeastBitsLeft(128 * 8)
 	d.FieldUTF8("magic", 3, d.AssertStr("TAG"))
 	if d.PeekBits(8) == uint64('+') {

--- a/format/id3/id3v11.go
+++ b/format/id3/id3v11.go
@@ -15,7 +15,7 @@ func init() {
 	})
 }
 
-func id3v11Decode(d *decode.D, in interface{}) interface{} {
+func id3v11Decode(d *decode.D, in any) any {
 	d.AssertAtLeastBitsLeft(128 * 8)
 	d.FieldUTF8("magic", 4, d.AssertStr("TAG+"))
 	d.FieldUTF8("title", 60)

--- a/format/id3/id3v2.go
+++ b/format/id3/id3v2.go
@@ -545,7 +545,7 @@ func decodeFrame(d *decode.D, version int) uint64 {
 		// TODO: DecodeFn
 		// TODO: unknown after frame decode
 		unsyncedBR := d.MustNewBitBufFromReader(unsyncReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), int64(dataSize)*8))})
-		d.FieldFormatBitBuf("unsync", unsyncedBR, decode.FormatFn(func(d *decode.D, in interface{}) interface{} {
+		d.FieldFormatBitBuf("unsync", unsyncedBR, decode.FormatFn(func(d *decode.D, in any) any {
 			if fn, ok := frames[idNormalized]; ok {
 				fn(d)
 			} else {
@@ -586,7 +586,7 @@ func decodeFrames(d *decode.D, version int, size uint64) {
 	}
 }
 
-func id3v2Decode(d *decode.D, in interface{}) interface{} {
+func id3v2Decode(d *decode.D, in any) any {
 	d.AssertAtLeastBitsLeft(4 * 8)
 	d.FieldUTF8("magic", 3, d.AssertStr("ID3"))
 	version := int(d.FieldU8("version"))

--- a/format/inet/bsd_loopback_frame.go
+++ b/format/inet/bsd_loopback_frame.go
@@ -38,7 +38,7 @@ var bsdLookbackNetworkLayerMap = scalar.UToScalar{
 	bsdLoopbackNetworkLayerIPv6: {Sym: "ipv6", Description: `Internet protocol v6`},
 }
 
-func decodeLoopbackFrame(d *decode.D, in interface{}) interface{} {
+func decodeLoopbackFrame(d *decode.D, in any) any {
 	if lfi, ok := in.(format.LinkFrameIn); ok {
 		if lfi.Type != format.LinkTypeNULL {
 			d.Fatalf("wrong link type %d", lfi.Type)

--- a/format/inet/ether8023_frame.go
+++ b/format/inet/ether8023_frame.go
@@ -34,7 +34,7 @@ var mapUToEtherSym = scalar.Fn(func(s scalar.S) (scalar.S, error) {
 	return s, nil
 })
 
-func decodeEthernetFrame(d *decode.D, in interface{}) interface{} {
+func decodeEthernetFrame(d *decode.D, in any) any {
 	if lfi, ok := in.(format.LinkFrameIn); ok {
 		if lfi.Type != format.LinkTypeETHERNET {
 			d.Fatalf("wrong link type %d", lfi.Type)

--- a/format/inet/icmp.go
+++ b/format/inet/icmp.go
@@ -92,7 +92,7 @@ var icmpCodeMapMap = map[uint64]scalar.UToDescription{
 	},
 }
 
-func decodeICMP(d *decode.D, in interface{}) interface{} {
+func decodeICMP(d *decode.D, in any) any {
 	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolICMP {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}

--- a/format/inet/icmpv6.go
+++ b/format/inet/icmpv6.go
@@ -77,7 +77,7 @@ var icmpv6CodeMapMap = map[uint64]scalar.UToDescription{
 	},
 }
 
-func decodeICMPv6(d *decode.D, in interface{}) interface{} {
+func decodeICMPv6(d *decode.D, in any) any {
 	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolICMPv6 {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}

--- a/format/inet/ipv4_packet.go
+++ b/format/inet/ipv4_packet.go
@@ -49,7 +49,7 @@ var mapUToIPv4Sym = scalar.Fn(func(s scalar.S) (scalar.S, error) {
 	return s, nil
 })
 
-func decodeIPv4(d *decode.D, in interface{}) interface{} {
+func decodeIPv4(d *decode.D, in any) any {
 	if ipi, ok := in.(format.InetPacketIn); ok && ipi.EtherType != format.EtherTypeIPv4 {
 		d.Fatalf("incorrect ethertype %d", ipi.EtherType)
 	}

--- a/format/inet/ipv6_packet.go
+++ b/format/inet/ipv6_packet.go
@@ -108,7 +108,7 @@ var mapUToIPv6Sym = scalar.Fn(func(s scalar.S) (scalar.S, error) {
 	return s, nil
 })
 
-func decodeIPv6(d *decode.D, in interface{}) interface{} {
+func decodeIPv6(d *decode.D, in any) any {
 	if ipi, ok := in.(format.InetPacketIn); ok && ipi.EtherType != format.EtherTypeIPv6 {
 		d.Fatalf("incorrect ethertype %d", ipi.EtherType)
 	}

--- a/format/inet/sll2_packet.go
+++ b/format/inet/sll2_packet.go
@@ -24,7 +24,7 @@ func init() {
 	})
 }
 
-func decodeSLL2(d *decode.D, in interface{}) interface{} {
+func decodeSLL2(d *decode.D, in any) any {
 	if lfi, ok := in.(format.LinkFrameIn); ok {
 		if lfi.Type != format.LinkTypeLINUX_SLL2 {
 			d.Fatalf("wrong link type %d", lfi.Type)

--- a/format/inet/sll_packet.go
+++ b/format/inet/sll_packet.go
@@ -108,7 +108,7 @@ var arpHdrTypeMAp = scalar.UToScalar{
 	0xfffe:             {Sym: "none", Description: `zero header length`},
 }
 
-func decodeSLL(d *decode.D, in interface{}) interface{} {
+func decodeSLL(d *decode.D, in any) any {
 	if lfi, ok := in.(format.LinkFrameIn); ok {
 		if lfi.Type != format.LinkTypeLINUX_SLL {
 			d.Fatalf("wrong link type %d", lfi.Type)

--- a/format/inet/tcp_segment.go
+++ b/format/inet/tcp_segment.go
@@ -33,7 +33,7 @@ var tcpOptionsMap = scalar.UToScalar{
 	8:            {Sym: "timestamp", Description: "Timestamp and echo of previous timestamp"},
 }
 
-func decodeTCP(d *decode.D, in interface{}) interface{} {
+func decodeTCP(d *decode.D, in any) any {
 	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolTCP {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}

--- a/format/inet/udp_datagram.go
+++ b/format/inet/udp_datagram.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func decodeUDP(d *decode.D, in interface{}) interface{} {
+func decodeUDP(d *decode.D, in any) any {
 	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolUDP {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}

--- a/format/jpeg/jpeg.go
+++ b/format/jpeg/jpeg.go
@@ -164,7 +164,7 @@ var markers = scalar.UToScalar{
 	TEM:   {Sym: "tem", Description: "For temporary private use in arithmetic coding"},
 }
 
-func jpegDecode(d *decode.D, in interface{}) interface{} {
+func jpegDecode(d *decode.D, in any) any {
 	d.AssertLeastBytesLeft(2)
 	if !bytes.Equal(d.PeekBytes(2), []byte{0xff, SOI}) {
 		d.Errorf("no SOI marker")

--- a/format/json/json.go
+++ b/format/json/json.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func decodeJSON(d *decode.D, in interface{}) interface{} {
+func decodeJSON(d *decode.D, in any) any {
 	br := d.RawLen(d.Len())
 	jd := stdjson.NewDecoder(bitio.NewIOReader(br))
 	var s scalar.S
@@ -33,8 +33,8 @@ func decodeJSON(d *decode.D, in interface{}) interface{} {
 		d.Fatalf(err.Error())
 	}
 	switch s.Actual.(type) {
-	case map[string]interface{},
-		[]interface{}:
+	case map[string]any,
+		[]any:
 	default:
 		d.Fatalf("root not object or array")
 	}

--- a/format/macho/macho.go
+++ b/format/macho/macho.go
@@ -355,7 +355,7 @@ var sectionTypes = scalar.UToSymStr{
 	0x15: "thread_local_init_function_pointers",
 }
 
-func machoDecode(d *decode.D, in interface{}) interface{} {
+func machoDecode(d *decode.D, in any) any {
 	ofileDecode(d)
 	return nil
 }

--- a/format/matroska/matroska.go
+++ b/format/matroska/matroska.go
@@ -129,7 +129,7 @@ type track struct {
 	codec               string
 	codecPrivatePos     int64
 	codecPrivateTagSize int64
-	formatInArg         interface{}
+	formatInArg         any
 }
 
 type block struct {
@@ -300,7 +300,7 @@ func decodeMaster(d *decode.D, bitsLimit int64, tag ebml.Tag, dc *decodeContext)
 
 }
 
-func matroskaDecode(d *decode.D, in interface{}) interface{} {
+func matroskaDecode(d *decode.D, in any) any {
 	ebmlHeaderID := uint64(0x1a45dfa3)
 	if d.PeekBits(32) != ebmlHeaderID {
 		d.Errorf("no EBML header found")

--- a/format/mp3/mp3.go
+++ b/format/mp3/mp3.go
@@ -40,7 +40,7 @@ func init() {
 	})
 }
 
-func mp3Decode(d *decode.D, in interface{}) interface{} {
+func mp3Decode(d *decode.D, in any) any {
 	mi, _ := in.(format.Mp3In)
 
 	// things in a mp3 stream usually have few unique combinations of.

--- a/format/mp3/xing.go
+++ b/format/mp3/xing.go
@@ -16,7 +16,7 @@ func init() {
 	})
 }
 
-func xingDecode(d *decode.D, in interface{}) interface{} {
+func xingDecode(d *decode.D, in any) any {
 	// TODO: info has lame extension?
 	hasLameExtension := false
 	switch d.FieldUTF8("header", 4) {

--- a/format/mp4/boxes.go
+++ b/format/mp4/boxes.go
@@ -111,7 +111,7 @@ func decodeFieldMatrix(d *decode.D, name string) {
 	})
 }
 
-func decodeBoxWithParentData(ctx *decodeContext, d *decode.D, parentData interface{}) {
+func decodeBoxWithParentData(ctx *decodeContext, d *decode.D, parentData any) {
 	var typ string
 	var dataSize uint64
 
@@ -165,7 +165,7 @@ func decodeBoxes(ctx *decodeContext, d *decode.D) {
 	decodeBoxesWithParentData(ctx, d, nil)
 }
 
-func decodeBoxesWithParentData(ctx *decodeContext, d *decode.D, parentData interface{}) {
+func decodeBoxesWithParentData(ctx *decodeContext, d *decode.D, parentData any) {
 	d.FieldStructArrayLoop("boxes", "box", func() bool { return d.BitsLeft() >= 8*8 }, func(d *decode.D) {
 		decodeBoxWithParentData(ctx, d, parentData)
 	})

--- a/format/mp4/mp4.go
+++ b/format/mp4/mp4.go
@@ -123,7 +123,7 @@ type track struct {
 	stco               []int64
 	stsc               []stsc
 	stsz               []stsz
-	formatInArg        interface{}
+	formatInArg        any
 	objectType         int // if data format is "mp4a"
 
 	moofs       []*moof // for fmp4
@@ -132,7 +132,7 @@ type track struct {
 
 type pathEntry struct {
 	typ  string
-	data interface{}
+	data any
 }
 
 type decodeContext struct {
@@ -163,7 +163,7 @@ func mp4Tracks(d *decode.D, ctx *decodeContext) {
 		d.RangeSorted = false
 
 		for _, t := range sortedTracks {
-			decodeSampleRange := func(d *decode.D, t *track, dataFormat string, name string, firstBit int64, nBits int64, inArg interface{}) {
+			decodeSampleRange := func(d *decode.D, t *track, dataFormat string, name string, firstBit int64, nBits int64, inArg any) {
 				d.RangeFn(firstBit, nBits, func(d *decode.D) {
 					if !ctx.opts.DecodeSamples {
 						d.FieldRawLen(name, d.BitsLeft())
@@ -320,7 +320,7 @@ func mp4Tracks(d *decode.D, ctx *decodeContext) {
 	})
 }
 
-func mp4Decode(d *decode.D, in interface{}) interface{} {
+func mp4Decode(d *decode.D, in any) any {
 	mi, _ := in.(format.Mp4In)
 
 	ctx := &decodeContext{

--- a/format/mp4/pssh_playready.go
+++ b/format/mp4/pssh_playready.go
@@ -25,7 +25,7 @@ var recordTypeNames = scalar.UToSymStr{
 	recordTypeLicenseStore:           "License store",
 }
 
-func playreadyPsshDecode(d *decode.D, in interface{}) interface{} {
+func playreadyPsshDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldU32("size")

--- a/format/mpeg/aac_frame.go
+++ b/format/mpeg/aac_frame.go
@@ -272,7 +272,7 @@ func aacFillElement(d *decode.D) {
 	})
 }
 
-func aacDecode(d *decode.D, in interface{}) interface{} {
+func aacDecode(d *decode.D, in any) any {
 	var objectType int
 	if afi, ok := in.(format.AACFrameIn); ok {
 		objectType = afi.ObjectType

--- a/format/mpeg/adts.go
+++ b/format/mpeg/adts.go
@@ -22,7 +22,7 @@ func init() {
 	})
 }
 
-func adtsDecoder(d *decode.D, in interface{}) interface{} {
+func adtsDecoder(d *decode.D, in any) any {
 	validFrames := 0
 	for !d.End() {
 		if dv, _, _ := d.TryFieldFormat("frame", adtsFrame, nil); dv == nil {

--- a/format/mpeg/adts_frame.go
+++ b/format/mpeg/adts_frame.go
@@ -29,7 +29,7 @@ var protectionAbsentNames = scalar.BoolToDescription{
 	false: "Has CRC",
 }
 
-func adtsFrameDecoder(d *decode.D, in interface{}) interface{} {
+func adtsFrameDecoder(d *decode.D, in any) any {
 
 	/*
 	   adts_frame() {

--- a/format/mpeg/annexb.go
+++ b/format/mpeg/annexb.go
@@ -22,7 +22,7 @@ func annexBDecodeStartCodeLen(v uint64) int64 {
 	}
 }
 
-func annexBDecode(d *decode.D, _ interface{}, format decode.Group) interface{} {
+func annexBDecode(d *decode.D, _ any, format decode.Group) any {
 	currentOffset, currentPrefixLen, err := annexBFindStartCode(d)
 	// TODO: really restrict to 0?
 	if err != nil || currentOffset != 0 {

--- a/format/mpeg/avc_annexb.go
+++ b/format/mpeg/avc_annexb.go
@@ -12,7 +12,7 @@ func init() {
 	registry.MustRegister(decode.Format{
 		Name:        format.AVC_ANNEXB,
 		Description: "H.264/AVC Annex B",
-		DecodeFn: func(d *decode.D, in interface{}) interface{} {
+		DecodeFn: func(d *decode.D, in any) any {
 			return annexBDecode(d, in, annexBAVCNALUFormat)
 		},
 		RootArray: true,

--- a/format/mpeg/avc_au.go
+++ b/format/mpeg/avc_au.go
@@ -26,7 +26,7 @@ func init() {
 	})
 }
 
-func avcAUDecode(d *decode.D, in interface{}) interface{} {
+func avcAUDecode(d *decode.D, in any) any {
 	avcIn, ok := in.(format.AvcAuIn)
 	if !ok {
 		d.Fatalf("avcIn required")

--- a/format/mpeg/avc_dcr.go
+++ b/format/mpeg/avc_dcr.go
@@ -116,7 +116,7 @@ func avcDcrParameterSet(d *decode.D, numParamSets uint64) {
 	}
 }
 
-func avcDcrDecode(d *decode.D, in interface{}) interface{} {
+func avcDcrDecode(d *decode.D, in any) any {
 	d.FieldU8("configuration_version")
 	d.FieldU8("profile_indication", avcProfileNames)
 	d.FieldU8("profile_compatibility")

--- a/format/mpeg/avc_nalu.go
+++ b/format/mpeg/avc_nalu.go
@@ -98,7 +98,7 @@ var sliceNames = scalar.UToSymStr{
 	9: "si",
 }
 
-func avcNALUDecode(d *decode.D, in interface{}) interface{} {
+func avcNALUDecode(d *decode.D, in any) any {
 	d.FieldBool("forbidden_zero_bit")
 	d.FieldU2("nal_ref_idc")
 	nalType := d.FieldU5("nal_unit_type", avcNALNames)

--- a/format/mpeg/avc_pps.go
+++ b/format/mpeg/avc_pps.go
@@ -20,7 +20,7 @@ func moreRBSPData(d *decode.D) bool {
 	return l >= 8 && d.PeekBits(8) != 0b1000_0000
 }
 
-func avcPPSDecode(d *decode.D, in interface{}) interface{} {
+func avcPPSDecode(d *decode.D, in any) any {
 	d.FieldUFn("pic_parameter_set_id", uEV)
 	d.FieldUFn("seq_parameter_set_id", uEV)
 	d.FieldBool("entropy_coding_mode_flag")

--- a/format/mpeg/avc_sei.go
+++ b/format/mpeg/avc_sei.go
@@ -101,7 +101,7 @@ func ffSum(d *decode.D) uint64 {
 	return s
 }
 
-func avcSEIDecode(d *decode.D, in interface{}) interface{} {
+func avcSEIDecode(d *decode.D, in any) any {
 	payloadType := d.FieldUFn("payload_type", func(d *decode.D) uint64 { return ffSum(d) }, seiNames)
 	payloadSize := d.FieldUFn("payload_size", func(d *decode.D) uint64 { return ffSum(d) })
 

--- a/format/mpeg/avc_sps.go
+++ b/format/mpeg/avc_sps.go
@@ -134,7 +134,7 @@ func avcHdrParameters(d *decode.D) {
 	d.FieldU5("time_offset_length")
 }
 
-func avcSPSDecode(d *decode.D, in interface{}) interface{} {
+func avcSPSDecode(d *decode.D, in any) any {
 	profileIdc := d.FieldU8("profile_idc", avcProfileNames)
 	d.FieldBool("constraint_set0_flag")
 	d.FieldBool("constraint_set1_flag")

--- a/format/mpeg/hevc_annexb.go
+++ b/format/mpeg/hevc_annexb.go
@@ -12,7 +12,7 @@ func init() {
 	registry.MustRegister(decode.Format{
 		Name:        format.HEVC_ANNEXB,
 		Description: "H.265/HEVC Annex B",
-		DecodeFn: func(d *decode.D, in interface{}) interface{} {
+		DecodeFn: func(d *decode.D, in any) any {
 			return annexBDecode(d, in, annexBHEVCNALUFormat)
 		},
 		RootArray: true,

--- a/format/mpeg/hevc_au.go
+++ b/format/mpeg/hevc_au.go
@@ -24,7 +24,7 @@ func init() {
 	})
 }
 
-func hevcAUDecode(d *decode.D, in interface{}) interface{} {
+func hevcAUDecode(d *decode.D, in any) any {
 	hevcIn, ok := in.(format.HevcAuIn)
 	if !ok {
 		d.Errorf("HevcAuIn required")

--- a/format/mpeg/hevc_dcr.go
+++ b/format/mpeg/hevc_dcr.go
@@ -20,7 +20,7 @@ func init() {
 	})
 }
 
-func hevcDcrDecode(d *decode.D, in interface{}) interface{} {
+func hevcDcrDecode(d *decode.D, in any) any {
 	d.FieldU8("configuration_version")
 	d.FieldU2("general_profile_space")
 	d.FieldU1("general_tier_flag")

--- a/format/mpeg/hevc_nalu.go
+++ b/format/mpeg/hevc_nalu.go
@@ -82,7 +82,7 @@ var hevcNALNames = scalar.UToSymStr{
 	47:            "RSV_NVCL47",
 }
 
-func hevcNALUDecode(d *decode.D, in interface{}) interface{} {
+func hevcNALUDecode(d *decode.D, in any) any {
 	d.FieldBool("forbidden_zero_bit")
 	nalType := d.FieldU6("nal_unit_type", hevcNALNames)
 	d.FieldU6("nuh_layer_id")

--- a/format/mpeg/hevc_pps.go
+++ b/format/mpeg/hevc_pps.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 // H.265 page 36
-func hevcPPSDecode(d *decode.D, in interface{}) interface{} {
+func hevcPPSDecode(d *decode.D, in any) any {
 	d.FieldUFn("pps_pic_parameter_set_id", uEV)
 	d.FieldUFn("pps_seq_parameter_set_id", uEV)
 	d.FieldBool("dependent_slice_segments_enabled_flag")

--- a/format/mpeg/hevc_sps.go
+++ b/format/mpeg/hevc_sps.go
@@ -241,7 +241,7 @@ func hevcVuiParameters(d *decode.D, spsMaxSubLayersMinus1 uint64) {
 }
 
 // H.265 page 34
-func hevcSPSDecode(d *decode.D, in interface{}) interface{} {
+func hevcSPSDecode(d *decode.D, in any) any {
 	d.FieldU4("sps_video_parameter_set_id")
 	spsMaxSubLayersMinus1 := d.FieldU3("sps_max_sub_layers_minus1")
 	d.FieldBool("sps_temporal_id_nesting_flag")

--- a/format/mpeg/hevc_vps.go
+++ b/format/mpeg/hevc_vps.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 // H.265 page 33
-func hevcVPSDecode(d *decode.D, in interface{}) interface{} {
+func hevcVPSDecode(d *decode.D, in any) any {
 	d.FieldU4("vps_video_parameter_set_id")
 	d.FieldBool("vps_base_layer_internal_flag")
 	d.FieldBool("vps_base_layer_available_flag")

--- a/format/mpeg/mp3_frame.go
+++ b/format/mpeg/mp3_frame.go
@@ -140,7 +140,7 @@ var protectionNames = scalar.BoolToDescription{
 	false: "Has CRC",
 }
 
-func frameDecode(d *decode.D, in interface{}) interface{} {
+func frameDecode(d *decode.D, in any) any {
 	const headerBytes = 4
 	var sideInfoBytes int64
 	var isStereo bool

--- a/format/mpeg/mpeg_asc.go
+++ b/format/mpeg/mpeg_asc.go
@@ -44,7 +44,7 @@ var channelConfigurationNames = scalar.UToDescription{
 	7: "front-center, front-left, front-right, side-left, side-right, back-left, back-right, LFE-channel",
 }
 
-func ascDecoder(d *decode.D, in interface{}) interface{} {
+func ascDecoder(d *decode.D, in any) any {
 	objectType := d.FieldUFn("object_type", decodeEscapeValueCarryFn(5, 6, 0), format.MPEGAudioObjectTypeNames)
 	d.FieldUFn("sampling_frequency", decodeEscapeValueAbsFn(4, 24, 0), frequencyIndexHzMap)
 	d.FieldU4("channel_configuration", channelConfigurationNames)

--- a/format/mpeg/mpeg_es.go
+++ b/format/mpeg/mpeg_es.go
@@ -161,7 +161,7 @@ func esLengthEncoding(d *decode.D) uint64 {
 	return v
 }
 
-func fieldODDecodeTag(d *decode.D, edc *esDecodeContext, name string, expectedTagID int, fn func(d *decode.D)) { //nolint:unparam
+func fieldODDecodeTag(d *decode.D, edc *esDecodeContext, name string, expectedTagID int, fn func(d *decode.D)) {
 	d.FieldStruct(name, func(d *decode.D) {
 		odDecodeTag(d, edc, expectedTagID, fn)
 	})
@@ -172,7 +172,7 @@ type esDecodeContext struct {
 	decoderConfigs       []format.MpegDecoderConfig
 }
 
-func odDecodeTag(d *decode.D, edc *esDecodeContext, expectedTagID int, fn func(d *decode.D)) { //nolint:unparam
+func odDecodeTag(d *decode.D, edc *esDecodeContext, expectedTagID int, fn func(d *decode.D)) {
 	odDecoders := map[uint64]func(d *decode.D){
 		ES_DescrTag: func(d *decode.D) {
 			d.FieldU16("es_id")
@@ -276,7 +276,7 @@ func odDecodeTag(d *decode.D, edc *esDecodeContext, expectedTagID int, fn func(d
 	}
 }
 
-func esDecode(d *decode.D, in interface{}) interface{} {
+func esDecode(d *decode.D, in any) any {
 	var edc esDecodeContext
 	odDecodeTag(d, &edc, -1, nil)
 	return format.MpegEsOut{DecoderConfigs: edc.decoderConfigs}

--- a/format/mpeg/mpeg_pes.go
+++ b/format/mpeg/mpeg_pes.go
@@ -33,7 +33,7 @@ type subStream struct {
 	l int
 }
 
-func pesDecode(d *decode.D, in interface{}) interface{} {
+func pesDecode(d *decode.D, in any) any {
 	substreams := map[int]*subStream{}
 
 	prefix := d.PeekBits(24)

--- a/format/mpeg/mpeg_pes_packet.go
+++ b/format/mpeg/mpeg_pes_packet.go
@@ -69,8 +69,8 @@ var mpegVersion = scalar.UToDescription{
 	0b10: "MPEG1",
 }
 
-func pesPacketDecode(d *decode.D, in interface{}) interface{} {
-	var v interface{}
+func pesPacketDecode(d *decode.D, in any) any {
+	var v any
 
 	d.FieldU24("prefix", d.AssertU(0b0000_0000_0000_0000_0000_0001), scalar.ActualBin)
 	startCode := d.FieldU8("start_code", startAndStreamNames, scalar.ActualHex)

--- a/format/mpeg/mpeg_spu.go
+++ b/format/mpeg/mpeg_spu.go
@@ -70,7 +70,7 @@ func rleValue(d *decode.D) (uint64, uint64, int) {
 	}
 }
 
-func decodeLines(d *decode.D, lines int, width int) []string { //nolint:unparam
+func decodeLines(d *decode.D, lines int, width int) []string {
 	var ls []string
 
 	for i := 0; i < lines; i++ {
@@ -99,7 +99,7 @@ func decodeLines(d *decode.D, lines int, width int) []string { //nolint:unparam
 	return ls
 }
 
-func spuDecode(d *decode.D, in interface{}) interface{} {
+func spuDecode(d *decode.D, in any) any {
 	d.FieldU16("size")
 	dcsqtOffset := d.FieldU16("dcsqt_offset")
 

--- a/format/mpeg/mpeg_ts.go
+++ b/format/mpeg/mpeg_ts.go
@@ -19,7 +19,7 @@ func init() {
 
 // TODO: ts_packet
 
-func tsDecode(d *decode.D, in interface{}) interface{} {
+func tsDecode(d *decode.D, in any) any {
 	d.FieldU8("sync", d.AssertU(0x47), scalar.ActualHex)
 	d.FieldBool("transport_error_indicator")
 	d.FieldBool("payload_unit_start")

--- a/format/msgpack/msgpack.go
+++ b/format/msgpack/msgpack.go
@@ -153,7 +153,7 @@ func decodeMsgPackValue(d *decode.D) {
 	}
 }
 
-func decodeMsgPack(d *decode.D, in interface{}) interface{} {
+func decodeMsgPack(d *decode.D, in any) any {
 	decodeMsgPackValue(d)
 	return nil
 }

--- a/format/ogg/ogg.go
+++ b/format/ogg/ogg.go
@@ -57,7 +57,7 @@ type stream struct {
 	flacStreamInfo format.FlacStreamInfo
 }
 
-func decodeOgg(d *decode.D, in interface{}) interface{} {
+func decodeOgg(d *decode.D, in any) any {
 	validPages := 0
 	streams := map[uint32]*stream{}
 	streamsD := d.FieldArrayValue("streams")

--- a/format/ogg/ogg_page.go
+++ b/format/ogg/ogg_page.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func pageDecode(d *decode.D, in interface{}) interface{} {
+func pageDecode(d *decode.D, in any) any {
 	p := format.OggPageOut{}
 	startPos := d.Pos()
 

--- a/format/opus/opus_packet.go
+++ b/format/opus/opus_packet.go
@@ -23,7 +23,7 @@ func init() {
 	})
 }
 
-func opusDecode(d *decode.D, in interface{}) interface{} {
+func opusDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	var prefix []byte

--- a/format/pcap/pcap.go
+++ b/format/pcap/pcap.go
@@ -39,7 +39,7 @@ func init() {
 	})
 }
 
-func decodePcap(d *decode.D, in interface{}) interface{} {
+func decodePcap(d *decode.D, in any) any {
 	endian := d.FieldU32("magic", d.AssertU(bigEndian, littleEndian), endianMap, scalar.ActualHex)
 	switch endian {
 	case bigEndian:

--- a/format/pcap/pcapng.go
+++ b/format/pcap/pcapng.go
@@ -361,7 +361,7 @@ type decodeContext struct {
 	flowDecoder        *flowsdecoder.Decoder
 }
 
-func decodePcapng(d *decode.D, in interface{}) interface{} {
+func decodePcapng(d *decode.D, in any) any {
 	sectionHeaders := 0
 	for !d.End() {
 		fd := flowsdecoder.New()

--- a/format/png/png.go
+++ b/format/png/png.go
@@ -77,7 +77,7 @@ var colorTypeMap = scalar.UToSymStr{
 	colorTypeRGBA:               "rgba",
 }
 
-func pngDecode(d *decode.D, in interface{}) interface{} {
+func pngDecode(d *decode.D, in any) any {
 	iEndFound := false
 	var colorType uint64
 
@@ -127,7 +127,7 @@ func pngDecode(d *decode.D, in interface{}) interface{} {
 
 				switch compressionMethod {
 				case compressionDeflate:
-					d.FieldFormatReaderLen("uncompressed", dataLen, zlib.NewReader, decode.FormatFn(func(d *decode.D, in interface{}) interface{} {
+					d.FieldFormatReaderLen("uncompressed", dataLen, zlib.NewReader, decode.FormatFn(func(d *decode.D, in any) any {
 						d.FieldUTF8("text", int(d.BitsLeft()/8))
 						return nil
 					}))

--- a/format/protobuf/protobuf.go
+++ b/format/protobuf/protobuf.go
@@ -141,7 +141,7 @@ func protobufDecodeFields(d *decode.D, pbm *format.ProtoBufMessage) {
 	})
 }
 
-func protobufDecode(d *decode.D, in interface{}) interface{} {
+func protobufDecode(d *decode.D, in any) any {
 	var pbm *format.ProtoBufMessage
 	pbi, ok := in.(format.ProtoBufIn)
 	if ok {

--- a/format/protobuf/protobuf_widevine.go
+++ b/format/protobuf/protobuf_widevine.go
@@ -22,7 +22,7 @@ func init() {
 	})
 }
 
-func widevineDecode(d *decode.D, in interface{}) interface{} {
+func widevineDecode(d *decode.D, in any) any {
 	widewinePb := format.ProtoBufMessage{
 		1: {Type: format.ProtoBufTypeEnum, Name: "algorithm", Enums: scalar.UToSymStr{
 			0: "unencrypted",

--- a/format/raw/raw.go
+++ b/format/raw/raw.go
@@ -10,6 +10,6 @@ func init() {
 	registry.MustRegister(decode.Format{
 		Name:        format.RAW,
 		Description: "Raw bits",
-		DecodeFn:    func(d *decode.D, in interface{}) interface{} { return nil },
+		DecodeFn:    func(d *decode.D, in any) any { return nil },
 	})
 }

--- a/format/rtmp/amf0.go
+++ b/format/rtmp/amf0.go
@@ -144,7 +144,7 @@ func amf0DecodeValue(d *decode.D) {
 	}
 }
 
-func amf0Decode(d *decode.D, in interface{}) interface{} {
+func amf0Decode(d *decode.D, in any) any {
 	amf0DecodeValue(d)
 	return nil
 }

--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -195,7 +195,7 @@ var videoMessageH264PacketTypeNames = scalar.UToSymStr{
 }
 
 // TODO: invalid warning that timestampDelta is unused
-//nolint: structcheck,unused
+//nolint: unused
 type messageHeader struct {
 	timestamp       uint64
 	timestampDelta  uint64
@@ -307,7 +307,7 @@ func rtmpDecodeMessageType(d *decode.D, typ int, chunkSize *int) {
 	}
 }
 
-func rtmpDecode(d *decode.D, in interface{}) interface{} {
+func rtmpDecode(d *decode.D, in any) any {
 	var isClient bool
 	if tsi, ok := in.(format.TCPStreamIn); ok {
 		tsi.MustIsPort(d.Fatalf, format.TCPPortRTMP)

--- a/format/tar/tar.go
+++ b/format/tar/tar.go
@@ -26,7 +26,7 @@ func init() {
 	})
 }
 
-func tarDecode(d *decode.D, in interface{}) interface{} {
+func tarDecode(d *decode.D, in any) any {
 	const blockBytes = 512
 	const blockBits = blockBytes * 8
 

--- a/format/tiff/tiff.go
+++ b/format/tiff/tiff.go
@@ -201,7 +201,7 @@ func decodeIfd(d *decode.D, s *strips, tagNames scalar.UToSymStr) int64 {
 	return nextIfdOffset
 }
 
-func tiffDecode(d *decode.D, in interface{}) interface{} {
+func tiffDecode(d *decode.D, in any) any {
 	endian := d.FieldU32("endian", endianNames, scalar.ActualHex)
 
 	switch endian {

--- a/format/vorbis/vorbis_comment.go
+++ b/format/vorbis/vorbis_comment.go
@@ -23,7 +23,7 @@ func init() {
 	})
 }
 
-func commentDecode(d *decode.D, in interface{}) interface{} {
+func commentDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	vendorLen := d.FieldU32("vendor_length")

--- a/format/vorbis/vorbis_packet.go
+++ b/format/vorbis/vorbis_packet.go
@@ -38,7 +38,7 @@ var packetTypeNames = map[uint]string{
 	packetTypeSetup:          "Setup",
 }
 
-func vorbisDecode(d *decode.D, in interface{}) interface{} {
+func vorbisDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	packetType := d.FieldUScalarFn("packet_type", func(d *decode.D) scalar.S {

--- a/format/vpx/vp8_frame.go
+++ b/format/vpx/vp8_frame.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func vp8Decode(d *decode.D, in interface{}) interface{} {
+func vp8Decode(d *decode.D, in any) any {
 	var isKeyFrame bool
 
 	versions := map[uint64]struct {

--- a/format/vpx/vp9_cfm.go
+++ b/format/vpx/vp9_cfm.go
@@ -18,7 +18,7 @@ func init() {
 	})
 }
 
-func vp9CFMDecode(d *decode.D, in interface{}) interface{} {
+func vp9CFMDecode(d *decode.D, in any) any {
 	for d.NotEnd() {
 		d.FieldStruct("feature", func(d *decode.D) {
 			id := d.FieldU8("id", vp9FeatureIDNames)

--- a/format/vpx/vp9_frame.go
+++ b/format/vpx/vp9_frame.go
@@ -107,7 +107,7 @@ func vp9DecodeFrameSize(d *decode.D) {
 	d.FieldUFn("frame_height", func(d *decode.D) uint64 { return d.U16() + 1 })
 }
 
-func vp9Decode(d *decode.D, in interface{}) interface{} {
+func vp9Decode(d *decode.D, in any) any {
 
 	// TODO: header_size at end? even for show_existing_frame?
 

--- a/format/vpx/vpx_ccr.go
+++ b/format/vpx/vpx_ccr.go
@@ -16,7 +16,7 @@ func init() {
 	})
 }
 
-func vpxCCRDecode(d *decode.D, in interface{}) interface{} {
+func vpxCCRDecode(d *decode.D, in any) any {
 	d.FieldU8("profile")
 	d.FieldU8("level", vpxLevelNames)
 	d.FieldU4("bit_depth")

--- a/format/wav/wav.go
+++ b/format/wav/wav.go
@@ -124,7 +124,7 @@ var subFormatNames = scalar.BytesToScalar{
 	{Bytes: subFormatIEEEFloat[:], Scalar: scalar.S{Sym: "ieee_float"}},
 }
 
-func decodeChunk(d *decode.D, expectedChunkID string, stringData bool) int64 { //nolint:unparam
+func decodeChunk(d *decode.D, expectedChunkID string, stringData bool) int64 {
 	d.Endian = decode.LittleEndian
 
 	chunks := map[string]func(d *decode.D){
@@ -201,7 +201,7 @@ func decodeChunks(d *decode.D, stringData bool) {
 	})
 }
 
-func wavDecode(d *decode.D, in interface{}) interface{} {
+func wavDecode(d *decode.D, in any) any {
 	// there are wav files in the wild with id3v2 header id3v1 footer
 	_, _, _ = d.TryFieldFormat("header", headerFormat, nil)
 

--- a/format/webp/webp.go
+++ b/format/webp/webp.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func decodeChunk(d *decode.D, expectedChunkID string, fn func(d *decode.D)) bool { //nolint:unparam
+func decodeChunk(d *decode.D, expectedChunkID string, fn func(d *decode.D)) bool {
 	trimChunkID := d.FieldUTF8("id", 4, scalar.ActualTrimSpace)
 	if expectedChunkID != "" && trimChunkID != expectedChunkID {
 		return false
@@ -41,7 +41,7 @@ func decodeChunk(d *decode.D, expectedChunkID string, fn func(d *decode.D)) bool
 	return true
 }
 
-func webpDecode(d *decode.D, in interface{}) interface{} {
+func webpDecode(d *decode.D, in any) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldUTF8("riff_id", 4, d.AssertStr("RIFF"))

--- a/format/zip/zip.go
+++ b/format/zip/zip.go
@@ -128,7 +128,7 @@ func fieldMSDOSDate(d *decode.D) {
 	d.FieldU5("day")
 }
 
-func zipDecode(d *decode.D, in interface{}) interface{} {
+func zipDecode(d *decode.D, in any) any {
 	// TODO: just decode instead?
 	if !bytes.Equal(d.PeekBytes(4), []byte("PK\x03\x04")) {
 		d.Errorf("expected PK header")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wader/fq
 
-go 1.17
+go 1.18
 
 require (
 	// fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch

--- a/internal/ansi/ansi.go
+++ b/internal/ansi/ansi.go
@@ -163,7 +163,7 @@ func (c Code) Wrap(s string) string {
 	return s
 }
 
-type colorFormatter [3]interface{}
+type colorFormatter [3]any
 
 func (cf colorFormatter) Format(state fmt.State, verb rune) {
 	switch verb {
@@ -177,11 +177,11 @@ func (cf colorFormatter) Format(state fmt.State, verb rune) {
 	}
 }
 
-func (c Code) F(s interface{}) fmt.Formatter {
+func (c Code) F(s any) fmt.Formatter {
 	if c.SetString != "" {
-		return colorFormatter([3]interface{}{c.SetString, s, c.ResetString})
+		return colorFormatter([3]any{c.SetString, s, c.ResetString})
 	}
-	return colorFormatter([3]interface{}{s})
+	return colorFormatter([3]any{s})
 }
 
 type colorWriter struct {

--- a/internal/colorjson/encoder.go
+++ b/internal/colorjson/encoder.go
@@ -58,11 +58,11 @@ type Encoder struct {
 	indent  int
 	depth   int
 	buf     [64]byte
-	valueFn func(v interface{}) interface{}
+	valueFn func(v any) any
 	colors  Colors
 }
 
-func NewEncoder(color bool, tab bool, indent int, valueFn func(v interface{}) interface{}, colors Colors) *Encoder {
+func NewEncoder(color bool, tab bool, indent int, valueFn func(v any) any, colors Colors) *Encoder {
 	// reuse the buffer in multiple calls of marshal
 	return &Encoder{
 		color:   color,
@@ -73,7 +73,7 @@ func NewEncoder(color bool, tab bool, indent int, valueFn func(v interface{}) in
 	}
 }
 
-func (e *Encoder) Marshal(v interface{}, w io.Writer) error {
+func (e *Encoder) Marshal(v any, w io.Writer) error {
 	e.w = bufio.NewWriter(w)
 	e.encode(v)
 	if e.wErr != nil {
@@ -82,7 +82,7 @@ func (e *Encoder) Marshal(v interface{}, w io.Writer) error {
 	return e.w.Flush()
 }
 
-func (e *Encoder) encode(v interface{}) {
+func (e *Encoder) encode(v any) {
 	switch v := v.(type) {
 	case nil:
 		e.write([]byte("null"), e.colors.Null)
@@ -100,9 +100,9 @@ func (e *Encoder) encode(v interface{}) {
 		e.write(v.Append(e.buf[:0], 10), e.colors.Number)
 	case string:
 		e.encodeString(v, e.colors.String)
-	case []interface{}:
+	case []any:
 		e.encodeArray(v)
-	case map[string]interface{}:
+	case map[string]any:
 		e.encodeMap(v)
 	default:
 		if e.valueFn != nil {
@@ -201,7 +201,7 @@ func (e *Encoder) encodeString(s string, color []byte) {
 	}
 }
 
-func (e *Encoder) encodeArray(vs []interface{}) {
+func (e *Encoder) encodeArray(vs []any) {
 	e.writeByte('[', e.colors.Array)
 	e.depth += e.indent
 	for i, v := range vs {
@@ -224,12 +224,12 @@ func (e *Encoder) encodeArray(vs []interface{}) {
 	e.writeByte(']', e.colors.Array)
 }
 
-func (e *Encoder) encodeMap(vs map[string]interface{}) {
+func (e *Encoder) encodeMap(vs map[string]any) {
 	e.writeByte('{', e.colors.Object)
 	e.depth += e.indent
 	type keyVal struct {
 		key string
-		val interface{}
+		val any
 	}
 	kvs := make([]keyVal, len(vs))
 	var i int

--- a/internal/difftest/difftest.go
+++ b/internal/difftest/difftest.go
@@ -22,15 +22,15 @@ import (
 
 type tf interface {
 	Helper()
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 }
 
 const green = "\x1b[32m"
 const red = "\x1b[31m"
 const reset = "\x1b[0m"
 
-func testDeepEqual(t tf, color bool, printfFn func(format string, args ...interface{}), expected string, actual string) {
+func testDeepEqual(t tf, color bool, printfFn func(format string, args ...any), expected string, actual string) {
 	t.Helper()
 
 	diff := difflib.UnifiedDiff{

--- a/internal/gojqextra/error.go
+++ b/internal/gojqextra/error.go
@@ -10,7 +10,7 @@ import (
 
 type UnaryTypeError struct {
 	Name string
-	V    interface{}
+	V    any
 }
 
 func (err *UnaryTypeError) Error() string {
@@ -19,7 +19,7 @@ func (err *UnaryTypeError) Error() string {
 
 type BinopTypeError struct {
 	Name string
-	L, R interface{}
+	L, R any
 }
 
 func (err *BinopTypeError) Error() string {
@@ -37,7 +37,7 @@ func (err NonUpdatableTypeError) Error() string {
 
 type FuncTypeError struct {
 	Name string
-	V    interface{}
+	V    any
 }
 
 func (err FuncTypeError) Error() string { return err.Name + " cannot be applied to: " + Typeof(err.V) }
@@ -102,7 +102,7 @@ func (err HasKeyTypeError) Error() string {
 }
 
 type ArrayIndexTooLargeError struct {
-	V interface{}
+	V any
 }
 
 func (err *ArrayIndexTooLargeError) Error() string {

--- a/internal/gojqextra/totype.go
+++ b/internal/gojqextra/totype.go
@@ -13,7 +13,7 @@ import (
 	"github.com/wader/gojq"
 )
 
-func ToString(x interface{}) (string, bool) {
+func ToString(x any) (string, bool) {
 	switch x := x.(type) {
 	case string:
 		return x, true
@@ -24,9 +24,9 @@ func ToString(x interface{}) (string, bool) {
 	}
 }
 
-func ToObject(x interface{}) (map[string]interface{}, bool) {
+func ToObject(x any) (map[string]any, bool) {
 	switch x := x.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return x, true
 	case gojq.JQValue:
 		return ToObject(x.JQValueToGoJQ())
@@ -35,9 +35,9 @@ func ToObject(x interface{}) (map[string]interface{}, bool) {
 	}
 }
 
-func ToArray(x interface{}) ([]interface{}, bool) {
+func ToArray(x any) ([]any, bool) {
 	switch x := x.(type) {
-	case []interface{}:
+	case []any:
 		return x, true
 	case gojq.JQValue:
 		return ToArray(x.JQValueToGoJQ())
@@ -46,7 +46,7 @@ func ToArray(x interface{}) ([]interface{}, bool) {
 	}
 }
 
-func ToBoolean(x interface{}) (bool, bool) {
+func ToBoolean(x any) (bool, bool) {
 	switch x := x.(type) {
 	case bool:
 		return x, true
@@ -57,7 +57,7 @@ func ToBoolean(x interface{}) (bool, bool) {
 	}
 }
 
-func IsNull(x interface{}) bool {
+func IsNull(x any) bool {
 	switch x := x.(type) {
 	case nil:
 		return true
@@ -68,7 +68,7 @@ func IsNull(x interface{}) bool {
 	}
 }
 
-func ToInt(x interface{}) (int, bool) {
+func ToInt(x any) (int, bool) {
 	switch x := x.(type) {
 	case int:
 		return x, true
@@ -102,7 +102,7 @@ func floatToInt(x float64) int {
 	return minInt
 }
 
-func ToFloat(x interface{}) (float64, bool) {
+func ToFloat(x any) (float64, bool) {
 	switch x := x.(type) {
 	case int:
 		return float64(x), true
@@ -128,7 +128,7 @@ func bigToFloat(x *big.Int) float64 {
 	return math.Inf(x.Sign())
 }
 
-func ToGoJQValue(v interface{}) (interface{}, bool) {
+func ToGoJQValue(v any) (any, bool) {
 	switch vv := v.(type) {
 	case nil:
 		return vv, true
@@ -152,8 +152,8 @@ func ToGoJQValue(v interface{}) (interface{}, bool) {
 		return string(vv), true
 	case gojq.JQValue:
 		return ToGoJQValue(vv.JQValueToGoJQ())
-	case []interface{}:
-		vvs := make([]interface{}, len(vv))
+	case []any:
+		vvs := make([]any, len(vv))
 		for i, v := range vv {
 			v, ok := ToGoJQValue(v)
 			if !ok {
@@ -162,8 +162,8 @@ func ToGoJQValue(v interface{}) (interface{}, bool) {
 			vvs[i] = v
 		}
 		return vvs, true
-	case map[string]interface{}:
-		vvs := make(map[string]interface{}, len(vv))
+	case map[string]any:
+		vvs := make(map[string]any, len(vv))
 		for k, v := range vv {
 			v, ok := ToGoJQValue(v)
 			if !ok {

--- a/internal/gojqextra/types.go
+++ b/internal/gojqextra/types.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wader/gojq"
 )
 
-func Typeof(v interface{}) string {
+func Typeof(v any) string {
 	switch v := v.(type) {
 	case nil:
 		return "null"
@@ -21,9 +21,9 @@ func Typeof(v interface{}) string {
 		return "number"
 	case string:
 		return "string"
-	case []interface{}:
+	case []any:
 		return "array"
-	case map[string]interface{}:
+	case map[string]any:
 		return "object"
 	case gojq.JQValue:
 		return v.JQValueType()
@@ -38,35 +38,35 @@ func Typeof(v interface{}) string {
 
 var _ gojq.JQValue = Array{}
 
-type Array []interface{}
+type Array []any
 
-func (v Array) JQValueLength() interface{}   { return len(v) }
-func (v Array) JQValueSliceLen() interface{} { return len(v) }
-func (v Array) JQValueIndex(index int) interface{} {
+func (v Array) JQValueLength() any   { return len(v) }
+func (v Array) JQValueSliceLen() any { return len(v) }
+func (v Array) JQValueIndex(index int) any {
 	if index < 0 {
 		return nil
 	}
 	return v[index]
 }
-func (v Array) JQValueSlice(start int, end int) interface{} { return v[start:end] }
-func (v Array) JQValueKey(name string) interface{} {
+func (v Array) JQValueSlice(start int, end int) any { return v[start:end] }
+func (v Array) JQValueKey(name string) any {
 	return ExpectedObjectError{Typ: "array"}
 }
-func (v Array) JQValueEach() interface{} {
+func (v Array) JQValueEach() any {
 	vs := make([]gojq.PathValue, len(v))
 	for i, v := range v {
 		vs[i] = gojq.PathValue{Path: i, Value: v}
 	}
 	return vs
 }
-func (v Array) JQValueKeys() interface{} {
-	vs := make([]interface{}, len(v))
+func (v Array) JQValueKeys() any {
+	vs := make([]any, len(v))
 	for i := range v {
 		vs[i] = i
 	}
 	return vs
 }
-func (v Array) JQValueHas(key interface{}) interface{} {
+func (v Array) JQValueHas(key any) any {
 	intKey, ok := key.(int)
 	if !ok {
 		return HasKeyTypeError{L: "array", R: fmt.Sprintf("%v", key)}
@@ -74,28 +74,28 @@ func (v Array) JQValueHas(key interface{}) interface{} {
 	return intKey >= 0 && intKey < len(v)
 }
 func (v Array) JQValueType() string { return "array" }
-func (v Array) JQValueToNumber() interface{} {
+func (v Array) JQValueToNumber() any {
 	return FuncTypeNameError{Name: "tonumber", Typ: "array"}
 }
-func (v Array) JQValueToString() interface{} {
+func (v Array) JQValueToString() any {
 	return FuncTypeNameError{Name: "tostring", Typ: "array"}
 }
-func (v Array) JQValueToGoJQ() interface{} { return []interface{}(v) }
+func (v Array) JQValueToGoJQ() any { return []any(v) }
 
 // object
 
 var _ gojq.JQValue = Object{}
 
-type Object map[string]interface{}
+type Object map[string]any
 
-func (v Object) JQValueLength() interface{}         { return len(v) }
-func (v Object) JQValueSliceLen() interface{}       { return ExpectedArrayError{Typ: "object"} }
-func (v Object) JQValueIndex(index int) interface{} { return ExpectedArrayError{Typ: "object"} }
-func (v Object) JQValueSlice(start int, end int) interface{} {
+func (v Object) JQValueLength() any         { return len(v) }
+func (v Object) JQValueSliceLen() any       { return ExpectedArrayError{Typ: "object"} }
+func (v Object) JQValueIndex(index int) any { return ExpectedArrayError{Typ: "object"} }
+func (v Object) JQValueSlice(start int, end int) any {
 	return ExpectedArrayError{Typ: "object"}
 }
-func (v Object) JQValueKey(name string) interface{} { return v[name] }
-func (v Object) JQValueEach() interface{} {
+func (v Object) JQValueKey(name string) any { return v[name] }
+func (v Object) JQValueEach() any {
 	vs := make([]gojq.PathValue, len(v))
 	i := 0
 	for k, v := range v {
@@ -104,8 +104,8 @@ func (v Object) JQValueEach() interface{} {
 	}
 	return vs
 }
-func (v Object) JQValueKeys() interface{} {
-	vs := make([]interface{}, len(v))
+func (v Object) JQValueKeys() any {
+	vs := make([]any, len(v))
 	i := 0
 	for k := range v {
 		vs[i] = k
@@ -113,7 +113,7 @@ func (v Object) JQValueKeys() interface{} {
 	}
 	return vs
 }
-func (v Object) JQValueHas(key interface{}) interface{} {
+func (v Object) JQValueHas(key any) any {
 	stringKey, ok := key.(string)
 	if !ok {
 		return HasKeyTypeError{L: "object", R: fmt.Sprintf("%v", key)}
@@ -122,37 +122,37 @@ func (v Object) JQValueHas(key interface{}) interface{} {
 	return ok
 }
 func (v Object) JQValueType() string { return "object" }
-func (v Object) JQValueToNumber() interface{} {
+func (v Object) JQValueToNumber() any {
 	return FuncTypeNameError{Name: "tonumber", Typ: "object"}
 }
-func (v Object) JQValueToString() interface{} {
+func (v Object) JQValueToString() any {
 	return FuncTypeNameError{Name: "tostring", Typ: "object"}
 }
-func (v Object) JQValueToGoJQ() interface{} { return map[string]interface{}(v) }
+func (v Object) JQValueToGoJQ() any { return map[string]any(v) }
 
 // number
 
 var _ gojq.JQValue = Number{}
 
 type Number struct {
-	V interface{}
+	V any
 }
 
-func (v Number) JQValueLength() interface{}         { return v.V }
-func (v Number) JQValueSliceLen() interface{}       { return ExpectedArrayError{Typ: "number"} }
-func (v Number) JQValueIndex(index int) interface{} { return ExpectedArrayError{Typ: "number"} }
-func (v Number) JQValueSlice(start int, end int) interface{} {
+func (v Number) JQValueLength() any         { return v.V }
+func (v Number) JQValueSliceLen() any       { return ExpectedArrayError{Typ: "number"} }
+func (v Number) JQValueIndex(index int) any { return ExpectedArrayError{Typ: "number"} }
+func (v Number) JQValueSlice(start int, end int) any {
 	return ExpectedArrayError{Typ: "number"}
 }
-func (v Number) JQValueKey(name string) interface{} { return ExpectedObjectError{Typ: "number"} }
-func (v Number) JQValueEach() interface{}           { return IteratorError{Typ: "number"} }
-func (v Number) JQValueKeys() interface{}           { return FuncTypeNameError{Name: "keys", Typ: "number"} }
-func (v Number) JQValueHas(key interface{}) interface{} {
+func (v Number) JQValueKey(name string) any { return ExpectedObjectError{Typ: "number"} }
+func (v Number) JQValueEach() any           { return IteratorError{Typ: "number"} }
+func (v Number) JQValueKeys() any           { return FuncTypeNameError{Name: "keys", Typ: "number"} }
+func (v Number) JQValueHas(key any) any {
 	return FuncTypeNameError{Name: "has", Typ: "number"}
 }
-func (v Number) JQValueType() string          { return "number" }
-func (v Number) JQValueToNumber() interface{} { return v.V }
-func (v Number) JQValueToString() interface{} {
+func (v Number) JQValueType() string  { return "number" }
+func (v Number) JQValueToNumber() any { return v.V }
+func (v Number) JQValueToString() any {
 	b := &bytes.Buffer{}
 	// uses colorjson encode based on gojq encoder to support big.Int
 	if err := colorjson.NewEncoder(false, false, 0, nil, colorjson.Colors{}).Marshal(v.V, b); err != nil {
@@ -160,7 +160,7 @@ func (v Number) JQValueToString() interface{} {
 	}
 	return b.String()
 }
-func (v Number) JQValueToGoJQ() interface{} { return v.V }
+func (v Number) JQValueToGoJQ() any { return v.V }
 
 // string
 
@@ -168,26 +168,26 @@ var _ gojq.JQValue = String("")
 
 type String []rune
 
-func (v String) JQValueLength() interface{}   { return len(v) }
-func (v String) JQValueSliceLen() interface{} { return len(v) }
-func (v String) JQValueIndex(index int) interface{} {
+func (v String) JQValueLength() any   { return len(v) }
+func (v String) JQValueSliceLen() any { return len(v) }
+func (v String) JQValueIndex(index int) any {
 	// -1 outside after string, -2 outside before string
 	if index < 0 {
 		return ""
 	}
 	return fmt.Sprintf("%c", v[index])
 }
-func (v String) JQValueSlice(start int, end int) interface{} { return string(v[start:end]) }
-func (v String) JQValueKey(name string) interface{}          { return ExpectedObjectError{Typ: "string"} }
-func (v String) JQValueEach() interface{}                    { return IteratorError{Typ: "string"} }
-func (v String) JQValueKeys() interface{}                    { return FuncTypeNameError{Name: "keys", Typ: "string"} }
-func (v String) JQValueHas(key interface{}) interface{} {
+func (v String) JQValueSlice(start int, end int) any { return string(v[start:end]) }
+func (v String) JQValueKey(name string) any          { return ExpectedObjectError{Typ: "string"} }
+func (v String) JQValueEach() any                    { return IteratorError{Typ: "string"} }
+func (v String) JQValueKeys() any                    { return FuncTypeNameError{Name: "keys", Typ: "string"} }
+func (v String) JQValueHas(key any) any {
 	return FuncTypeNameError{Name: "has", Typ: "string"}
 }
-func (v String) JQValueType() string          { return "string" }
-func (v String) JQValueToNumber() interface{} { return gojq.NormalizeNumbers(string(v)) }
-func (v String) JQValueToString() interface{} { return string(v) }
-func (v String) JQValueToGoJQ() interface{}   { return string(v) }
+func (v String) JQValueType() string  { return "string" }
+func (v String) JQValueToNumber() any { return gojq.NormalizeNumbers(string(v)) }
+func (v String) JQValueToString() any { return string(v) }
+func (v String) JQValueToGoJQ() any   { return string(v) }
 
 // boolean
 
@@ -195,31 +195,31 @@ var _ gojq.JQValue = Boolean(true)
 
 type Boolean bool
 
-func (v Boolean) JQValueLength() interface{} {
+func (v Boolean) JQValueLength() any {
 	return FuncTypeNameError{Name: "length", Typ: "boolean"}
 }
-func (v Boolean) JQValueSliceLen() interface{}       { return ExpectedArrayError{Typ: "boolean"} }
-func (v Boolean) JQValueIndex(index int) interface{} { return ExpectedArrayError{Typ: "boolean"} }
-func (v Boolean) JQValueSlice(start int, end int) interface{} {
+func (v Boolean) JQValueSliceLen() any       { return ExpectedArrayError{Typ: "boolean"} }
+func (v Boolean) JQValueIndex(index int) any { return ExpectedArrayError{Typ: "boolean"} }
+func (v Boolean) JQValueSlice(start int, end int) any {
 	return ExpectedArrayError{Typ: "boolean"}
 }
-func (v Boolean) JQValueKey(name string) interface{} { return ExpectedObjectError{Typ: "boolean"} }
-func (v Boolean) JQValueEach() interface{}           { return IteratorError{Typ: "boolean"} }
-func (v Boolean) JQValueKeys() interface{}           { return FuncTypeNameError{Name: "keys", Typ: "boolean"} }
-func (v Boolean) JQValueHas(key interface{}) interface{} {
+func (v Boolean) JQValueKey(name string) any { return ExpectedObjectError{Typ: "boolean"} }
+func (v Boolean) JQValueEach() any           { return IteratorError{Typ: "boolean"} }
+func (v Boolean) JQValueKeys() any           { return FuncTypeNameError{Name: "keys", Typ: "boolean"} }
+func (v Boolean) JQValueHas(key any) any {
 	return FuncTypeNameError{Name: "has", Typ: "boolean"}
 }
 func (v Boolean) JQValueType() string { return "boolean" }
-func (v Boolean) JQValueToNumber() interface{} {
+func (v Boolean) JQValueToNumber() any {
 	return FuncTypeNameError{Name: "tonumber", Typ: "boolean"}
 }
-func (v Boolean) JQValueToString() interface{} {
+func (v Boolean) JQValueToString() any {
 	if v {
 		return "true"
 	}
 	return "false"
 }
-func (v Boolean) JQValueToGoJQ() interface{} { return bool(v) }
+func (v Boolean) JQValueToGoJQ() any { return bool(v) }
 
 // null
 
@@ -227,21 +227,21 @@ var _ gojq.JQValue = Null{}
 
 type Null struct{}
 
-func (v Null) JQValueLength() interface{}                  { return 0 }
-func (v Null) JQValueSliceLen() interface{}                { return ExpectedArrayError{Typ: "null"} }
-func (v Null) JQValueIndex(index int) interface{}          { return ExpectedArrayError{Typ: "null"} }
-func (v Null) JQValueSlice(start int, end int) interface{} { return ExpectedArrayError{Typ: "null"} }
-func (v Null) JQValueKey(name string) interface{}          { return ExpectedObjectError{Typ: "null"} }
+func (v Null) JQValueLength() any                  { return 0 }
+func (v Null) JQValueSliceLen() any                { return ExpectedArrayError{Typ: "null"} }
+func (v Null) JQValueIndex(index int) any          { return ExpectedArrayError{Typ: "null"} }
+func (v Null) JQValueSlice(start int, end int) any { return ExpectedArrayError{Typ: "null"} }
+func (v Null) JQValueKey(name string) any          { return ExpectedObjectError{Typ: "null"} }
 
-func (v Null) JQValueEach() interface{} { return IteratorError{Typ: "null"} }
-func (v Null) JQValueKeys() interface{} { return FuncTypeNameError{Name: "keys", Typ: "null"} }
-func (v Null) JQValueHas(key interface{}) interface{} {
+func (v Null) JQValueEach() any { return IteratorError{Typ: "null"} }
+func (v Null) JQValueKeys() any { return FuncTypeNameError{Name: "keys", Typ: "null"} }
+func (v Null) JQValueHas(key any) any {
 	return FuncTypeNameError{Name: "has", Typ: "null"}
 }
-func (v Null) JQValueType() string          { return "null" }
-func (v Null) JQValueToNumber() interface{} { return FuncTypeNameError{Name: "tonumber", Typ: "null"} }
-func (v Null) JQValueToString() interface{} { return "null" }
-func (v Null) JQValueToGoJQ() interface{}   { return nil }
+func (v Null) JQValueType() string  { return "null" }
+func (v Null) JQValueToNumber() any { return FuncTypeNameError{Name: "tonumber", Typ: "null"} }
+func (v Null) JQValueToString() any { return "null" }
+func (v Null) JQValueToGoJQ() any   { return nil }
 
 // Base
 
@@ -251,24 +251,24 @@ type Base struct {
 	Typ string
 }
 
-func (v Base) JQValueLength() interface{}   { return ExpectedArrayError{Typ: v.Typ} }
-func (v Base) JQValueSliceLen() interface{} { return ExpectedArrayError{Typ: v.Typ} }
-func (v Base) JQValueIndex(index int) interface{} {
+func (v Base) JQValueLength() any   { return ExpectedArrayError{Typ: v.Typ} }
+func (v Base) JQValueSliceLen() any { return ExpectedArrayError{Typ: v.Typ} }
+func (v Base) JQValueIndex(index int) any {
 	return ExpectedArrayWithIndexError{Typ: v.Typ, Index: index}
 }
-func (v Base) JQValueSlice(start int, end int) interface{} { return ExpectedArrayError{Typ: v.Typ} }
-func (v Base) JQValueKey(name string) interface{} {
+func (v Base) JQValueSlice(start int, end int) any { return ExpectedArrayError{Typ: v.Typ} }
+func (v Base) JQValueKey(name string) any {
 	return ExpectedObjectWithKeyError{Typ: v.Typ, Key: name}
 }
-func (v Base) JQValueEach() interface{} { return IteratorError{Typ: v.Typ} }
-func (v Base) JQValueKeys() interface{} { return FuncTypeNameError{Name: "keys", Typ: v.Typ} }
-func (v Base) JQValueHas(key interface{}) interface{} {
+func (v Base) JQValueEach() any { return IteratorError{Typ: v.Typ} }
+func (v Base) JQValueKeys() any { return FuncTypeNameError{Name: "keys", Typ: v.Typ} }
+func (v Base) JQValueHas(key any) any {
 	return HasKeyTypeError{L: "array", R: fmt.Sprintf("%v", key)}
 }
-func (v Base) JQValueType() string          { return v.Typ }
-func (v Base) JQValueToNumber() interface{} { return FuncTypeNameError{Name: "tonumber", Typ: v.Typ} }
-func (v Base) JQValueToString() interface{} { return FuncTypeNameError{Name: "tostring", Typ: v.Typ} }
-func (v Base) JQValueToGoJQ() interface{}   { return nil }
+func (v Base) JQValueType() string  { return v.Typ }
+func (v Base) JQValueToNumber() any { return FuncTypeNameError{Name: "tonumber", Typ: v.Typ} }
+func (v Base) JQValueToString() any { return FuncTypeNameError{Name: "tostring", Typ: v.Typ} }
+func (v Base) JQValueToGoJQ() any   { return nil }
 
 // lazy
 
@@ -292,7 +292,7 @@ func (v *Lazy) v() (gojq.JQValue, error) {
 	return v.jv, v.err
 }
 
-func (v *Lazy) f(fn func(jv gojq.JQValue) interface{}) interface{} {
+func (v *Lazy) f(fn func(jv gojq.JQValue) any) any {
 	jv, err := v.v()
 	if err != nil {
 		return err
@@ -300,46 +300,46 @@ func (v *Lazy) f(fn func(jv gojq.JQValue) interface{}) interface{} {
 	return fn(jv)
 }
 
-func (v *Lazy) JQValueLength() interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueLength() })
+func (v *Lazy) JQValueLength() any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueLength() })
 }
-func (v *Lazy) JQValueSliceLen() interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueSliceLen() })
+func (v *Lazy) JQValueSliceLen() any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueSliceLen() })
 }
-func (v *Lazy) JQValueIndex(index int) interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueIndex(index) })
+func (v *Lazy) JQValueIndex(index int) any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueIndex(index) })
 }
-func (v *Lazy) JQValueSlice(start int, end int) interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueSlice(start, end) })
+func (v *Lazy) JQValueSlice(start int, end int) any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueSlice(start, end) })
 }
-func (v *Lazy) JQValueKey(name string) interface{} {
+func (v *Lazy) JQValueKey(name string) any {
 	if v.IsScalar {
 		return ExpectedObjectWithKeyError{Typ: v.Type, Key: name}
 	}
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueKey(name) })
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueKey(name) })
 }
-func (v *Lazy) JQValueEach() interface{} {
+func (v *Lazy) JQValueEach() any {
 	if v.IsScalar {
 		return IteratorError{Typ: v.Type}
 	}
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueEach() })
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueEach() })
 }
-func (v *Lazy) JQValueKeys() interface{} {
+func (v *Lazy) JQValueKeys() any {
 	if v.IsScalar {
 		return FuncTypeNameError{Name: "keys", Typ: "string"}
 	}
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueKeys() })
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueKeys() })
 }
-func (v *Lazy) JQValueHas(key interface{}) interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueHas(key) })
+func (v *Lazy) JQValueHas(key any) any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueHas(key) })
 }
 func (v *Lazy) JQValueType() string { return v.Type }
-func (v *Lazy) JQValueToNumber() interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueToNumber() })
+func (v *Lazy) JQValueToNumber() any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueToNumber() })
 }
-func (v *Lazy) JQValueToString() interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueToString() })
+func (v *Lazy) JQValueToString() any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueToString() })
 }
-func (v *Lazy) JQValueToGoJQ() interface{} {
-	return v.f(func(jv gojq.JQValue) interface{} { return jv.JQValueToGoJQ() })
+func (v *Lazy) JQValueToGoJQ() any {
+	return v.f(func(jv gojq.JQValue) any { return jv.JQValueToGoJQ() })
 }

--- a/internal/recoverfn/recoverfn.go
+++ b/internal/recoverfn/recoverfn.go
@@ -10,7 +10,7 @@ import (
 const stackSizeLimit = 256
 
 type Raw struct {
-	RecoverV  interface{}
+	RecoverV  any
 	RecoverPC uintptr
 	PCs       []uintptr
 }
@@ -22,7 +22,7 @@ func Run(fn func()) (Raw, bool) {
 	var recoverPC [1]uintptr
 	runtime.Callers(1, recoverPC[:])
 
-	pc, v := func() (pcs []uintptr, v interface{}) {
+	pc, v := func() (pcs []uintptr, v any) {
 		defer func() {
 			if recoverErr := recover(); recoverErr != nil {
 				pcs = make([]uintptr, stackSizeLimit)

--- a/pkg/decode/errors.go
+++ b/pkg/decode/errors.go
@@ -39,13 +39,13 @@ func (fe FormatError) Error() string {
 	return fe.Err.Error()
 }
 
-func (fe FormatError) Value() interface{} {
-	var st []interface{}
+func (fe FormatError) Value() any {
+	var st []any
 	for _, f := range fe.Stacktrace.Frames() {
 		st = append(st, f.Function)
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"format":     fe.Format.Name,
 		"error":      fe.Err.Error(),
 		"stacktrace": st,

--- a/pkg/decode/format.go
+++ b/pkg/decode/format.go
@@ -14,9 +14,9 @@ type Format struct {
 	ProbeOrder    int // probe order is from low to hi value then by name
 	Description   string
 	Groups        []string
-	DecodeFn      func(d *D, in interface{}) interface{}
-	DecodeInArg   interface{}
-	DecodeOutType interface{}
+	DecodeFn      func(d *D, in any) any
+	DecodeInArg   any
+	DecodeOutType any
 	RootArray     bool
 	RootName      string
 	Dependencies  []Dependency
@@ -46,7 +46,7 @@ type FormatHelp struct {
 	References []HelpReference
 }
 
-func FormatFn(d func(d *D, in interface{}) interface{}) Group {
+func FormatFn(d func(d *D, in any) any) Group {
 	return Group{{
 		DecodeFn: d,
 	}}

--- a/pkg/decode/read.go
+++ b/pkg/decode/read.go
@@ -145,7 +145,6 @@ func (d *D) tryText(nBytes int, e encoding.Encoding) (string, error) {
 // read length prefixed text (ex pascal short string)
 // lBits length prefix
 // fixedBytes if != -1 read nBytes but trim to length
-//nolint:unparam
 func (d *D) tryTextLenPrefixed(lenBits int, fixedBytes int, e encoding.Encoding) (string, error) {
 	if lenBits < 0 {
 		return "", fmt.Errorf("tryTextLenPrefixed lenBits must be >= 0 (%d)", lenBits)

--- a/pkg/decode/value.go
+++ b/pkg/decode/value.go
@@ -25,8 +25,8 @@ type Compound struct {
 type Value struct {
 	Parent     *Value
 	Name       string
-	V          interface{} // scalar.S or Compound (array/struct)
-	Index      int         // index in parent array/struct
+	V          any // scalar.S or Compound (array/struct)
+	Index      int // index in parent array/struct
 	Range      ranges.Range
 	RootReader bitio.ReaderAtSeeker
 	IsRoot     bool // TODO: rework?

--- a/pkg/interp/bitops.go
+++ b/pkg/interp/bitops.go
@@ -20,7 +20,7 @@ func init() {
 	})
 }
 
-func (i *Interp) bnot(c interface{}, a []interface{}) interface{} {
+func (i *Interp) bnot(c any, a []any) any {
 	switch c := c.(type) {
 	case int:
 		return ^c
@@ -33,77 +33,77 @@ func (i *Interp) bnot(c interface{}, a []interface{}) interface{} {
 	}
 }
 
-func (i *Interp) bsl(c interface{}, a []interface{}) interface{} {
+func (i *Interp) bsl(c any, a []any) any {
 	return gojq.BinopTypeSwitch(a[0], a[1],
-		func(l, r int) interface{} {
+		func(l, r int) any {
 			if v := l << r; v>>r == l {
 				return v
 			}
 			return new(big.Int).Lsh(big.NewInt(int64(l)), uint(r))
 		},
-		func(l, r float64) interface{} { return int(l) << int(r) },
-		func(l, r *big.Int) interface{} { return new(big.Int).Lsh(l, uint(r.Uint64())) },
-		func(l, r string) interface{} { return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r} },
-		func(l, r []interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r} },
-		func(l, r map[string]interface{}) interface{} {
+		func(l, r float64) any { return int(l) << int(r) },
+		func(l, r *big.Int) any { return new(big.Int).Lsh(l, uint(r.Uint64())) },
+		func(l, r string) any { return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r} },
+		func(l, r []any) any { return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r} },
+		func(l, r map[string]any) any {
 			return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r}
 		},
-		func(l, r interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r} },
+		func(l, r any) any { return &gojqextra.BinopTypeError{Name: "bsl", L: l, R: r} },
 	)
 }
 
-func (i *Interp) bsr(c interface{}, a []interface{}) interface{} {
+func (i *Interp) bsr(c any, a []any) any {
 	return gojq.BinopTypeSwitch(a[0], a[1],
-		func(l, r int) interface{} { return l >> r },
-		func(l, r float64) interface{} { return int(l) >> int(r) },
-		func(l, r *big.Int) interface{} { return new(big.Int).Rsh(l, uint(r.Uint64())) },
-		func(l, r string) interface{} { return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r} },
-		func(l, r []interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r} },
-		func(l, r map[string]interface{}) interface{} {
+		func(l, r int) any { return l >> r },
+		func(l, r float64) any { return int(l) >> int(r) },
+		func(l, r *big.Int) any { return new(big.Int).Rsh(l, uint(r.Uint64())) },
+		func(l, r string) any { return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r} },
+		func(l, r []any) any { return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r} },
+		func(l, r map[string]any) any {
 			return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r}
 		},
-		func(l, r interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r} },
+		func(l, r any) any { return &gojqextra.BinopTypeError{Name: "bsr", L: l, R: r} },
 	)
 }
 
-func (i *Interp) band(c interface{}, a []interface{}) interface{} {
+func (i *Interp) band(c any, a []any) any {
 	return gojq.BinopTypeSwitch(a[0], a[1],
-		func(l, r int) interface{} { return l & r },
-		func(l, r float64) interface{} { return int(l) & int(r) },
-		func(l, r *big.Int) interface{} { return new(big.Int).And(l, r) },
-		func(l, r string) interface{} { return &gojqextra.BinopTypeError{Name: "band", L: l, R: r} },
-		func(l, r []interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "band", L: l, R: r} },
-		func(l, r map[string]interface{}) interface{} {
+		func(l, r int) any { return l & r },
+		func(l, r float64) any { return int(l) & int(r) },
+		func(l, r *big.Int) any { return new(big.Int).And(l, r) },
+		func(l, r string) any { return &gojqextra.BinopTypeError{Name: "band", L: l, R: r} },
+		func(l, r []any) any { return &gojqextra.BinopTypeError{Name: "band", L: l, R: r} },
+		func(l, r map[string]any) any {
 			return &gojqextra.BinopTypeError{Name: "band", L: l, R: r}
 		},
-		func(l, r interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "band", L: l, R: r} },
+		func(l, r any) any { return &gojqextra.BinopTypeError{Name: "band", L: l, R: r} },
 	)
 }
 
-func (i *Interp) bor(c interface{}, a []interface{}) interface{} {
+func (i *Interp) bor(c any, a []any) any {
 	return gojq.BinopTypeSwitch(a[0], a[1],
-		func(l, r int) interface{} { return l | r },
-		func(l, r float64) interface{} { return int(l) | int(r) },
-		func(l, r *big.Int) interface{} { return new(big.Int).Or(l, r) },
-		func(l, r string) interface{} { return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r} },
-		func(l, r []interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r} },
-		func(l, r map[string]interface{}) interface{} {
+		func(l, r int) any { return l | r },
+		func(l, r float64) any { return int(l) | int(r) },
+		func(l, r *big.Int) any { return new(big.Int).Or(l, r) },
+		func(l, r string) any { return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r} },
+		func(l, r []any) any { return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r} },
+		func(l, r map[string]any) any {
 			return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r}
 		},
-		func(l, r interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r} },
+		func(l, r any) any { return &gojqextra.BinopTypeError{Name: "bor", L: l, R: r} },
 	)
 }
 
-func (i *Interp) bxor(c interface{}, a []interface{}) interface{} {
+func (i *Interp) bxor(c any, a []any) any {
 	return gojq.BinopTypeSwitch(a[0], a[1],
-		func(l, r int) interface{} { return l ^ r },
-		func(l, r float64) interface{} { return int(l) ^ int(r) },
-		func(l, r *big.Int) interface{} { return new(big.Int).Xor(l, r) },
-		func(l, r string) interface{} { return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r} },
-		func(l, r []interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r} },
-		func(l, r map[string]interface{}) interface{} {
+		func(l, r int) any { return l ^ r },
+		func(l, r float64) any { return int(l) ^ int(r) },
+		func(l, r *big.Int) any { return new(big.Int).Xor(l, r) },
+		func(l, r string) any { return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r} },
+		func(l, r []any) any { return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r} },
+		func(l, r map[string]any) any {
 			return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r}
 		},
-		func(l, r interface{}) interface{} { return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r} },
+		func(l, r any) any { return &gojqextra.BinopTypeError{Name: "bxor", L: l, R: r} },
 	)
 }

--- a/pkg/interp/decorator.go
+++ b/pkg/interp/decorator.go
@@ -9,7 +9,7 @@ import (
 
 var PlainDecorator = Decorator{
 	Column:     "|",
-	ValueColor: func(v interface{}) ansi.Code { return ansi.None },
+	ValueColor: func(v any) ansi.Code { return ansi.None },
 	ByteColor:  func(b byte) ansi.Code { return ansi.None },
 }
 
@@ -41,7 +41,7 @@ func decoratorFromOptions(opts Options) Decorator {
 
 		d.Error = ansi.FromString(colors["error"])
 
-		d.ValueColor = func(v interface{}) ansi.Code {
+		d.ValueColor = func(v any) ansi.Code {
 			switch vv := v.(type) {
 			case bool:
 				if vv {
@@ -76,7 +76,7 @@ func decoratorFromOptions(opts Options) Decorator {
 		}
 		d.ByteColor = func(b byte) ansi.Code { return byteColors[b] }
 	} else {
-		d.ValueColor = func(v interface{}) ansi.Code { return ansi.None }
+		d.ValueColor = func(v any) ansi.Code { return ansi.None }
 		d.ByteColor = func(b byte) ansi.Code { return ansi.None }
 	}
 
@@ -101,7 +101,7 @@ type Decorator struct {
 
 	Error ansi.Code
 
-	ValueColor func(v interface{}) ansi.Code
+	ValueColor func(v any) ansi.Code
 	ByteColor  func(b byte) ansi.Code
 
 	Column string

--- a/pkg/interp/dump.go
+++ b/pkg/interp/dump.go
@@ -58,10 +58,10 @@ func dumpEx(v *decode.Value, ctx *dumpCtx, depth int, rootV *decode.Value, rootD
 
 	// no error check as we write into buffering column
 	// we check for err later for Flush()
-	cprint := func(c int, a ...interface{}) {
+	cprint := func(c int, a ...any) {
 		fmt.Fprint(cw.Columns[c], a...)
 	}
-	cfmt := func(c int, format string, a ...interface{}) {
+	cfmt := func(c int, format string, a ...any) {
 		fmt.Fprintf(cw.Columns[c], format, a...)
 	}
 
@@ -126,7 +126,7 @@ func dumpEx(v *decode.Value, ctx *dumpCtx, depth int, rootV *decode.Value, rootD
 
 	var valueErr error
 
-	// TODO: cleanup map[string]interface{} []interface{} or json format
+	// TODO: cleanup map[string]any []any or json format
 	// dump should use some internal interface instead?
 	switch vv := v.V.(type) {
 	case *decode.Compound:
@@ -150,9 +150,9 @@ func dumpEx(v *decode.Value, ctx *dumpCtx, depth int, rootV *decode.Value, rootD
 	case *scalar.S:
 		// TODO: rethink scalar array/struct (json format)
 		switch av := vv.Actual.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			cfmt(colField, ": %s (%s)", deco.Object.F("{}"), deco.Value.F("json"))
-		case []interface{}:
+		case []any:
 			cfmt(colField, ": %s%s:%s%s (%s)", deco.Index.F("["), deco.Number.F("0"), deco.Number.F(strconv.Itoa(len(av))), deco.Index.F("]"), deco.Value.F("json"))
 		default:
 			cprint(colField, ":")

--- a/pkg/interp/funcs.go
+++ b/pkg/interp/funcs.go
@@ -61,8 +61,8 @@ func init() {
 func makeStringBinaryTransformFn(
 	decodeFn func(r io.Reader) (io.Reader, error),
 	encodeFn func(w io.Writer) (io.Writer, error),
-) func(c interface{}, a []interface{}) interface{} {
-	return func(c interface{}, a []interface{}) interface{} {
+) func(c any, a []any) any {
+	return func(c any, a []any) any {
 		switch c := c.(type) {
 		case string:
 			br, err := toBitReader(c)
@@ -111,8 +111,8 @@ func makeStringBinaryTransformFn(
 }
 
 // transform to binary using fn
-func makeBinaryTransformFn(fn func(r io.Reader) (io.Reader, error)) func(c interface{}, a []interface{}) interface{} {
-	return func(c interface{}, a []interface{}) interface{} {
+func makeBinaryTransformFn(fn func(r io.Reader) (io.Reader, error)) func(c any, a []any) any {
+	return func(c any, a []any) any {
 		inBR, err := toBitReader(c)
 		if err != nil {
 			return err
@@ -139,8 +139,8 @@ func makeBinaryTransformFn(fn func(r io.Reader) (io.Reader, error)) func(c inter
 }
 
 // transform to binary using fn
-func makeHashFn(fn func() (hash.Hash, error)) func(c interface{}, a []interface{}) interface{} {
-	return func(c interface{}, a []interface{}) interface{} {
+func makeHashFn(fn func() (hash.Hash, error)) func(c any, a []any) any {
+	return func(c any, a []any) any {
 		inBR, err := toBitReader(c)
 		if err != nil {
 			return err
@@ -164,7 +164,7 @@ func makeHashFn(fn func() (hash.Hash, error)) func(c interface{}, a []interface{
 	}
 }
 
-func (i *Interp) queryEscape(c interface{}, a []interface{}) interface{} {
+func (i *Interp) queryEscape(c any, a []any) any {
 	s, err := toString(c)
 	if err != nil {
 		return err
@@ -172,7 +172,7 @@ func (i *Interp) queryEscape(c interface{}, a []interface{}) interface{} {
 	return url.QueryEscape(s)
 }
 
-func (i *Interp) queryUnescape(c interface{}, a []interface{}) interface{} {
+func (i *Interp) queryUnescape(c any, a []any) any {
 	s, err := toString(c)
 	if err != nil {
 		return err
@@ -183,7 +183,7 @@ func (i *Interp) queryUnescape(c interface{}, a []interface{}) interface{} {
 	}
 	return u
 }
-func (i *Interp) pathEscape(c interface{}, a []interface{}) interface{} {
+func (i *Interp) pathEscape(c any, a []any) any {
 	s, err := toString(c)
 	if err != nil {
 		return err
@@ -191,7 +191,7 @@ func (i *Interp) pathEscape(c interface{}, a []interface{}) interface{} {
 	return url.PathEscape(s)
 }
 
-func (i *Interp) pathUnescape(c interface{}, a []interface{}) interface{} {
+func (i *Interp) pathUnescape(c any, a []any) any {
 	s, err := toString(c)
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ func (i *Interp) pathUnescape(c interface{}, a []interface{}) interface{} {
 	return u
 }
 
-func (i *Interp) aesCtr(c interface{}, a []interface{}) interface{} {
+func (i *Interp) aesCtr(c any, a []any) any {
 	keyBytes, err := toBytes(a[0])
 	if err != nil {
 		return err
@@ -252,7 +252,7 @@ func (i *Interp) aesCtr(c interface{}, a []interface{}) interface{} {
 	return bb
 }
 
-func (i *Interp) _hexdump(c interface{}, a []interface{}) gojq.Iter {
+func (i *Interp) _hexdump(c any, a []any) gojq.Iter {
 	opts := i.Options(a[0])
 	bv, err := toBinary(c)
 	if err != nil {

--- a/pkg/interp/match.go
+++ b/pkg/interp/match.go
@@ -20,7 +20,7 @@ func init() {
 	})
 }
 
-func (i *Interp) _binaryMatch(c interface{}, a []interface{}) gojq.Iter {
+func (i *Interp) _binaryMatch(c any, a []any) gojq.Iter {
 	var ok bool
 
 	bv, err := toBinary(c)
@@ -91,7 +91,7 @@ func (i *Interp) _binaryMatch(c interface{}, a []interface{}) gojq.Iter {
 
 	var off int64
 	prevOff := int64(-1)
-	return iterFn(func() (interface{}, bool) {
+	return iterFn(func() (any, bool) {
 		// TODO: correct way to handle empty match for binary, move one byte forward?
 		// > "asdasd" | [match(""; "g")], [(tobytes | match(""; "g"))] | length
 		// 7
@@ -114,12 +114,12 @@ func (i *Interp) _binaryMatch(c interface{}, a []interface{}) gojq.Iter {
 			return nil, false
 		}
 
-		var captures []interface{}
-		var firstCapture map[string]interface{}
+		var captures []any
+		var firstCapture map[string]any
 
 		for i := 0; i < len(l)/2; i++ {
 			start, end := l[i*2], l[i*2+1]
-			capture := map[string]interface{}{
+			capture := map[string]any{
 				"offset": int(off) + start,
 				"length": end - start,
 			}

--- a/pkg/interp/preview.go
+++ b/pkg/interp/preview.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-func previewValue(v interface{}, df scalar.DisplayFormat) string {
+func previewValue(v any, df scalar.DisplayFormat) string {
 	switch vv := v.(type) {
 	case bool:
 		if vv {

--- a/pkg/interp/query.go
+++ b/pkg/interp/query.go
@@ -15,7 +15,7 @@ func init() {
 	})
 }
 
-func (i *Interp) queryFromString(c interface{}, a []interface{}) interface{} {
+func (i *Interp) queryFromString(c any, a []any) any {
 	s, err := toString(c)
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func (i *Interp) queryFromString(c interface{}, a []interface{}) interface{} {
 	if err != nil {
 		return err
 	}
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (i *Interp) queryFromString(c interface{}, a []interface{}) interface{} {
 
 }
 
-func (i *Interp) queryToString(c interface{}, a []interface{}) interface{} {
+func (i *Interp) queryToString(c any, a []any) any {
 	b, err := json.Marshal(c)
 	if err != nil {
 		return err

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -22,7 +22,7 @@ func New() *Registry {
 	}
 }
 
-func (r *Registry) register(groupName string, format decode.Format, single bool) decode.Format { //nolint:unparam
+func (r *Registry) register(groupName string, format decode.Format, single bool) decode.Format {
 	if r.resolved {
 		// for now can't change after resolved
 		panic("registry already resolved")

--- a/pkg/scalar/scalar.go
+++ b/pkg/scalar/scalar.go
@@ -43,15 +43,15 @@ func (df DisplayFormat) FormatBase() int {
 }
 
 type S struct {
-	Actual        interface{} // nil, int, int64, uint64, float64, string, bool, []byte, *bit.Int, bitio.BitReaderAtSeeker,
+	Actual        any // nil, int, int64, uint64, float64, string, bool, []byte, *bit.Int, bitio.BitReaderAtSeeker,
 	ActualDisplay DisplayFormat
-	Sym           interface{}
+	Sym           any
 	SymDisplay    DisplayFormat
 	Description   string
 	Unknown       bool
 }
 
-func (s S) Value() interface{} {
+func (s S) Value() any {
 	if s.Sym != nil {
 		return s.Sym
 	}
@@ -78,10 +78,10 @@ var SymOct = Fn(func(s S) (S, error) { s.SymDisplay = NumberOctal; return s, nil
 var SymDec = Fn(func(s S) (S, error) { s.SymDisplay = NumberDecimal; return s, nil })
 var SymHex = Fn(func(s S) (S, error) { s.SymDisplay = NumberHex; return s, nil })
 
-func Actual(v interface{}) Mapper {
+func Actual(v any) Mapper {
 	return Fn(func(s S) (S, error) { s.Actual = v; return s, nil })
 }
-func Sym(v interface{}) Mapper {
+func Sym(v any) Mapper {
 	return Fn(func(s S) (S, error) { s.Sym = v; return s, nil })
 }
 func Description(v string) Mapper {
@@ -103,7 +103,7 @@ func ActualTrim(cutset string) ActualStrFn {
 
 var ActualTrimSpace = ActualStrFn(strings.TrimSpace)
 
-func strMapToSym(fn func(s string) (interface{}, error)) Mapper {
+func strMapToSym(fn func(s string) (any, error)) Mapper {
 	return Fn(func(s S) (S, error) {
 		ts := strings.TrimSpace(s.ActualStr())
 		if ts != "" {
@@ -118,15 +118,15 @@ func strMapToSym(fn func(s string) (interface{}, error)) Mapper {
 }
 
 func SymUParseUint(base int) Mapper {
-	return strMapToSym(func(s string) (interface{}, error) { return strconv.ParseUint(s, base, 64) })
+	return strMapToSym(func(s string) (any, error) { return strconv.ParseUint(s, base, 64) })
 }
 
 func SymSParseInt(base int) Mapper {
-	return strMapToSym(func(s string) (interface{}, error) { return strconv.ParseInt(s, base, 64) })
+	return strMapToSym(func(s string) (any, error) { return strconv.ParseInt(s, base, 64) })
 }
 
 func SymFParseFloat(base int) Mapper {
-	return strMapToSym(func(s string) (interface{}, error) { return strconv.ParseFloat(s, base) })
+	return strMapToSym(func(s string) (any, error) { return strconv.ParseFloat(s, base) })
 }
 
 type URangeEntry struct {


### PR DESCRIPTION
Rename s/interface{}/any/g
Preparation for using generics in decode API and native jq funcations etc
Remove some unused linter ignores as linter has been fixed