### PR TITLE
fqtest: Cleanup path usage

### DIFF
--- a/format/ape/testdata/apev2.fqtest
+++ b/format/ape/testdata/apev2.fqtest
@@ -1,8 +1,8 @@
 # ffmpeg -f lavfi -i sine -ac 2 -t 10ms -f mp3 test.mp3
 # mp3gain test.mp3
 # fq '.footers[0] | tobytes' test.mp3 > apev2
-$ fq -d apev2 dv /apev2
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /apev2 (apev2) 0x0-0xad.7 (174)
+$ fq -d apev2 dv apev2
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: apev2 (apev2) 0x0-0xad.7 (174)
     |                                               |                |  header{}: 0x0-0x1f.7 (32)
 0x00|41 50 45 54 41 47 45 58                        |APETAGEX        |    preamble: "APETAGEX" (valid) 0x0-0x7.7 (8)
 0x00|                        d0 07 00 00            |        ....    |    version: 2000 0x8-0xb.7 (4)

--- a/format/bson/testdata/test.fqtest
+++ b/format/bson/testdata/test.fqtest
@@ -1,7 +1,7 @@
 # https://github.com/dwight/bsontools
 # echo '{array: [1,2,3], object: {key: "value"}, number: 123, string: "abc", true: true, false: false, null: null}' | fromjson test.bson
-$ fq -d bson dv /test.bson
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.bson (bson) 0x0-0x72.7 (115)
+$ fq -d bson dv test.bson
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.bson (bson) 0x0-0x72.7 (115)
 0x00|73 00 00 00                                    |s...            |  size: 115 0x0-0x3.7 (4)
     |                                               |                |  elements[0:7]: 0x4-0x71.7 (110)
     |                                               |                |    [0]{}: element 0x4-0x24.7 (33)
@@ -61,7 +61,7 @@ $ fq -d bson dv /test.bson
 0x70|6c 00                                          |l.              |
     |                                               |                |      value: null 0x72-NA (0)
 0x70|      00|                                      |  .|            |  terminator: 0 (valid) 0x72-0x72.7 (1)
-$ fq -d bson torepr /test.bson
+$ fq -d bson torepr test.bson
 {
   "array": [
     1,

--- a/format/bzip2/testdata/test.fqtest
+++ b/format/bzip2/testdata/test.fqtest
@@ -1,6 +1,6 @@
 # echo test | bzip2 > test.bz2
-$ fq -d bzip2 dv /test.bz2
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.bz2 (bzip2) 0x0-0x2c.7 (45)
+$ fq -d bzip2 dv test.bz2
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.bz2 (bzip2) 0x0-0x2c.7 (45)
 0x00|42 5a                                          |BZ              |  magic: "BZ" (valid) 0x0-0x1.7 (2)
 0x00|      68                                       |  h             |  version: 104 0x2-0x2.7 (1)
 0x00|         39                                    |   9            |  hundred_k_blocksize: 57 0x3-0x3.7 (1)

--- a/format/dns/testdata/cern-rsp.fqtest
+++ b/format/dns/testdata/cern-rsp.fqtest
@@ -1,5 +1,5 @@
-$ fq -d dns dv /cern-rsp
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /cern-rsp (dns) 0x0-0x4f.7 (80)
+$ fq -d dns dv cern-rsp
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: cern-rsp (dns) 0x0-0x4f.7 (80)
     |                                               |                |  header{}: 0x0-0x3.7 (4)
 0x00|71 02                                          |q.              |    id: 28930 0x0-0x1.7 (2)
 0x00|      81                                       |  .             |    qr: "response" (1) 0x2-0x2 (0.1)

--- a/format/flac/testdata/frame.fqtest
+++ b/format/flac/testdata/frame.fqtest
@@ -1,7 +1,7 @@
 # test decode separate frame
 # ffmpeg -f lavfi -i sine -t 0.01s -f flac pipe:1 | fq - '.frames[0]._bytes' > frame
-$ fq -d flac_frame dv /frame
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /frame (flac_frame) 0x0-0x1ff.7 (512)
+$ fq -d flac_frame dv frame
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: frame (flac_frame) 0x0-0x1ff.7 (512)
      |                                               |                |  header{}: 0x0-0x7.7 (8)
 0x000|ff f8                                          |..              |    sync: 0b11111111111110 (valid) 0x0-0x1.5 (1.6)
 0x000|   f8                                          | .              |    reserved0: 0 (valid) 0x1.6-0x1.6 (0.1)

--- a/format/flac/testdata/mono16.fqtest
+++ b/format/flac/testdata/mono16.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /mono16.flac
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mono16.flac (flac) 0x0-0x8597.7 (34200)
+$ fq -d flac dv mono16.flac
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mono16.flac (flac) 0x0-0x8597.7 (34200)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)
       |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/flac/testdata/mono24.fqtest
+++ b/format/flac/testdata/mono24.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /mono24.flac
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mono24.flac (flac) 0x0-0xbcca.7 (48331)
+$ fq -d flac dv mono24.flac
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mono24.flac (flac) 0x0-0xbcca.7 (48331)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x209b.7 (8344)
       |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/flac/testdata/mono8.fqtest
+++ b/format/flac/testdata/mono8.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /mono8.flac
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mono8.flac (flac) 0x0-0x4cef.7 (19696)
+$ fq -d flac dv mono8.flac
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mono8.flac (flac) 0x0-0x4cef.7 (19696)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)
       |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/flac/testdata/picture_seek_gain.fqtest
+++ b/format/flac/testdata/picture_seek_gain.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /picture_seek_gain.flac
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /picture_seek_gain.flac (flac) 0x0-0x225f.7 (8800)
+$ fq -d flac dv picture_seek_gain.flac
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: picture_seek_gain.flac (flac) 0x0-0x225f.7 (8800)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:5]: (flac_metadatablocks) 0x4-0x205f.7 (8284)
       |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/flac/testdata/stereo16.fqtest
+++ b/format/flac/testdata/stereo16.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /stereo16.flac
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo16.flac (flac) 0x0-0xc54b.7 (50508)
+$ fq -d flac dv stereo16.flac
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: stereo16.flac (flac) 0x0-0xc54b.7 (50508)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)
       |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/flac/testdata/stereo24.fqtest
+++ b/format/flac/testdata/stereo24.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /stereo24.flac
-       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo24.flac (flac) 0x0-0x11bcb.7 (72652)
+$ fq -d flac dv stereo24.flac
+       |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: stereo24.flac (flac) 0x0-0x11bcb.7 (72652)
 0x00000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
        |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x209b.7 (8344)
        |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/flac/testdata/stereo8.fqtest
+++ b/format/flac/testdata/stereo8.fqtest
@@ -1,5 +1,5 @@
-$ fq -d flac dv /stereo8.flac
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo8.flac (flac) 0x0-0x6d5c.7 (27997)
+$ fq -d flac dv stereo8.flac
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: stereo8.flac (flac) 0x0-0x6d5c.7 (27997)
 0x0000|66 4c 61 43                                    |fLaC            |  magic: "fLaC" (valid) 0x0-0x3.7 (4)
       |                                               |                |  metadatablocks[0:4]: (flac_metadatablocks) 0x4-0x206f.7 (8300)
       |                                               |                |    [0]{}: metadatablock (flac_metadatablock) 0x4-0x29.7 (38)

--- a/format/gif/testdata/4x4.fqtest
+++ b/format/gif/testdata/4x4.fqtest
@@ -1,6 +1,6 @@
 # gm convert -size 4x4 'xc:#000' 'xc:#fff' 4x4.gif
-$ fq -d gif dv /4x4.gif
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.gif (gif) 0x0-0x5e.7 (95)
+$ fq -d gif dv 4x4.gif
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4.gif (gif) 0x0-0x5e.7 (95)
 0x00|47 49 46 38 39 61                              |GIF89a          |  header: "GIF89a" (valid) 0x0-0x5.7 (6)
 0x00|                  04 00                        |      ..        |  width: 4 0x6-0x7.7 (2)
 0x00|                        04 00                  |        ..      |  height: 4 0x8-0x9.7 (2)

--- a/format/gzip/testdata/test.fqtest
+++ b/format/gzip/testdata/test.fqtest
@@ -1,6 +1,6 @@
 # echo test | gzip -N > test.gz
-$ fq -d gzip dv /test.gz
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.gz (gzip) 0x0-0x18.7 (25)
+$ fq -d gzip dv test.gz
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.gz (gzip) 0x0-0x18.7 (25)
 0x00|1f 8b                                          |..              |  identification: raw bits (valid) 0x0-0x1.7 (2)
 0x00|      08                                       |  .             |  compression_method: "deflate" (8) 0x2-0x2.7 (1)
     |                                               |                |  flags{}: 0x3-0x3.7 (1)

--- a/format/icc/testdata/sRGB2014.fqtest
+++ b/format/icc/testdata/sRGB2014.fqtest
@@ -1,6 +1,6 @@
 # sRGB2014.icc is from https://www.color.org/srgbprofiles.xalter
-$ fq -d icc_profile dv /sRGB2014.icc
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /sRGB2014.icc (icc_profile) 0x0-0xbcf.7 (3024)
+$ fq -d icc_profile dv sRGB2014.icc
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: sRGB2014.icc (icc_profile) 0x0-0xbcf.7 (3024)
      |                                               |                |  header{}: 0x0-0x7f.7 (128)
 0x000|00 00 0b d0                                    |....            |    size: 3024 0x0-0x3.7 (4)
 0x000|            00 00 00 00                        |    ....        |    cmm_type_signature: "" 0x4-0x7.7 (4)

--- a/format/id3/testdata/apic.fqtest
+++ b/format/id3/testdata/apic.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -f lavfi -i anullsrc=d=10ms -f lavfi -i testsrc=s=4x4:r=1:d=1 -map 0:0 -map 1:0 -f mp3 test.mp3
 # fq test.mp3 '.. | select(format == "id3v2")._bytes' > apic
-$ fq -d id3v2 dv /apic
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /apic (id3v2) 0x0-0xb3.7 (180)
+$ fq -d id3v2 dv apic
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: apic (id3v2) 0x0-0xb3.7 (180)
 0x00|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x00|         04                                    |   .            |  version: 4 0x3-0x3.7 (1)
 0x00|            00                                 |    .           |  revision: 0 0x4-0x4.7 (1)

--- a/format/id3/testdata/id3v1.fqtest
+++ b/format/id3/testdata/id3v1.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 10ms -write_id3v1 1 -metadata title=test -f mp3 pipe:1 | fq - '.footers[0]._bytes' > id3v1
-$ fq -d id3v1 dv /id3v1
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /id3v1 (id3v1) 0x0-0x7f.7 (128)
+$ fq -d id3v1 dv id3v1
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: id3v1 (id3v1) 0x0-0x7f.7 (128)
 0x00|54 41 47                                       |TAG             |  magic: "TAG" (valid) 0x0-0x2.7 (3)
 0x00|         74 65 73 74 00 00 00 00 00 00 00 00 00|   test.........|  song_name: "test" 0x3-0x20.7 (30)
 0x10|00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00|................|

--- a/format/id3/testdata/id3v23.fqtest
+++ b/format/id3/testdata/id3v23.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 0s -id3v2_version 3 -f mp3 pipe:1 > id3v23
-$ fq -d id3v2 dv /id3v23
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /id3v23 (id3v2) 0x0-0x2c.7 (45)
+$ fq -d id3v2 dv id3v23
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: id3v23 (id3v2) 0x0-0x2c.7 (45)
 0x00|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x00|         03                                    |   .            |  version: 3 0x3-0x3.7 (1)
 0x00|            00                                 |    .           |  revision: 0 0x4-0x4.7 (1)

--- a/format/id3/testdata/id3v24.fqtest
+++ b/format/id3/testdata/id3v24.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 0s -id3v2_version 4 -f mp3 pipe:1 > id3v24
-$ fq -d id3v2 dv /id3v24
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /id3v24 (id3v2) 0x0-0x2c.7 (45)
+$ fq -d id3v2 dv id3v24
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: id3v24 (id3v2) 0x0-0x2c.7 (45)
 0x00|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x00|         04                                    |   .            |  version: 4 0x3-0x3.7 (1)
 0x00|            00                                 |    .           |  revision: 0 0x4-0x4.7 (1)

--- a/format/id3/testdata/utf16-apic.fqtest
+++ b/format/id3/testdata/utf16-apic.fqtest
@@ -2,8 +2,8 @@
 # convert -size 4x4 "xc:#000" 4x4.png
 # eyeD3 --encoding=utf16 --add-image=4x4.png:OTHER:test test.mp3
 # fq test.mp3 .headers[0]._bits > utf16-apic
-$ fq -d id3v2 dv /utf16-apic
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /utf16-apic (id3v2) 0x0-0x255.7 (598)
+$ fq -d id3v2 dv utf16-apic
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: utf16-apic (id3v2) 0x0-0x255.7 (598)
 0x000|49 44 33                                       |ID3             |  magic: "ID3" (valid) 0x0-0x2.7 (3)
 0x000|         04                                    |   .            |  version: 4 0x3-0x3.7 (1)
 0x000|            00                                 |    .           |  revision: 0 0x4-0x4.7 (1)

--- a/format/inet/testdata/ether8023_frame.fqtest
+++ b/format/inet/testdata/ether8023_frame.fqtest
@@ -1,6 +1,6 @@
 # fq 'first(.. | select(format=="ether8023")) | tobytes' many_interfaces.pcapng > ether8023_frame
-$ fq -d ether8023_frame dv /ether8023_frame
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /ether8023_frame (ether8023_frame) 0x0-0xb1.7 (178)
+$ fq -d ether8023_frame dv ether8023_frame
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: ether8023_frame (ether8023_frame) 0x0-0xb1.7 (178)
 0x00|ff ff ff ff ff ff                              |......          |  destination: "ff:ff:ff:ff:ff:ff" (0xffffffffffff) 0x0-0x5.7 (6)
 0x00|                  a4 5e 60 f1 7d 93            |      .^`.}.    |  source: "a4:5e:60:f1:7d:93" (0xa45e60f17d93) 0x6-0xb.7 (6)
 0x00|                                    08 00      |            ..  |  ether_type: "ipv4" (0x800) (Internet Protocol version 4) 0xc-0xd.7 (2)

--- a/format/inet/testdata/ipv4_packet.fqtest
+++ b/format/inet/testdata/ipv4_packet.fqtest
@@ -1,6 +1,6 @@
 # fq 'first(.. | select(format=="ipv4")) | tobytes' many_interfaces.pcapng > ipv4_packet
-$ fq -d ipv4_packet dv /ipv4_packet
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /ipv4_packet (ipv4_packet) 0x0-0x3e3.7 (996)
+$ fq -d ipv4_packet dv ipv4_packet
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: ipv4_packet (ipv4_packet) 0x0-0x3e3.7 (996)
 0x000|45                                             |E               |  version: 4 0x0-0x0.3 (0.4)
 0x000|45                                             |E               |  ihl: 5 0x0.4-0x0.7 (0.4)
 0x000|   00                                          | .              |  dscp: 0 0x1-0x1.5 (0.6)

--- a/format/inet/testdata/tcp_segment.fqtest
+++ b/format/inet/testdata/tcp_segment.fqtest
@@ -1,6 +1,6 @@
 # fq 'first(.. | select(format=="tcp")) | tobytes' many_interfaces.pcapng > tcp_segment
-$ fq -d tcp_segment dv /tcp_segment
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /tcp_segment (tcp_segment) 0x0-0x2b.7 (44)
+$ fq -d tcp_segment dv tcp_segment
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: tcp_segment (tcp_segment) 0x0-0x2b.7 (44)
 0x00|c7 25                                          |.%              |  source_port: 50981 0x0-0x1.7 (2)
 0x00|      01 bb                                    |  ..            |  destination_port: "https" (443) (http protocol over TLS/SSL) 0x2-0x3.7 (2)
 0x00|            2b ce 2e 8a                        |    +...        |  sequence_number: 734932618 0x4-0x7.7 (4)

--- a/format/inet/testdata/udp_datagram.fqtest
+++ b/format/inet/testdata/udp_datagram.fqtest
@@ -1,6 +1,6 @@
 # fq 'first(.. | select(format=="udp")) | tobytes' many_interfaces.pcapng > udp_datagram
-$ fq -d udp_datagram dv /udp_datagram
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /udp_datagram (udp_datagram) 0x0-0x8f.7 (144)
+$ fq -d udp_datagram dv udp_datagram
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: udp_datagram (udp_datagram) 0x0-0x8f.7 (144)
 0x00|44 5c                                          |D\              |  source_port: 17500 0x0-0x1.7 (2)
 0x00|      44 5c                                    |  D\            |  destination_port: 17500 0x2-0x3.7 (2)
 0x00|            00 90                              |    ..          |  length: 144 0x4-0x5.7 (2)

--- a/format/jpeg/testdata/4x4.fqtest
+++ b/format/jpeg/testdata/4x4.fqtest
@@ -1,6 +1,6 @@
 # gm convert -size 4x4 'xc:#000' 4x4.jpg
-$ fq -d jpeg dv /4x4.jpg
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.jpg (jpeg) 0x0-0x9f.7 (160)
+$ fq -d jpeg dv 4x4.jpg
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4.jpg (jpeg) 0x0-0x9f.7 (160)
     |                                               |                |  segments[0:9]: 0x0-0x9f.7 (160)
     |                                               |                |    [0]{}: marker 0x0-0x1.7 (2)
 0x00|ff                                             |.               |      prefix: raw bits (valid) 0x0-0x0.7 (1)

--- a/format/json/testdata/json.fqtest
+++ b/format/json/testdata/json.fqtest
@@ -1,8 +1,8 @@
-$ fq -d json . /test.json
+$ fq -d json . test.json
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|7b 0a 20 20 20 20 22 61 22 3a 20 31 32 33 2c 0a|{.    "a": 123,.|.: {} (json)
 *   |until 0x74.7 (end) (117)                       |                |
-$ fq -d json tovalue /test.json
+$ fq -d json tovalue test.json
 {
   "a": 123,
   "b": [
@@ -14,14 +14,14 @@ $ fq -d json tovalue /test.json
   "d": null,
   "e": 123.4
 }
-$ fq . /test.json
+$ fq . test.json
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|7b 0a 20 20 20 20 22 61 22 3a 20 31 32 33 2c 0a|{.    "a": 123,.|.: {} (json)
 *   |until 0x74.7 (end) (117)                       |                |
-$ fq .b[1] /test.json
+$ fq .b[1] test.json
 2
-$ fq . /json.gz
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /json.gz (gzip)
+$ fq . json.gz
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: json.gz (gzip)
 0x00|1f 8b                                          |..              |  identification: raw bits (valid)
 0x00|      08                                       |  .             |  compression_method: "deflate" (8)
 0x00|         00                                    |   .            |  flags{}:
@@ -33,7 +33,7 @@ $ fq . /json.gz
 0x10|30 34 32 ae e5 02 00                           |042....         |
 0x10|                     20 ac d2 9c               |        ...     |  crc32: 0x9cd2ac20 (valid)
 0x10|                                 0b 00 00 00|  |           ....||  isize: 11
-$ fq tovalue /json.gz
+$ fq tovalue json.gz
 {
   "compressed": "<13>q1ZKVLJSMDQyruUCAA==",
   "compression_method": "deflate",
@@ -55,6 +55,6 @@ $ fq tovalue /json.gz
     "a": 123
   }
 }
-$ fq .uncompressed /json.gz
+$ fq .uncompressed json.gz
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|7b 22 61 22 3a 20 31 32 33 7d 0a|              |{"a": 123}.|    |.uncompressed: {} (json)

--- a/format/matroska/testdata/aac.fqtest
+++ b/format/matroska/testdata/aac.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -c:a aac -f matroska -t 50ms aac.mkv
-$ fq -d matroska dv /aac.mkv
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /aac.mkv (matroska) 0x0-0x4c3.7 (1220)
+$ fq -d matroska dv aac.mkv
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: aac.mkv (matroska) 0x0-0x4c3.7 (1220)
      |                                               |                |  elements[0:2]: 0x0-0x4c3.7 (1220)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/av1.fqtest
+++ b/format/matroska/testdata/av1.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -g 1 -c:v librav1e -t 50ms av1.mkv
-$ fq -d matroska dv /av1.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /av1.mkv (matroska) 0x0-0x13e6.7 (5095)
+$ fq -d matroska dv av1.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: av1.mkv (matroska) 0x0-0x13e6.7 (5095)
       |                                               |                |  elements[0:2]: 0x0-0x13e6.7 (5095)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/avc.fqtest
+++ b/format/matroska/testdata/avc.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v h264 -f matroska -t 50ms avc.mkv
-$ fq -d matroska dv /avc.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /avc.mkv (matroska) 0x0-0xd46.7 (3399)
+$ fq -d matroska dv avc.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: avc.mkv (matroska) 0x0-0xd46.7 (3399)
       |                                               |                |  elements[0:2]: 0x0-0xd46.7 (3399)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/flac.fqtest
+++ b/format/matroska/testdata/flac.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -ac 2 -c:a flac -strict experimental -f matroska -t 50ms flac.mkv
-$ fq -d matroska dv /flac.mkv
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /flac.mkv (matroska) 0x0-0x4ce.7 (1231)
+$ fq -d matroska dv flac.mkv
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: flac.mkv (matroska) 0x0-0x4ce.7 (1231)
      |                                               |                |  elements[0:2]: 0x0-0x4ce.7 (1231)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/hevc.fqtest
+++ b/format/matroska/testdata/hevc.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v hevc -f matroska -t 50ms hevc.mkv
-$ fq -d matroska dv /hevc.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /hevc.mkv (matroska) 0x0-0x13ea.7 (5099)
+$ fq -d matroska dv hevc.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: hevc.mkv (matroska) 0x0-0x13ea.7 (5099)
       |                                               |                |  elements[0:2]: 0x0-0x13ea.7 (5099)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/mp3.fqtest
+++ b/format/matroska/testdata/mp3.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -c:a mp3 -f matroska -t 50ms mp3.mkv
-$ fq -d matroska dv /mp3.mkv
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3.mkv (matroska) 0x0-0x4db.7 (1244)
+$ fq -d matroska dv mp3.mkv
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mp3.mkv (matroska) 0x0-0x4db.7 (1244)
      |                                               |                |  elements[0:2]: 0x0-0x4db.7 (1244)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/mpeg2.fqtest
+++ b/format/matroska/testdata/mpeg2.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v mpeg2video -f matroska -t 50ms mpeg2.mkv
-$ fq -d matroska dv /mpeg2.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mpeg2.mkv (matroska) 0x0-0x21c9.7 (8650)
+$ fq -d matroska dv mpeg2.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mpeg2.mkv (matroska) 0x0-0x21c9.7 (8650)
       |                                               |                |  elements[0:2]: 0x0-0x21c9.7 (8650)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/opus.fqtest
+++ b/format/matroska/testdata/opus.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -strict experimental -c:a opus -f matroska -t 50ms opus.mkv
-$ fq -d matroska dv /opus.mkv
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus.mkv (matroska) 0x0-0x3ec.7 (1005)
+$ fq -d matroska dv opus.mkv
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: opus.mkv (matroska) 0x0-0x3ec.7 (1005)
      |                                               |                |  elements[0:2]: 0x0-0x3ec.7 (1005)
      |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/path.fqtest
+++ b/format/matroska/testdata/path.fqtest
@@ -1,15 +1,15 @@
-$ fq -d matroska 'matroska_path(".Segment.Tracks[0].TrackEntry[0].CodecID")' /avc.mkv
+$ fq -d matroska 'matroska_path(".Segment.Tracks[0].TrackEntry[0].CodecID")' avc.mkv
 exitcode: 5
 stderr:
-error: /avc.mkv: cannot iterate over: null
-$ fq -d matroska 'matroska_path(".Segment.Tracks[0].TrackEntry[0].CodecID") | matroska_path' /avc.mkv
+error: avc.mkv: cannot iterate over: null
+$ fq -d matroska 'matroska_path(".Segment.Tracks[0].TrackEntry[0].CodecID") | matroska_path' avc.mkv
 exitcode: 5
 stderr:
-error: /avc.mkv: cannot iterate over: null
-$ fq -d matroska 'matroska_path(matroska_path(".Segment.Tracks[0].TrackEntry[0].CodecID"))' /avc.mkv
+error: avc.mkv: cannot iterate over: null
+$ fq -d matroska 'matroska_path(matroska_path(".Segment.Tracks[0].TrackEntry[0].CodecID"))' avc.mkv
 exitcode: 5
 stderr:
-error: /avc.mkv: cannot iterate over: null
+error: avc.mkv: cannot iterate over: null
 $ fq -n '"a" | raw | matroska_path(".Segment")'
 exitcode: 5
 stderr:

--- a/format/matroska/testdata/vorbis.fqtest
+++ b/format/matroska/testdata/vorbis.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -ac 2 -strict experimental -c:a vorbis -f matroska -t 50ms vorbis.mkv
-$ fq -d matroska dv /vorbis.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis.mkv (matroska) 0x0-0x10fa.7 (4347)
+$ fq -d matroska dv vorbis.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis.mkv (matroska) 0x0-0x10fa.7 (4347)
       |                                               |                |  elements[0:2]: 0x0-0x10fa.7 (4347)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/vp8.fqtest
+++ b/format/matroska/testdata/vp8.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v vp8 -f matroska -t 50ms vp8.mkv
-$ fq -d matroska dv /vp8.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vp8.mkv (matroska) 0x0-0x148b.7 (5260)
+$ fq -d matroska dv vp8.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vp8.mkv (matroska) 0x0-0x148b.7 (5260)
       |                                               |                |  elements[0:2]: 0x0-0x148b.7 (5260)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/matroska/testdata/vp9.fqtest
+++ b/format/matroska/testdata/vp9.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v vp9 -f matroska -t 50ms vp9.mkv
-$ fq -d matroska dv /vp9.mkv
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vp9.mkv (matroska) 0x0-0x1785.7 (6022)
+$ fq -d matroska dv vp9.mkv
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vp9.mkv (matroska) 0x0-0x1785.7 (6022)
       |                                               |                |  elements[0:2]: 0x0-0x1785.7 (6022)
       |                                               |                |    [0]{}: element 0x0-0x27.7 (40)
 0x0000|1a 45 df a3                                    |.E..            |      id: "ebml" (0x1a45dfa3) 0x0-0x3.7 (4)

--- a/format/mp3/testdata/header-zeros-frames.fqtest
+++ b/format/mp3/testdata/header-zeros-frames.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f mp3 pipe:1 | fq - '.headers._bytes, ("\x00\x00\x00" | tobytes), .frames[0]._bytes' > header-zeros-frames.mp3
-$ fq -d mp3 dv /header-zeros-frames.mp3
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /header-zeros-frames.mp3 (mp3) 0x0-0xff.7 (256)
+$ fq -d mp3 dv header-zeros-frames.mp3
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: header-zeros-frames.mp3 (mp3) 0x0-0xff.7 (256)
      |                                               |                |  headers[0:1]: 0x0-0x2c.7 (45)
      |                                               |                |    [0]{}: header (id3v2) 0x0-0x2c.7 (45)
 0x000|49 44 33                                       |ID3             |      magic: "ID3" (valid) 0x0-0x2.7 (3)

--- a/format/mp3/testdata/headerfooter.fqtest
+++ b/format/mp3/testdata/headerfooter.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 1ms -write_xing 0 -write_id3v2 4 -write_id3v1 1 -metadata title=test -f mp3 headerfooter.mp3
-$ fq -d mp3 dv /headerfooter.mp3
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /headerfooter.mp3 (mp3) 0x0-0x25d.7 (606)
+$ fq -d mp3 dv headerfooter.mp3
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: headerfooter.mp3 (mp3) 0x0-0x25d.7 (606)
      |                                               |                |  headers[0:1]: 0x0-0x3c.7 (61)
      |                                               |                |    [0]{}: header (id3v2) 0x0-0x3c.7 (61)
 0x000|49 44 33                                       |ID3             |      magic: "ID3" (valid) 0x0-0x2.7 (3)

--- a/format/mp3/testdata/test.fqtest
+++ b/format/mp3/testdata/test.fqtest
@@ -1,10 +1,10 @@
 # ffmpeg -f lavfi -i sine -ac 2 -t 10ms -metadata title=test -write_xing 1 -write_id3v1 1 -f mp3 test.mp3
-$ fq -d mp3 '.headers[0].magic | verbose' /test.mp3
+$ fq -d mp3 '.headers[0].magic | verbose' test.mp3
 exitcode: 3
 stderr:
 error: arg: function not defined: verbose/0
-$ fq -d mp3 dv /test.mp3
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3) 0x0-0x4cf.7 (1232)
+$ fq -d mp3 dv test.mp3
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3) 0x0-0x4cf.7 (1232)
      |                                               |                |  headers[0:1]: 0x0-0x3c.7 (61)
      |                                               |                |    [0]{}: header (id3v2) 0x0-0x3c.7 (61)
 0x000|49 44 33                                       |ID3             |      magic: "ID3" (valid) 0x0-0x2.7 (3)

--- a/format/mp3/testdata/unknown.fqtest
+++ b/format/mp3/testdata/unknown.fqtest
@@ -1,6 +1,6 @@
 # fq '"aaaa", .frames[0], "bbbb", .frames[0], "ccccc" | tobytes' test.mp3 > unknown.mp3
-$ fq -d mp3 . /unknown.mp3
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /unknown.mp3 (mp3)
+$ fq -d mp3 . unknown.mp3
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: unknown.mp3 (mp3)
      |                                               |                |  headers[0:0]:
 0x000|61 61 61 61                                    |aaaa            |  unknown0: raw bits
 0x000|            ff fb 90 64 00 00 02 6b 0b ce 9d 60|    ...d...k...`|  frames[0:2]:

--- a/format/mp3/testdata/xing.fqtest
+++ b/format/mp3/testdata/xing.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i sine -ac 2 -t 10ms -f mp3 temp.mp3 && fq temp.mp3 '.frame[0].xing | tobits' > xing
-$ fq -d xing dv /xing
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /xing (xing) 0x0-0x9b.7 (156)
+$ fq -d xing dv xing
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: xing (xing) 0x0-0x9b.7 (156)
 0x00|49 6e 66 6f                                    |Info            |  header: "Info" 0x0-0x3.7 (4)
     |                                               |                |  present_flags{}: 0x4-0x7.7 (4)
 0x00|            00 00 00 0f                        |    ....        |    unused: 0 0x4-0x7.3 (3.4)

--- a/format/mp4/testdata/aac.fqtest
+++ b/format/mp4/testdata/aac.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -c:a aac -f mp4 -t 50ms aac.mp4
-$ fq -d mp4 dv /aac.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /aac.mp4 (mp4) 0x0-0x59c.7 (1437)
+$ fq -d mp4 dv aac.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: aac.mp4 (mp4) 0x0-0x59c.7 (1437)
      |                                               |                |  boxes[0:4]: 0x0-0x59c.7 (1437)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/av1.fqtest
+++ b/format/mp4/testdata/av1.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -v trace -f lavfi -i testsrc -c:v librav1e -t 50ms av1.mp4
-$ fq -d mp4 dv /av1.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /av1.mp4 (mp4) 0x0-0x14b1.7 (5298)
+$ fq -d mp4 dv av1.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: av1.mp4 (mp4) 0x0-0x14b1.7 (5298)
       |                                               |                |  boxes[0:4]: 0x0-0x14b1.7 (5298)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x0000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/avc.fqtest
+++ b/format/mp4/testdata/avc.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v h264 -f mp4 -t 100ms avc.mp4
-$ fq -d mp4 dv /avc.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /avc.mp4 (mp4) 0x0-0x10df.7 (4320)
+$ fq -d mp4 dv avc.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: avc.mp4 (mp4) 0x0-0x10df.7 (4320)
       |                                               |                |  boxes[0:4]: 0x0-0x10df.7 (4320)
       |                                               |                |    [0]{}: box 0x0-0x1f.7 (32)
 0x0000|00 00 00 20                                    |...             |      size: 32 0x0-0x3.7 (4)

--- a/format/mp4/testdata/dash.fqtest
+++ b/format/mp4/testdata/dash.fqtest
@@ -1,8 +1,8 @@
 # ffmpeg -f lavfi -i sine -f lavfi -i testsrc -g 1 -c:a aac -c:v h264 -f mp4 -t 100ms dash_in.mp4
 # packager 'in=dash_in.mp4,stream=audio,init_segment=dash_audio_init.mp4,segment_template=dash_audio_$Number$.m4s
 # packager 'in=dash_in.mp4,stream=video,init_segment=dash_video_init.mp4,segment_template=dash_video_$Number$.m4s'
-$ fq -d mp4 dv /dash_audio_init.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_audio_init.mp4 (mp4) 0x0-0x32f.7 (816)
+$ fq -d mp4 dv dash_audio_init.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: dash_audio_init.mp4 (mp4) 0x0-0x32f.7 (816)
      |                                               |                |  boxes[0:2]: 0x0-0x32f.7 (816)
      |                                               |                |    [0]{}: box 0x0-0x1f.7 (32)
 0x000|00 00 00 20                                    |...             |      size: 32 0x0-0x3.7 (4)
@@ -350,8 +350,8 @@ $ fq -d mp4 dv /dash_audio_init.mp4
      |                                               |                |      id: 1 0x330-NA (0)
      |                                               |                |      data_foramt: "mp4a" 0x330-NA (0)
      |                                               |                |      samples[0:0]: 0x330-NA (0)
-$ fq -d mp4 dv /dash_audio_1.m4s
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_audio_1.m4s (mp4) 0x0-0x4eb.7 (1260)
+$ fq -d mp4 dv dash_audio_1.m4s
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: dash_audio_1.m4s (mp4) 0x0-0x4eb.7 (1260)
      |                                               |                |  boxes[0:4]: 0x0-0x4eb.7 (1260)
      |                                               |                |    [0]{}: box 0x0-0x1f.7 (32)
 0x000|00 00 00 20                                    |...             |      size: 32 0x0-0x3.7 (4)
@@ -492,8 +492,8 @@ $ fq -d mp4 dv /dash_audio_1.m4s
 0x4e0|                     01 18 81 b4 70|           |       ....p|   |        [5]: raw bits sample 0x4e7-0x4eb.7 (5)
      |                                               |                |      id: 1 0x4ec-NA (0)
      |                                               |                |      data_foramt: "unknown" 0x4ec-NA (0)
-$ fq -d mp4 dv /dash_video_init.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_video_init.mp4 (mp4) 0x0-0x332.7 (819)
+$ fq -d mp4 dv dash_video_init.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: dash_video_init.mp4 (mp4) 0x0-0x332.7 (819)
      |                                               |                |  boxes[0:2]: 0x0-0x332.7 (819)
      |                                               |                |    [0]{}: box 0x0-0x23.7 (36)
 0x000|00 00 00 24                                    |...$            |      size: 36 0x0-0x3.7 (4)
@@ -888,8 +888,8 @@ $ fq -d mp4 dv /dash_video_init.mp4
      |                                               |                |      id: 1 0x333-NA (0)
      |                                               |                |      data_foramt: "avc1" 0x333-NA (0)
      |                                               |                |      samples[0:0]: 0x333-NA (0)
-$ fq -d mp4 dv /dash_video_1.m4s
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /dash_video_1.m4s (mp4) 0x0-0x1fd0.7 (8145)
+$ fq -d mp4 dv dash_video_1.m4s
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: dash_video_1.m4s (mp4) 0x0-0x1fd0.7 (8145)
       |                                               |                |  boxes[0:4]: 0x0-0x1fd0.7 (8145)
       |                                               |                |    [0]{}: box 0x0-0x23.7 (36)
 0x0000|00 00 00 24                                    |...$            |      size: 36 0x0-0x3.7 (4)

--- a/format/mp4/testdata/decode_samples.fqtest
+++ b/format/mp4/testdata/decode_samples.fqtest
@@ -1,4 +1,4 @@
-$ fq -o decode_samples=false -d mp4 '.tracks | dv' /aac.mp4
+$ fq -o decode_samples=false -d mp4 '.tracks | dv' aac.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.tracks[0:1]: 0x2c-0x59c.7 (1393)
      |                                               |                |  [0]{}: track 0x2c-0x59c.7 (1393)
      |                                               |                |    samples[0:4]: 0x2c-0x291.7 (614)

--- a/format/mp4/testdata/flac.fqtest
+++ b/format/mp4/testdata/flac.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -ac 2 -c:a flac -strict experimental -f mp4 -t 50ms flac.mp4
-$ fq -d mp4 dv /flac.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /flac.mp4 (mp4) 0x0-0x542.7 (1347)
+$ fq -d mp4 dv flac.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: flac.mp4 (mp4) 0x0-0x542.7 (1347)
      |                                               |                |  boxes[0:4]: 0x0-0x542.7 (1347)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/fragmented.fqtest
+++ b/format/mp4/testdata/fragmented.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -f lavfi -i testsrc -g 1 -c:a aac -c:v h264 -f mp4 -movflags +global_sidx+frag_keyframe+empty_moov -t 100ms fragmented.mp4
-$ fq -d mp4 dv /fragmented.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /fragmented.mp4 (mp4) 0x0-0x2bb3.7 (11188)
+$ fq -d mp4 dv fragmented.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: fragmented.mp4 (mp4) 0x0-0x2bb3.7 (11188)
       |                                               |                |  boxes[0:11]: 0x0-0x2bb3.7 (11188)
       |                                               |                |    [0]{}: box 0x0-0x23.7 (36)
 0x0000|00 00 00 24                                    |...$            |      size: 36 0x0-0x3.7 (4)

--- a/format/mp4/testdata/heic.fqtest
+++ b/format/mp4/testdata/heic.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -f lavfi -i testsrc=size=16x16:r=1 -preset slower -r 1 -t 1s -pix_fmt yuv420p -f hevc heic.hvc
 # MP4Box -add-image heic.hvc -ab heic -new heic.mp4
-$ fq -d mp4 dv /heic.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /heic.mp4 (mp4) 0x0-0xb2c.7 (2861)
+$ fq -d mp4 dv heic.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: heic.mp4 (mp4) 0x0-0xb2c.7 (2861)
      |                                               |                |  boxes[0:4]: 0x0-0xb2c.7 (2861)
      |                                               |                |    [0]{}: box 0x0-0x17.7 (24)
 0x000|00 00 00 18                                    |....            |      size: 24 0x0-0x3.7 (4)

--- a/format/mp4/testdata/hevc.fqtest
+++ b/format/mp4/testdata/hevc.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v hevc -f mp4 -t 50ms hevc.mp4
-$ fq -d mp4 dv /hevc.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /hevc.mp4 (mp4) 0x0-0x149a.7 (5275)
+$ fq -d mp4 dv hevc.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: hevc.mp4 (mp4) 0x0-0x149a.7 (5275)
       |                                               |                |  boxes[0:4]: 0x0-0x149a.7 (5275)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x0000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/in24.fqtest
+++ b/format/mp4/testdata/in24.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 1ms -ac 2 -c:a pcm_s24le -f mov in24.mp4
-$ fq dv /in24.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /in24.mp4 (mp4) 0x0-0x3eb.7 (1004)
+$ fq dv in24.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: in24.mp4 (mp4) 0x0-0x3eb.7 (1004)
      |                                               |                |  boxes[0:4]: 0x0-0x3eb.7 (1004)
      |                                               |                |    [0]{}: box 0x0-0x13.7 (20)
 0x000|00 00 00 14                                    |....            |      size: 20 0x0-0x3.7 (4)

--- a/format/mp4/testdata/lpcm.fqtest
+++ b/format/mp4/testdata/lpcm.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine=r=96000 -t 1ms -ac 2 -c:a pcm_s24le -f mov lpcm.mp4
-$ fq dv /lpcm.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /lpcm.mp4 (mp4) 0x0-0x511.7 (1298)
+$ fq dv lpcm.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: lpcm.mp4 (mp4) 0x0-0x511.7 (1298)
      |                                               |                |  boxes[0:4]: 0x0-0x511.7 (1298)
      |                                               |                |    [0]{}: box 0x0-0x13.7 (20)
 0x000|00 00 00 14                                    |....            |      size: 20 0x0-0x3.7 (4)

--- a/format/mp4/testdata/mp3.fqtest
+++ b/format/mp4/testdata/mp3.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -c:a mp3 -f mp4 -t 50ms mp3.mp4
-$ fq -d mp4 dv /mp3.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3.mp4 (mp4) 0x0-0x564.7 (1381)
+$ fq -d mp4 dv mp3.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mp3.mp4 (mp4) 0x0-0x564.7 (1381)
      |                                               |                |  boxes[0:4]: 0x0-0x564.7 (1381)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/mpeg2.fqtest
+++ b/format/mp4/testdata/mpeg2.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v mpeg2video -f mp4 -t 50ms mpeg2.mp4
-$ fq -d mp4 dv /mpeg2.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mpeg2.mp4 (mp4) 0x0-0x22a8.7 (8873)
+$ fq -d mp4 dv mpeg2.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mpeg2.mp4 (mp4) 0x0-0x22a8.7 (8873)
       |                                               |                |  boxes[0:4]: 0x0-0x22a8.7 (8873)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x0000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/opus.fqtest
+++ b/format/mp4/testdata/opus.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -strict experimental -c:a opus -t 50ms opus.mp4
-$ fq -d mp4 dv /opus.mp4
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus.mp4 (mp4) 0x0-0x438.7 (1081)
+$ fq -d mp4 dv opus.mp4
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: opus.mp4 (mp4) 0x0-0x438.7 (1081)
      |                                               |                |  boxes[0:4]: 0x0-0x438.7 (1081)
      |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/path.fqtest
+++ b/format/mp4/testdata/path.fqtest
@@ -1,13 +1,13 @@
-$ fq -d mp4 'mp4_path(".moov.trak[1]")' /fragmented.mp4
+$ fq -d mp4 'mp4_path(".moov.trak[1]")' fragmented.mp4
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.boxes[1].boxes[2]{}: box
 0x280|            00 00 01 bf                        |    ....        |  size: 447
 0x280|                        74 72 61 6b            |        trak    |  type: "trak" (Container for an individual track or stream)
 0x280|                                    00 00 00 5c|            ...\|  boxes[0:2]:
 0x290|74 6b 68 64 00 00 00 03 00 00 00 00 00 00 00 00|tkhd............|
 *    |until 0x442.7 (439)                            |                |
-$ fq -d mp4 'mp4_path(".moov.trak[1]") | mp4_path' /fragmented.mp4
+$ fq -d mp4 'mp4_path(".moov.trak[1]") | mp4_path' fragmented.mp4
 ".moov.trak[1]"
-$ fq -d mp4 'mp4_path(mp4_path(".moov.trak[1]"))' /fragmented.mp4
+$ fq -d mp4 'mp4_path(mp4_path(".moov.trak[1]"))' fragmented.mp4
 ".moov.trak[1]"
 $ fq -n '"a" | raw | mp4_path(".moov")'
 exitcode: 5

--- a/format/mp4/testdata/size64.fqtest
+++ b/format/mp4/testdata/size64.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -y -f lavfi -i anoisesrc -lpc_passes 1 -strict -2 -c:a flac -t 50000s size64.mp4
 # fq -d raw 'tobytes[0:100]' size64.mp4 > size64
 # TODO: test that don't uses decode failure?
-$ fq -d mp4 '.boxes[] | d' /size64
+$ fq -d mp4 '.boxes[] | d' size64
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.boxes[0]{}: box
 0x00|00 00 00 1c                                    |....            |  size: 28
 0x00|            66 74 79 70                        |    ftyp        |  type: "ftyp" (File type and compatibility)

--- a/format/mp4/testdata/vorbis.fqtest
+++ b/format/mp4/testdata/vorbis.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -ac 2 -strict experimental -c:a vorbis -t 50ms vorbis.mp4
-$ fq -d mp4 dv /vorbis.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis.mp4 (mp4) 0x0-0x1188.7 (4489)
+$ fq -d mp4 dv vorbis.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis.mp4 (mp4) 0x0-0x1188.7 (4489)
       |                                               |                |  boxes[0:4]: 0x0-0x1188.7 (4489)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x0000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mp4/testdata/vp9.fqtest
+++ b/format/mp4/testdata/vp9.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i testsrc -c:v vp9 -t 50ms vp9.mp4
-$ fq -d mp4 dv /vp9.mp4
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vp9.mp4 (mp4) 0x0-0x184e.7 (6223)
+$ fq -d mp4 dv vp9.mp4
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vp9.mp4 (mp4) 0x0-0x184e.7 (6223)
       |                                               |                |  boxes[0:4]: 0x0-0x184e.7 (6223)
       |                                               |                |    [0]{}: box 0x0-0x1b.7 (28)
 0x0000|00 00 00 1c                                    |....            |      size: 28 0x0-0x3.7 (4)

--- a/format/mpeg/testdata/adts.fqtest
+++ b/format/mpeg/testdata/adts.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i sine -ac 2 -t 40ms -f adts adts
-$ fq -d adts dv /adts
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:3]: /adts (adts) 0x0-0x406.7 (1031)
+$ fq -d adts dv adts
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:3]: adts (adts) 0x0-0x406.7 (1031)
      |                                               |                |  [0]{}: frame (adts_frame) 0x0-0x153.7 (340)
 0x000|ff f1                                          |..              |    syncword: 0b111111111111 (valid) 0x0-0x1.3 (1.4)
 0x000|   f1                                          | .              |    mpeg_version: "mpeg4" (0) 0x1.4-0x1.4 (0.1)

--- a/format/mpeg/testdata/avc_annexb.fqtest
+++ b/format/mpeg/testdata/avc_annexb.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i testsrc -t 10ms -f h264 avc_annexb
-$ fq -d avc_annexb dv /avc_annexb
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:8]: /avc_annexb (avc_annexb) 0x0-0xae4.7 (2789)
+$ fq -d avc_annexb dv avc_annexb
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:8]: avc_annexb (avc_annexb) 0x0-0xae4.7 (2789)
 0x0000|00 00 00 01                                    |....            |  [0]: raw bits start_code 0x0-0x3.7 (4)
       |                                               |                |  [1]{}: nalu (avc_nalu) 0x4-0x1c.7 (25)
       |                                               |                |    sps{}: (avc_sps) 0x0-0x15.7 (22)

--- a/format/mpeg/testdata/hevc_annexb.fqtest
+++ b/format/mpeg/testdata/hevc_annexb.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i testsrc -t 10ms -f hevc hevc_annexb
-$ fq -d hevc_annexb dv /hevc_annexb
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:10]: /hevc_annexb (hevc_annexb) 0x0-0x1193.7 (4500)
+$ fq -d hevc_annexb dv hevc_annexb
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:10]: hevc_annexb (hevc_annexb) 0x0-0x1193.7 (4500)
 0x0000|00 00 00 01                                    |....            |  [0]: raw bits start_code 0x0-0x3.7 (4)
       |                                               |                |  [1]{}: nalu (hevc_nalu) 0x4-0x1a.7 (23)
       |                                               |                |    vps{}: (hevc_vps) 0x0-0x12.7 (19)

--- a/format/mpeg/testdata/mp3-frame-mono-crc.fqtest
+++ b/format/mpeg/testdata/mp3-frame-mono-crc.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f wav pipe:1 | lame - - | fq - '.frame[1] | tobits' > mp3-frame-mono-crc
-$ fq -d mp3_frame '.header.crc | verbose' /mp3-frame-mono-crc
+$ fq -d mp3_frame '.header.crc | verbose' mp3-frame-mono-crc
 exitcode: 3
 stderr:
 error: arg: function not defined: verbose/0

--- a/format/mpeg/testdata/mp3-frame-mono.fqtest
+++ b/format/mpeg/testdata/mp3-frame-mono.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i sine -ac 1 -t 10ms -f mp3 file && fq file '.frame[1] | tobits' > mp3-frame-mono
-$ fq -d mp3_frame dv /mp3-frame-mono
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3-frame-mono (mp3_frame) 0x0-0xcf.7 (208)
+$ fq -d mp3_frame dv mp3-frame-mono
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mp3-frame-mono (mp3_frame) 0x0-0xcf.7 (208)
     |                                               |                |  header{}: 0x0-0x3.7 (4)
 0x00|ff fb                                          |..              |    sync: 0b11111111111 (valid) 0x0-0x1.2 (1.3)
 0x00|   fb                                          | .              |    mpeg_version: "1" (3) (MPEG Version 1) 0x1.3-0x1.4 (0.2)

--- a/format/mpeg/testdata/mp3-frame-stereo.fqtest
+++ b/format/mpeg/testdata/mp3-frame-stereo.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i sine -ac 2 -t 10ms -f mp3 file && fq file '.frame[1] | tobits' > mp3-frame-stereo
-$ fq -d mp3_frame dv /mp3-frame-stereo
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /mp3-frame-stereo (mp3_frame) 0x0-0x1a0.7 (417)
+$ fq -d mp3_frame dv mp3-frame-stereo
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: mp3-frame-stereo (mp3_frame) 0x0-0x1a0.7 (417)
      |                                               |                |  header{}: 0x0-0x3.7 (4)
 0x000|ff fb                                          |..              |    sync: 0b11111111111 (valid) 0x0-0x1.2 (1.3)
 0x000|   fb                                          | .              |    mpeg_version: "1" (3) (MPEG Version 1) 0x1.3-0x1.4 (0.2)

--- a/format/ogg/testdata/flac.fqtest
+++ b/format/ogg/testdata/flac.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 50ms -c:a flac flac.ogg
-$ fq -d ogg dv /flac.ogg
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /flac.ogg (ogg) 0x0-0x31b.7 (796)
+$ fq -d ogg dv flac.ogg
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: flac.ogg (ogg) 0x0-0x31b.7 (796)
       |                                               |                |  pages[0:3]: 0x0-0x31b.7 (796)
       |                                               |                |    [0]{}: page (ogg_page) 0x0-0x4e.7 (79)
 0x0000|4f 67 67 53                                    |OggS            |      capture_pattern: "OggS" (valid) 0x0-0x3.7 (4)

--- a/format/ogg/testdata/opsu.fqtest
+++ b/format/ogg/testdata/opsu.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 50ms -c:a libopus opus.ogg
-$ fq -d ogg dv /opus.ogg
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus.ogg (ogg) 0x0-0x3b0.7 (945)
+$ fq -d ogg dv opus.ogg
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: opus.ogg (ogg) 0x0-0x3b0.7 (945)
       |                                               |                |  pages[0:3]: 0x0-0x3b0.7 (945)
       |                                               |                |    [0]{}: page (ogg_page) 0x0-0x2e.7 (47)
 0x0000|4f 67 67 53                                    |OggS            |      capture_pattern: "OggS" (valid) 0x0-0x3.7 (4)

--- a/format/ogg/testdata/page.fqtest
+++ b/format/ogg/testdata/page.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.page[0] | tobits' > page
-$ fq -d ogg_page dv /page
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /page (ogg_page) 0x0-0x39.7 (58)
+$ fq -d ogg_page dv page
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: page (ogg_page) 0x0-0x39.7 (58)
 0x00|4f 67 67 53                                    |OggS            |  capture_pattern: "OggS" (valid) 0x0-0x3.7 (4)
 0x00|            00                                 |    .           |  version: 0 (valid) 0x4-0x4.7 (1)
 0x00|               02                              |     .          |  unused_flags: 0 0x5-0x5.4 (0.5)

--- a/format/ogg/testdata/vorbis.fqtest
+++ b/format/ogg/testdata/vorbis.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 50ms -c:a libvorbis vorbis.ogg
-$ fq -d ogg dv /vorbis.ogg
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis.ogg (ogg) 0x0-0xe46.7 (3655)
+$ fq -d ogg dv vorbis.ogg
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis.ogg (ogg) 0x0-0xe46.7 (3655)
       |                                               |                |  pages[0:3]: 0x0-0xe46.7 (3655)
       |                                               |                |    [0]{}: page (ogg_page) 0x0-0x39.7 (58)
 0x0000|4f 67 67 53                                    |OggS            |      capture_pattern: "OggS" (valid) 0x0-0x3.7 (4)

--- a/format/opus/testdata/opus.fqtest
+++ b/format/opus/testdata/opus.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -y -f lavfi -i sine -t 10ms -ac 2 -metadata artist=bla -c:a libopus opus.ogg
 # fq opus.ogg '.stream[0].packet[1] | tobits' > opus-tags
-$ fq -d opus_packet dv /opus-audio
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus-audio (opus_packet) 0x0-0x1b5.7 (438)
+$ fq -d opus_packet dv opus-audio
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: opus-audio (opus_packet) 0x0-0x1b5.7 (438)
      |                                               |                |  type: "audio" 0x0-NA (0)
      |                                               |                |  toc{}: 0x0-0x1b5.7 (438)
      |                                               |                |    config{}: 0x0-0x0.4 (0.5)
@@ -17,8 +17,8 @@ $ fq -d opus_packet dv /opus-audio
 0x000|   70 5b f3 71 54 45 4a c7 79 14 ea d1 59 61 85| p[.qTEJ.y...Ya.|    data: raw bits 0x1-0x1b5.7 (437)
 0x010|c8 c2 56 2c a6 b7 6e 98 00 9b 34 cb 23 1d 98 b7|..V,..n...4.#...|
 *    |until 0x1b5.7 (end) (437)                      |                |
-$ fq -d opus_packet dv /opus-head
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus-head (opus_packet) 0x0-0x12.7 (19)
+$ fq -d opus_packet dv opus-head
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: opus-head (opus_packet) 0x0-0x12.7 (19)
     |                                               |                |  type: "head" 0x0-NA (0)
 0x00|4f 70 75 73 48 65 61 64                        |OpusHead        |  prefix: "OpusHead" 0x0-0x7.7 (8)
 0x00|                        01                     |        .       |  version: 1 0x8-0x8.7 (1)
@@ -27,8 +27,8 @@ $ fq -d opus_packet dv /opus-head
 0x00|                                    80 bb 00 00|            ....|  sample_rate: 48000 0xc-0xf.7 (4)
 0x10|00 00                                          |..              |  output_gain: 0 0x10-0x11.7 (2)
 0x10|      00|                                      |  .|            |  map_family: 0 0x12-0x12.7 (1)
-$ fq -d opus_packet dv /opus-tags
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /opus-tags (opus_packet) 0x0-0x4b.7 (76)
+$ fq -d opus_packet dv opus-tags
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: opus-tags (opus_packet) 0x0-0x4b.7 (76)
     |                                               |                |  type: "tags" 0x0-NA (0)
 0x00|4f 70 75 73 54 61 67 73                        |OpusTags        |  prefix: "OpusTags" 0x0-0x7.7 (8)
     |                                               |                |  comment{}: (vorbis_comment) 0x8-0x4b.7 (68)

--- a/format/pcap/testdata/dhcp_big_endian.fqtest
+++ b/format/pcap/testdata/dhcp_big_endian.fqtest
@@ -1,6 +1,6 @@
 # from https://wiki.wireshark.org/Development/PcapNg
-$ fq -d pcapng dv /dhcp_big_endian.pcapng
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: /dhcp_big_endian.pcapng (pcapng) 0x0-0x5fb.7 (1532)
+$ fq -d pcapng dv dhcp_big_endian.pcapng
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: dhcp_big_endian.pcapng (pcapng) 0x0-0x5fb.7 (1532)
      |                                               |                |  [0]{}: section 0x0-0x5fb.7 (1532)
      |                                               |                |    blocks[0:7]: 0x0-0x5fb.7 (1532)
      |                                               |                |      [0]{}: block 0x0-0x1b.7 (28)

--- a/format/pcap/testdata/dhcp_little_endian.fqtest
+++ b/format/pcap/testdata/dhcp_little_endian.fqtest
@@ -1,6 +1,6 @@
 # from https://wiki.wireshark.org/Development/PcapNg
 # TODO: move once we can have decode value tests somehow
-$ fq '.[0].blocks[0]' /dhcp_little_endian.pcapng
+$ fq '.[0].blocks[0]' dhcp_little_endian.pcapng
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0].blocks[0]{}: block
 0x00|0a 0d 0d 0a                                    |....            |  type: "section_header" (0xa0d0d0a) (Section Header Block)
 0x00|            1c 00 00 00                        |    ....        |  length: 28
@@ -10,8 +10,8 @@ $ fq '.[0].blocks[0]' /dhcp_little_endian.pcapng
 0x10|ff ff ff ff ff ff ff ff                        |........        |  section_length: -1
     |                                               |                |  options[0:0]:
 0x10|                        1c 00 00 00            |        ....    |  footer_total_length: 28
-$ fq dv /dhcp_little_endian.pcapng
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: /dhcp_little_endian.pcapng (pcapng) 0x0-0x5fb.7 (1532)
+$ fq dv dhcp_little_endian.pcapng
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: dhcp_little_endian.pcapng (pcapng) 0x0-0x5fb.7 (1532)
      |                                               |                |  [0]{}: section 0x0-0x5fb.7 (1532)
      |                                               |                |    blocks[0:7]: 0x0-0x5fb.7 (1532)
      |                                               |                |      [0]{}: block 0x0-0x1b.7 (28)

--- a/format/pcap/testdata/http_gzip.fqtest
+++ b/format/pcap/testdata/http_gzip.fqtest
@@ -1,6 +1,6 @@
 # from https://wiki.wireshark.org/SampleCaptures
-$ fq -d pcap dv /http_gzip.cap
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /http_gzip.cap (pcap) 0x0-0x6aa.7 (1707)
+$ fq -d pcap dv http_gzip.cap
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: http_gzip.cap (pcap) 0x0-0x6aa.7 (1707)
 0x0000|d4 c3 b2 a1                                    |....            |  magic: "little_endian" (0xd4c3b2a1) (valid) 0x0-0x3.7 (4)
 0x0000|            02 00                              |    ..          |  version_major: 2 0x4-0x5.7 (2)
 0x0000|                  04 00                        |      ..        |  version_minor: 4 0x6-0x7.7 (2)

--- a/format/pcap/testdata/ipv4frags.fqtest
+++ b/format/pcap/testdata/ipv4frags.fqtest
@@ -1,6 +1,6 @@
 # from https://wiki.wireshark.org/SampleCaptures
-$ fq -d pcap dv /ipv4frags.pcap
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /ipv4frags.pcap (pcap) 0x0-0xbad.7 (2990)
+$ fq -d pcap dv ipv4frags.pcap
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: ipv4frags.pcap (pcap) 0x0-0xbad.7 (2990)
 0x0000|d4 c3 b2 a1                                    |....            |  magic: "little_endian" (0xd4c3b2a1) (valid) 0x0-0x3.7 (4)
 0x0000|            02 00                              |    ..          |  version_major: 2 0x4-0x5.7 (2)
 0x0000|                  04 00                        |      ..        |  version_minor: 4 0x6-0x7.7 (2)

--- a/format/pcap/testdata/many_interfaces.fqtest
+++ b/format/pcap/testdata/many_interfaces.fqtest
@@ -1,6 +1,6 @@
 # from https://wiki.wireshark.org/Development/PcapNg
-$ fq -d pcapng dv /many_interfaces.pcapng
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: /many_interfaces.pcapng (pcapng) 0x0-0x51b7.7 (20920)
+$ fq -d pcapng dv many_interfaces.pcapng
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.[0:1]: many_interfaces.pcapng (pcapng) 0x0-0x51b7.7 (20920)
       |                                               |                |  [0]{}: section 0x0-0x51b7.7 (20920)
       |                                               |                |    blocks[0:88]: 0x0-0x51b7.7 (20920)
       |                                               |                |      [0]{}: block 0x0-0x8b.7 (140)

--- a/format/pcap/testdata/sll2_tcp.fqtest
+++ b/format/pcap/testdata/sll2_tcp.fqtest
@@ -1,5 +1,5 @@
-$ fq -d pcap dv /sll2_tcp.pcap
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /sll2_tcp.pcap (pcap) 0x0-0x1e4.7 (485)
+$ fq -d pcap dv sll2_tcp.pcap
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: sll2_tcp.pcap (pcap) 0x0-0x1e4.7 (485)
 0x000|d4 c3 b2 a1                                    |....            |  magic: "little_endian" (0xd4c3b2a1) (valid) 0x0-0x3.7 (4)
 0x000|            02 00                              |    ..          |  version_major: 2 0x4-0x5.7 (2)
 0x000|                  04 00                        |      ..        |  version_minor: 4 0x6-0x7.7 (2)

--- a/format/png/testdata/4x4.fqtest
+++ b/format/png/testdata/4x4.fqtest
@@ -1,8 +1,8 @@
 # convert -size 4x4 "xc:#000" 4x4.png
 # pngcrush -ztxt a akeyword atext 4x4.png 4x4out.png
 # mv 4x4out.png 4x4.png
-$ fq -d png dv /4x4.png
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.png (png) 0x0-0x125.7 (294)
+$ fq -d png dv 4x4.png
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4.png (png) 0x0-0x125.7 (294)
 0x000|89 50 4e 47 0d 0a 1a 0a                        |.PNG....        |  signature: raw bits (valid) 0x0-0x7.7 (8)
      |                                               |                |  chunks[0:10]: 0x8-0x125.7 (286)
      |                                               |                |    [0]{}: chunk 0x8-0x20.7 (25)

--- a/format/png/testdata/4x4a.fqtest
+++ b/format/png/testdata/4x4a.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -y -f lavfi -i testsrc=size=4x4:r=1 -t 2s 4x4a.apng
-$ fq -d png dv /4x4a.apng
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4a.apng (png) 0x0-0xf3.7 (244)
+$ fq -d png dv 4x4a.apng
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4a.apng (png) 0x0-0xf3.7 (244)
 0x00|89 50 4e 47 0d 0a 1a 0a                        |.PNG....        |  signature: raw bits (valid) 0x0-0x7.7 (8)
     |                                               |                |  chunks[0:8]: 0x8-0xf3.7 (236)
     |                                               |                |    [0]{}: chunk 0x8-0x20.7 (25)

--- a/format/protobuf/testdata/golden_message.fqtest
+++ b/format/protobuf/testdata/golden_message.fqtest
@@ -1,8 +1,8 @@
 # from https://github.com/protocolbuffers/protobuf/blob/master/objectivec/Tests/golden_message
 # https://github.com/protocolbuffers/protobuf/blob/master/LICENSE
 # TODO: test with schema somehow
-$ fq -d protobuf dv /golden_message
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /golden_message (protobuf) 0x0-0x212.7 (531)
+$ fq -d protobuf dv golden_message
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: golden_message (protobuf) 0x0-0x212.7 (531)
      |                                               |                |  fields[0:106]: 0x0-0x212.7 (531)
      |                                               |                |    [0]{}: field 0x0-0x1.7 (2)
 0x000|08                                             |.               |      key_n: 8 0x0-0x0.7 (1)

--- a/format/tar/testdata/tar.fqtest
+++ b/format/tar/testdata/tar.fqtest
@@ -1,7 +1,7 @@
 # echo hello > test
 # tar test c > test.tar
-$ fq -d tar dv /test.tar
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.tar (tar) 0x0-0x27ff.7 (10240)
+$ fq -d tar dv test.tar
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.tar (tar) 0x0-0x27ff.7 (10240)
       |                                               |                |  files[0:1]: 0x0-0x3ff.7 (1024)
       |                                               |                |    [0]{}: file 0x0-0x3ff.7 (1024)
 0x0000|74 65 73 74 00 00 00 00 00 00 00 00 00 00 00 00|test............|      name: "test" 0x0-0x63.7 (100)

--- a/format/tiff/testdata/4x4.fqtest
+++ b/format/tiff/testdata/4x4.fqtest
@@ -1,6 +1,6 @@
 # gm convert -size 4x4 'xc:#000' 4x4.tiff
-$ fq -d tiff dv /4x4.tiff
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.tiff (tiff) 0x0-0x107.7 (264)
+$ fq -d tiff dv 4x4.tiff
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4.tiff (tiff) 0x0-0x107.7 (264)
 0x000|49 49 2a 00                                    |II*.            |  endian: "little-endian" (0x49492a00) 0x0-0x3.7 (4)
 0x000|49 49                                          |II              |  order: "II" (valid) 0x0-0x1.7 (2)
 0x000|      2a 00                                    |  *.            |  integer_42: 42 (valid) 0x2-0x3.7 (2)

--- a/format/vorbis/testdata/vorbis-comment-picture.fqtest
+++ b/format/vorbis/testdata/vorbis-comment-picture.fqtest
@@ -2,8 +2,8 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg test.ogg
 # vorbiscomment -a test.ogg -t METADATA_BLOCK_PICTURE=$(fq -r '.. | select(format=="flac_picture") | tobytes | base64' test.flac)
 # fq '.. | select(format=="vorbis_comment") | tobytes' test.ogg > vorbis-comment-picture
-$ fq -d vorbis_comment dv /vorbis-comment-picture
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-comment-picture (vorbis_comment) 0x0-0x11f.7 (288)
+$ fq -d vorbis_comment dv vorbis-comment-picture
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis-comment-picture (vorbis_comment) 0x0-0x11f.7 (288)
 0x000|0d 00 00 00                                    |....            |  vendor_length: 13 0x0-0x3.7 (4)
 0x000|            4c 61 76 66 35 38 2e 37 36 2e 31 30|    Lavf58.76.10|  vendor: "Lavf58.76.100" 0x4-0x10.7 (13)
 0x010|30                                             |0               |

--- a/format/vorbis/testdata/vorbis.fqtest
+++ b/format/vorbis/testdata/vorbis.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.steam[0].packet[0] | tobits' > vorbis-identifcation
-$ fq -d vorbis_packet dv /vorbis-identifcation
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-identifcation (vorbis_packet) 0x0-0x1d.7 (30)
+$ fq -d vorbis_packet dv vorbis-identifcation
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis-identifcation (vorbis_packet) 0x0-0x1d.7 (30)
 0x00|01                                             |.               |  packet_type: "Identification" (1) 0x0-0x0.7 (1)
 0x00|   76 6f 72 62 69 73                           | vorbis         |  magic: "vorbis" (valid) 0x1-0x6.7 (6)
 0x00|                     00 00 00 00               |       ....     |  vorbis_version: 0 (valid) 0x7-0xa.7 (4)
@@ -14,8 +14,8 @@ $ fq -d vorbis_packet dv /vorbis-identifcation
 0x10|                                       01|     |             .| |  padding0: raw bits (all zero) 0x1d-0x1d.6 (0.7)
 0x10|                                       01|     |             .| |  framing_flag: 1 (valid) 0x1d.7-0x1d.7 (0.1)
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.packet[1] | tobits' > vorbis-comment
-$ fq -d vorbis_packet dv /vorbis-comment
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-comment (vorbis_packet) 0x0-0x3f.7 (64)
+$ fq -d vorbis_packet dv vorbis-comment
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis-comment (vorbis_packet) 0x0-0x3f.7 (64)
 0x00|03                                             |.               |  packet_type: "Comment" (3) 0x0-0x0.7 (1)
 0x00|   76 6f 72 62 69 73                           | vorbis         |  magic: "vorbis" (valid) 0x1-0x6.7 (6)
     |                                               |                |  comment{}: (vorbis_comment) 0x7-0x3e.7 (56)
@@ -31,8 +31,8 @@ $ fq -d vorbis_packet dv /vorbis-comment
 0x30|                                             01|               .|  padding0: raw bits (all zero) 0x3f-0x3f.6 (0.7)
 0x30|                                             01|               .|  frame_bit: 1 (valid) 0x3f.7-0x3f.7 (0.1)
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.packet[2] | tobits' > vorbis-setup
-$ fq -d vorbis_packet dv /vorbis-setup
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-setup (vorbis_packet) 0x0-0xc74.7 (3189)
+$ fq -d vorbis_packet dv vorbis-setup
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis-setup (vorbis_packet) 0x0-0xc74.7 (3189)
 0x000|05                                             |.               |  packet_type: "Setup" (5) 0x0-0x0.7 (1)
 0x000|   76 6f 72 62 69 73                           | vorbis         |  magic: "vorbis" (valid) 0x1-0x6.7 (6)
 0x000|                     22                        |       "        |  vorbis_codebook_count: 35 0x7-0x7.7 (1)
@@ -42,8 +42,8 @@ $ fq -d vorbis_packet dv /vorbis-setup
 0x010|24 73 18 2a 46 a5 73 16 84 10 1a 42 50 19 e3 1c|$s.*F.s....BP...|  unknown0: raw bits 0x10-0xc74.7 (3173)
 *    |until 0xc74.7 (end) (3173)                     |                |
 # ffmpeg -f lavfi -i sine -t 10ms -f ogg pipe:1 | fq - '.packet[3] | tobits' > vorbis-audio
-$ fq -d vorbis_packet dv /vorbis-audio
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /vorbis-audio (vorbis_packet) 0x0-0x20.7 (33)
+$ fq -d vorbis_packet dv vorbis-audio
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: vorbis-audio (vorbis_packet) 0x0-0x20.7 (33)
 0x00|54                                             |T               |  packet_type: "Audio" (0) 0x0-0x0.7 (1)
 0x00|   dd cb ce aa 5e d8 7f 2d 01 42 00 a0 dd 71 77| ....^..-.B...qw|  unknown0: raw bits 0x1-0x20.7 (32)
 0x10|8b ed cd 37 df 7c 33 3a 0c c3 30 0c c3 30 d4 50|...7.|3:..0..0.P|

--- a/format/wav/testdata/end-of-file.fqtest
+++ b/format/wav/testdata/end-of-file.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 10ms -ac 2 -f wav pipe:1 > end-of-file.wav
-$ fq -d wav dv /end-of-file.wav
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /end-of-file.wav (wav) 0x0-0x731.7 (1842)
+$ fq -d wav dv end-of-file.wav
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: end-of-file.wav (wav) 0x0-0x731.7 (1842)
 0x000|52 49 46 46                                    |RIFF            |  id: "RIFF" 0x0-0x3.7 (4)
 0x000|            ff ff ff ff                        |    ....        |  size: 0xffffffff (Rest of file) 0x4-0x7.7 (4)
 0x000|                        57 41 56 45            |        WAVE    |  format: "WAVE" 0x8-0xb.7 (4)

--- a/format/wav/testdata/stereo.fqtest
+++ b/format/wav/testdata/stereo.fqtest
@@ -1,6 +1,6 @@
 # ffmpeg -f lavfi -i sine -t 10ms -ac 2 stereo.wav
-$ fq -d wav dv /stereo.wav
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /stereo.wav (wav) 0x0-0x731.7 (1842)
+$ fq -d wav dv stereo.wav
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: stereo.wav (wav) 0x0-0x731.7 (1842)
 0x000|52 49 46 46                                    |RIFF            |  id: "RIFF" 0x0-0x3.7 (4)
 0x000|            2a 07 00 00                        |    *...        |  size: 1834 0x4-0x7.7 (4)
 0x000|                        57 41 56 45            |        WAVE    |  format: "WAVE" 0x8-0xb.7 (4)

--- a/format/webp/testdata/4x4.fqtest
+++ b/format/webp/testdata/4x4.fqtest
@@ -1,6 +1,6 @@
 # convert -size 4x4 "xc:#000" 4x4.webp
-$ fq -d webp dv /4x4.webp
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /4x4.webp (webp) 0x0-0x2b.7 (44)
+$ fq -d webp dv 4x4.webp
+    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: 4x4.webp (webp) 0x0-0x2b.7 (44)
 0x00|52 49 46 46                                    |RIFF            |  riff_id: "RIFF" (valid) 0x0-0x3.7 (4)
 0x00|            24 00 00 00                        |    $...        |  riff_length: 36 0x4-0x7.7 (4)
 0x00|                        57 45 42 50            |        WEBP    |  webp_id: "WEBP" (valid) 0x8-0xb.7 (4)

--- a/format/zip/testdata/test-macos.fqtest
+++ b/format/zip/testdata/test-macos.fqtest
@@ -1,5 +1,5 @@
-$ fq -d zip dv /test-macos.zip
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test-macos.zip (zip) 0x0-0x435.7 (1078)
+$ fq -d zip dv test-macos.zip
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test-macos.zip (zip) 0x0-0x435.7 (1078)
       |                                               |                |  local_files[0:5]: 0x0-0x26d.7 (622)
       |                                               |                |    [0]{}: local_file 0x0-0x42.7 (67)
 0x0000|50 4b 03 04                                    |PK..            |      signature: raw bits (valid) 0x0-0x3.7 (4)

--- a/format/zip/testdata/test0.fqtest
+++ b/format/zip/testdata/test0.fqtest
@@ -1,5 +1,5 @@
-$ fq -d zip dv /test0.zip
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test0.zip (zip) 0x0-0x3c7.7 (968)
+$ fq -d zip dv test0.zip
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test0.zip (zip) 0x0-0x3c7.7 (968)
       |                                               |                |  local_files[0:5]: 0x0-0x227.7 (552)
       |                                               |                |    [0]{}: local_file 0x0-0x3e.7 (63)
 0x0000|50 4b 03 04                                    |PK..            |      signature: raw bits (valid) 0x0-0x3.7 (4)

--- a/format/zip/testdata/test9.fqtest
+++ b/format/zip/testdata/test9.fqtest
@@ -1,5 +1,5 @@
-$ fq -d zip dv /test9.zip
-      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test9.zip (zip) 0x0-0x3c7.7 (968)
+$ fq -d zip dv test9.zip
+      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test9.zip (zip) 0x0-0x3c7.7 (968)
       |                                               |                |  local_files[0:5]: 0x0-0x227.7 (552)
       |                                               |                |    [0]{}: local_file 0x0-0x3e.7 (63)
 0x0000|50 4b 03 04                                    |PK..            |      signature: raw bits (valid) 0x0-0x3.7 (4)

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -342,14 +341,20 @@ func normalizeOSError(err error) error {
 }
 
 func (c *Case) Open(name string) (fs.File, error) {
-	// test assume cwd "/"
-	name = path.Join("/", name)
+	const testData = "testdata"
+	testDataIndex := strings.Index(c.Path, testData)
+	// cwd is directory where current script file is
+	testRoot := c.Path[0 : testDataIndex+len(testData)]
+	testCwd := filepath.Dir(c.Path[testDataIndex+len(testData):])
+	testAbsPath := filepath.Join(testCwd, name)
+	fsPath := filepath.Join(testRoot, testAbsPath)
+
 	for _, p := range c.Parts {
 		f, ok := p.(*caseFile)
 		if !ok {
 			continue
 		}
-		if f.name == name {
+		if f.name == filepath.ToSlash(testAbsPath) {
 			return interp.FileReader{
 				R: io.NewSectionReader(bytes.NewReader(f.data), 0, int64(len(f.data))),
 				FileInfo: interp.FixedFileInfo{
@@ -359,7 +364,7 @@ func (c *Case) Open(name string) (fs.File, error) {
 			}, nil
 		}
 	}
-	f, err := os.Open(filepath.Join(filepath.Dir(c.Path), name))
+	f, err := os.Open(fsPath)
 	// normalizeOSError is used to normalize OS specific path and messages into the ones unix uses
 	// this needed to make difftest work
 	return f, normalizeOSError(err)

--- a/pkg/interp/testdata/args.fqtest
+++ b/pkg/interp/testdata/args.fqtest
@@ -39,7 +39,7 @@ Example usages:
 --version,-v             Show version
 $ fq -i
 null> ^D
-$ fq -i . /test.mp3
+$ fq -i . test.mp3
 mp3> ^D
 $ fq -n
 null

--- a/pkg/interp/testdata/argvars.fqtest
+++ b/pkg/interp/testdata/argvars.fqtest
@@ -2,7 +2,7 @@
 aaa
 /b.json:
 bbb
-$ fq -i -n --raw-file filea /a.json --raw-file fileb /b.json --arg arga aa --arg argb bb --argjson argjsona 123 --argjson argjsonb '[true,123,{},"abc"]' --decode-file decodefilea /test.mp3 --decode-file decodefileb /test.mp3
+$ fq -i -n --raw-file filea a.json --raw-file fileb b.json --arg arga aa --arg argb bb --argjson argjsona 123 --argjson argjsonb '[true,123,{},"abc"]' --decode-file decodefilea test.mp3 --decode-file decodefileb test.mp3
 null> $filea
 "aaa\n"
 null> $fileb
@@ -25,16 +25,16 @@ null> $decodefileb | format
 null> $decodefileb | format
 "mp3"
 null> ^D
-$ fq -n --raw-file filea /nonexisting
+$ fq -n --raw-file filea nonexisting
 exitcode: 2
 stderr:
-error: /nonexisting: no such file or directory
-$ fq -n --decode-file filea /nonexisting
+error: nonexisting: no such file or directory
+$ fq -n --decode-file filea nonexisting
 exitcode: 2
 stderr:
 error: --decode-file filea: no such file or directory
-$ fq -n -d mp4 --decode-file filea /test.mp3 '$filea'
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp4)
+$ fq -n -d mp4 --decode-file filea test.mp3 '$filea'
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp4)
      |                                               |                |  error: mp4: error at position 0x8: no styp, ftyp, free or moov box found
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  unknown0: raw bits
 *    |until 0x283.7 (end) (644)                      |                |

--- a/pkg/interp/testdata/basic.fqtest
+++ b/pkg/interp/testdata/basic.fqtest
@@ -1,5 +1,5 @@
 # ffmpeg -f lavfi -i sine -t 10ms test.mp3
-$ fq -i . /test.mp3
+$ fq -i . test.mp3
 mp3> .headers[0].magic == "ID3"
 true
 mp3> .headers[0].version == 4

--- a/pkg/interp/testdata/binary.fqtest
+++ b/pkg/interp/testdata/binary.fqtest
@@ -1,13 +1,13 @@
-$ fq -d mp3 '.headers[0].magic._bits[8:16] | hd' /test.mp3
+$ fq -d mp3 '.headers[0].magic._bits[8:16] | hd' test.mp3
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|   44                                          | D              |.: raw bits 0x1-0x1.7 (1)
-$ fq -d mp3 '.headers[0].magic._bits | [.[8:16], .[0:8]] | hd' /test.mp3
+$ fq -d mp3 '.headers[0].magic._bits | [.[8:16], .[0:8]] | hd' test.mp3
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|44 49|                                         |DI|             |.: raw bits 0x0-0x1.7 (2)
-$ fq -d mp3 '.headers[0].magic._bits | [.[8:16], .[0:8]] | tobits | hd' /test.mp3
+$ fq -d mp3 '.headers[0].magic._bits | [.[8:16], .[0:8]] | tobits | hd' test.mp3
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|44 49|                                         |DI|             |.: raw bits 0x0-0x1.7 (2)
-$ fq -d mp3 '.headers[0].magic._bits | [.[8:16], .[0:8]] | tobytes | hd' /test.mp3
+$ fq -d mp3 '.headers[0].magic._bits | [.[8:16], .[0:8]] | tobytes | hd' test.mp3
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|44 49|                                         |DI|             |.: raw bits 0x0-0x1.7 (2)
 $ fq -n '"12" | tobytes | hd'
@@ -29,18 +29,18 @@ $ fq -n '[("11" | hex), ("22" | hex)] | tobits  | hd'
 $ fq -n '[("12" | hex | .bits[4:]), ("34" | hex | .bits[0:4])] | tobits  | hd'
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|23|                                            |#|              |.: raw bits 0x0-0x0.7 (1)
-$ fq -d mp3 '.frames[]._bits[0:12] | tonumber' /test.mp3
+$ fq -d mp3 '.frames[]._bits[0:12] | tonumber' test.mp3
 4095
 4095
 4095
-$ fq -d mp3 '.headers[0].magic._bits[0:24] | tostring' /test.mp3
+$ fq -d mp3 '.headers[0].magic._bits[0:24] | tostring' test.mp3
 "ID3"
-$ fq -d mp3 '.frames[0].padding | ("", "md5", "base64", "snippet") as $f | tovalue({bits_format: $f})' /test.mp3
+$ fq -d mp3 '.frames[0].padding | ("", "md5", "base64", "snippet") as $f | tovalue({bits_format: $f})' test.mp3
 "<5>AAAAAAA="
 "ca9c491ac66b2c62500882e93f3719a8"
 "AAAAAAA="
 "<5>AAAAAAA="
-$ fq -d mp3 -i . /test.mp3
+$ fq -d mp3 -i . test.mp3
 mp3> [1, 2, 3] | tobytes
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|01 02 03|                                      |...|            |.: raw bits 0x0-0x2.7 (3)
@@ -55,7 +55,7 @@ error: byte in binary list must be bytes (0-255) got -1
 mp3> [256] | tobytes
 error: byte in binary list must be bytes (0-255) got 256
 mp3> ^D
-$ fq -d mp3 -i . /test.mp3
+$ fq -d mp3 -i . test.mp3
 mp3> .frames[1] | tobits       | ., .start, .stop, .size, .[4:17], (tobits, tobytes, tobitsrange, tobytesrange | ., .start, .stop, .size, .[4:17])
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|ff fb 50 c4 00 00 0a 2c 43 2e 55 94 80 01 80 93|..P....,C.U.....|.: raw bits 0x0-0xcf.7 (208)

--- a/pkg/interp/testdata/completion.fqtest
+++ b/pkg/interp/testdata/completion.fqtest
@@ -32,7 +32,7 @@ aa
 ab
 > object> ^D
 null> ^D
-$ fq -i . /test.mp3
+$ fq -i . test.mp3
 mp3> .f\t
 footers
 frames

--- a/pkg/interp/testdata/decode.fqtest
+++ b/pkg/interp/testdata/decode.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> decode
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: (mp3)
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  headers[0:1]:
@@ -62,17 +62,17 @@ mp3> .[] = 1
 mp3> walk(tovalue) | .headers[0].magic
 "ID3"
 mp3> ^D
-$ fq -d raw 'png | d' /test.mp3
+$ fq -d raw 'png | d' test.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: (png)
      |                                               |                |  error: png: RawLen(signature): failed at position 8 (read size 0 seek pos 0): failed to validate raw
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  unknown0: raw bits
 *    |until 0x283.7 (end) (644)                      |                |
-$ fq -d raw 'tobytes[0:1] | png | d' /test.mp3
+$ fq -d raw 'tobytes[0:1] | png | d' test.mp3
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: (png)
    |                                               |                |  error: png: RawLen(signature): failed at position 0 (read size 0 seek pos 0): outside buffer
 0x0|49                                             |I               |  unknown0: raw bits
-$ fq -o force=true -d png d /test.mp3
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (png)
+$ fq -o force=true -d png d test.mp3
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (png)
      |                                               |                |  error: png: BitBufRange: failed at position 0 (read size 2315363 seek pos 0): outside buffer
 0x000|49 44 33 04 00 00 00 00                        |ID3.....        |  signature: raw bits (invalid)
      |                                               |                |  chunks[0:1]:
@@ -85,9 +85,9 @@ $ fq -o force=true -d png d /test.mp3
 0x000|                                             00|               .|      safe_to_copy: false
 0x010|00 0f 00 00 03 4c 61 76 66 35 38 2e 34 35 2e 31|.....Lavf58.45.1|  unknown0: raw bits
 *    |until 0x283.7 (end) (628)                      |                |
-$ fq -d raw 'tobytes[0:1] | try probe catch . | type' /test.mp3
+$ fq -d raw 'tobytes[0:1] | try probe catch . | type' test.mp3
 "array"
-$ fq -d raw 'png({force: true}) | d' /test.mp3
+$ fq -d raw 'png({force: true}) | d' test.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: (png)
      |                                               |                |  error: png: BitBufRange: failed at position 0 (read size 2315363 seek pos 0): outside buffer
 0x000|49 44 33 04 00 00 00 00                        |ID3.....        |  signature: raw bits (invalid)
@@ -101,10 +101,10 @@ $ fq -d raw 'png({force: true}) | d' /test.mp3
 0x000|                                             00|               .|      safe_to_copy: false
 0x010|00 0f 00 00 03 4c 61 76 66 35 38 2e 34 35 2e 31|.....Lavf58.45.1|  unknown0: raw bits
 *    |until 0x283.7 (end) (628)                      |                |
-$ fq -d bbb . /test.mp3
+$ fq -d bbb . test.mp3
 exitcode: 4
 stderr:
-error: /test.mp3: bbb: format group not found
+error: test.mp3: bbb: format group not found
 $ fq -n '"aaa" | decode("aaa")'
 exitcode: 5
 stderr:

--- a/pkg/interp/testdata/display.fqtest
+++ b/pkg/interp/testdata/display.fqtest
@@ -1,7 +1,7 @@
 # ffmpeg -f lavfi -i sine -t 10ms test.mp3
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> display({depth: 1})
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3)
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  headers[0:1]:
 *    |until 0x2c.7 (45)                              |                |
 0x020|                                       ff fb 40|             ..@|  frames[0:3]:
@@ -9,7 +9,7 @@ mp3> display({depth: 1})
 *    |until 0x283.7 (end) (599)                      |                |
      |                                               |                |  footers[0:0]:
 mp3> display({depth: 2})
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3)
      |                                               |                |  headers[0:1]:
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|    [0]{}: header (id3v2)
 *    |until 0x2c.7 (45)                              |                |
@@ -25,7 +25,7 @@ mp3> display({depth: 2})
 *    |until 0x283.7 (end) (209)                      |                |
      |                                               |                |  footers[0:0]:
 mp3> display({depth: 1, display_bytes: 8})
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3)
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  headers[0:1]:
 *    |until 0x2c.7 (45)                              |                |
 0x020|                                       ff fb 40|             ..@|  frames[0:3]:
@@ -33,7 +33,7 @@ mp3> display({depth: 1, display_bytes: 8})
 *    |until 0x283.7 (end) (599)                      |                |
      |                                               |                |  footers[0:0]:
 mp3> display({depth: 1, line_bytes: 8})
-     |00 01 02 03 04 05 06 07|01234567|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07|01234567|.{}: test.mp3 (mp3)
 0x000|49 44 33 04 00 00 00 00|ID3.....|  headers[0:1]:
 0x008|00 23 54 53 53 45 00 00|.#TSSE..|
 *    |until 0x2c.7 (45)      |        |
@@ -43,7 +43,7 @@ mp3> display({depth: 1, line_bytes: 8})
 *    |until 0x283.7 (end) (59|        |
      |                       |        |  footers[0:0]:
 mp3> display({width: 30, depth: 1})
-     |00 01 02 03|0123|.{}: /test.mp3 (mp3)
+     |00 01 02 03|0123|.{}: test.mp3 (mp3)
 0x000|49 44 33 04|ID3.|  headers[0:1]:
 *    |until 0x2c.|    |
 0x02c|   ff fb 40| ..@|  frames[0:3]:

--- a/pkg/interp/testdata/exprfile.fqtest
+++ b/pkg/interp/testdata/exprfile.fqtest
@@ -4,18 +4,18 @@
 .headers[0].magic | tovalue
 /err.jq:
 asdad)
-$ fq -n -f /test.jq
+$ fq -n -f test.jq
 123
 /test.jq:
 123
-$ fq -f /test2.jq /test.mp3
+$ fq -f test2.jq test.mp3
 "ID3"
-$ fq --from-file /test2.jq /test.mp3
+$ fq --from-file test2.jq test.mp3
 "ID3"
-$ fq -nf /err.jq
+$ fq -nf err.jq
 exitcode: 3
 stderr:
-error: /err.jq:1:6: unexpected token ")"
+error: err.jq:1:6: unexpected token ")"
 $ fq -n -f missing
 exitcode: 2
 stderr:

--- a/pkg/interp/testdata/gojq.fqtest
+++ b/pkg/interp/testdata/gojq.fqtest
@@ -24,20 +24,20 @@ $ fq -n '{a:1, b: 2} | tostream'
     "b"
   ]
 ]
-$ fq -d mp3 '{(.headers[0].magic): 123}' /test.mp3
+$ fq -d mp3 '{(.headers[0].magic): 123}' test.mp3
 {
   "ID3": 123
 }
-$ fq -d mp3 '{(.headers[0].magic): 123}' /test.mp3
+$ fq -d mp3 '{(.headers[0].magic): 123}' test.mp3
 {
   "ID3": 123
 }
-$ fq -d mp3 '.frames | group_by(.side_info | {b: .main_data_end}) | map(length)' /test.mp3
+$ fq -d mp3 '.frames | group_by(.side_info | {b: .main_data_end}) | map(length)' test.mp3
 [
   2,
   1
 ]
-$ fq -d mp3 '.frames | map(.header) | group_by(.bitrate)' /test.mp3
+$ fq -d mp3 '.frames | map(.header) | group_by(.bitrate)' test.mp3
 [
   [
     {
@@ -92,7 +92,7 @@ $ fq -d mp3 '.frames | map(.header) | group_by(.bitrate)' /test.mp3
     }
   ]
 ]
-$ fq -d mp3 '.frames | map(.header) | sort_by(.bitrate)' /test.mp3
+$ fq -d mp3 '.frames | map(.header) | sort_by(.bitrate)' test.mp3
 [
   {
     "bitrate": 56000,
@@ -143,7 +143,7 @@ $ fq -d mp3 '.frames | map(.header) | sort_by(.bitrate)' /test.mp3
     "sync": 2047
   }
 ]
-$ fq -d mp3 '.frames | map(.header) | sort_by(.bitrate)[0]' /test.mp3
+$ fq -d mp3 '.frames | map(.header) | sort_by(.bitrate)[0]' test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].header{}:
 0x20|                                       ff fb   |             .. |  sync: 0b11111111111 (valid)
 0x20|                                          fb   |              . |  mpeg_version: "1" (3) (MPEG Version 1)
@@ -159,7 +159,7 @@ $ fq -d mp3 '.frames | map(.header) | sort_by(.bitrate)[0]' /test.mp3
 0x30|c0                                             |.               |  copyright: 0
 0x30|c0                                             |.               |  original: 0
 0x30|c0                                             |.               |  emphasis: "none" (0b0)
-$ fq -d mp3 '.frames | map(.header) | min_by(.bitrate)' /test.mp3
+$ fq -d mp3 '.frames | map(.header) | min_by(.bitrate)' test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0].header{}:
 0x20|                                       ff fb   |             .. |  sync: 0b11111111111 (valid)
 0x20|                                          fb   |              . |  mpeg_version: "1" (3) (MPEG Version 1)
@@ -175,7 +175,7 @@ $ fq -d mp3 '.frames | map(.header) | min_by(.bitrate)' /test.mp3
 0x30|c0                                             |.               |  copyright: 0
 0x30|c0                                             |.               |  original: 0
 0x30|c0                                             |.               |  emphasis: "none" (0b0)
-$ fq -d mp3 '.frames | map(.header) | max_by(.bitrate)' /test.mp3
+$ fq -d mp3 '.frames | map(.header) | max_by(.bitrate)' test.mp3
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[2].header{}:
 0x1b0|         ff fb                                 |   ..           |  sync: 0b11111111111 (valid)
 0x1b0|            fb                                 |    .           |  mpeg_version: "1" (3) (MPEG Version 1)
@@ -191,7 +191,7 @@ $ fq -d mp3 '.frames | map(.header) | max_by(.bitrate)' /test.mp3
 0x1b0|                  c4                           |      .         |  copyright: 0
 0x1b0|                  c4                           |      .         |  original: 1
 0x1b0|                  c4                           |      .         |  emphasis: "none" (0b0)
-$ fq -d mp3 '.frames[0] | . + .header | keys, .bitrate' /test.mp3
+$ fq -d mp3 '.frames[0] | . + .header | keys, .bitrate' test.mp3
 [
   "bitrate",
   "channel_mode",
@@ -214,7 +214,7 @@ $ fq -d mp3 '.frames[0] | . + .header | keys, .bitrate' /test.mp3
 ]
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|                                             40|               @|.frames[0].header.bitrate: 56000 (4)
-$ fq -d mp3 '[.frames[0] | ., .header] | add | keys, .bitrate' /test.mp3
+$ fq -d mp3 '[.frames[0] | ., .header] | add | keys, .bitrate' test.mp3
 [
   "bitrate",
   "channel_mode",

--- a/pkg/interp/testdata/grep.fqtest
+++ b/pkg/interp/testdata/grep.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> grep(44100, "ID", "^ID3$", "^ID.?$", "Info", "magic", "\u00ff", [0x49, 0x44])
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|                                             40|               @|.frames[0].header.sample_rate: 44100 (0)

--- a/pkg/interp/testdata/hexdump.fqtest
+++ b/pkg/interp/testdata/hexdump.fqtest
@@ -1,11 +1,11 @@
 # ffmpeg -f lavfi -i sine -t 10ms test.mp3
-$ fq -d mp3 '._bits[0:(16+8)*8] | hexdump' /test.mp3
+$ fq -d mp3 '._bits[0:(16+8)*8] | hexdump' test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|.: raw bits 0x0-0x17.7 (24)
 0x10|00 0f 00 00 03 4c 61 76                        |.....Lav        |
-$ fq -d mp3 '.frames[1].header.layer | hexdump' /test.mp3
+$ fq -d mp3 '.frames[1].header.layer | hexdump' test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0xe0|            fb                                 |    .           |.: raw bits 0xe4.5-0xe4.6 (0.2)
-$ fq -d mp3 '.frames[1].header.layer._bytes | hexdump' /test.mp3
+$ fq -d mp3 '.frames[1].header.layer._bytes | hexdump' test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0xe0|            fb                                 |    .           |.: raw bits 0xe4.5-0xe4.6 (0.2)

--- a/pkg/interp/testdata/incudepath.fqtest
+++ b/pkg/interp/testdata/incudepath.fqtest
@@ -2,17 +2,17 @@
 def a: "a";
 /config/has_error.jq:
 )
-$ fq -L /library -n 'include "a"; a'
+$ fq -L library -n 'include "a"; a'
 "a"
-$ fq --include-path /library -n 'include "a"; a'
+$ fq --include-path library -n 'include "a"; a'
 "a"
-$ fq -L /wrong -L /library -n 'include "a"; a'
+$ fq -L /wrong -L library -n 'include "a"; a'
 "a"
 $ fq -n 'include "/library/a"; a'
 "a"
 $ fq -n 'include "./library/a"; a'
 "a"
-$ fq -L /wrong -n 'include "a"; a'
+$ fq -L wrong -n 'include "a"; a'
 exitcode: 3
 stderr:
 error: arg: open a.jq: file does not exist

--- a/pkg/interp/testdata/inputs.fqtest
+++ b/pkg/interp/testdata/inputs.fqtest
@@ -4,90 +4,90 @@ a
 b
 /c:
 c
-$ fq -d raw todescription /a /b /c
-"/a"
-"/b"
-"/c"
-$ fq -d raw '(.,inputs) | todescription' /a /b /c
-"/a"
-"/b"
-"/c"
-$ fq -d raw '(.,input,input,input) | try todescription catch .' /a /b /c
-"/a"
-"/b"
-"/c"
+$ fq -d raw todescription a b c
+"a"
+"b"
+"c"
+$ fq -d raw '(.,inputs) | todescription' a b c
+"a"
+"b"
+"c"
+$ fq -d raw '(.,input,input,input) | try todescription catch .' a b c
+"a"
+"b"
+"c"
 exitcode: 5
 stderr:
-error: /c: break
-$ fq -d raw -n '(.,inputs) | try todescription catch .' /a /b /c
+error: c: break
+$ fq -d raw -n '(.,inputs) | try todescription catch .' a b c
 "expected decode value but got: null (null)"
-"/a"
-"/b"
-"/c"
-$ fq -d raw -n 'inputs | try todescription catch .' /a /b /c
-"/a"
-"/b"
-"/c"
-$ fq -d raw -n '[inputs | try todescription catch .]' /a /b /c
+"a"
+"b"
+"c"
+$ fq -d raw -n 'inputs | try todescription catch .' a b c
+"a"
+"b"
+"c"
+$ fq -d raw -n '[inputs | try todescription catch .]' a b c
 [
-  "/a",
-  "/b",
-  "/c"
+  "a",
+  "b",
+  "c"
 ]
-$ fq -d raw -n '(input,input,input,input) | todescription' /a /b /c
-"/a"
-"/b"
-"/c"
+$ fq -d raw -n '(input,input,input,input) | todescription' a b c
+"a"
+"b"
+"c"
 exitcode: 5
 stderr:
-error: /c: break
+error: c: break
 $ fq -d raw input_filename
 "<stdin>"
 stdin:
 test
-$ fq -d raw input_filename /a /b /c
-"/a"
-"/b"
-"/c"
-$ fq -d raw input_filename /a /non-existing /c
-"/a"
-"/c"
+$ fq -d raw input_filename a b c
+"a"
+"b"
+"c"
+$ fq -d raw input_filename a non-existing c
+"a"
+"c"
 exitcode: 2
 stderr:
-error: /non-existing: no such file or directory
-$ fq -d raw '(' /a /b /c
+error: non-existing: no such file or directory
+$ fq -d raw '(' a b c
 exitcode: 3
 stderr:
 error: arg:1:2: unexpected token <EOF>
-$ fq -d raw bla /a /b /c
+$ fq -d raw bla a b c
 exitcode: 3
 stderr:
 error: arg: function not defined: bla/0
-$ fq -d raw '1+"a"' /a /b /c
+$ fq -d raw '1+"a"' a b c
 exitcode: 5
 stderr:
-error: /a: cannot add: number (1) and string ("a")
-error: /b: cannot add: number (1) and string ("a")
-error: /c: cannot add: number (1) and string ("a")
-$ fq -s -d raw '[.[] | todescription]' /a /b /c
+error: a: cannot add: number (1) and string ("a")
+error: b: cannot add: number (1) and string ("a")
+error: c: cannot add: number (1) and string ("a")
+$ fq -s -d raw '[.[] | todescription]' a b c
 [
-  "/a",
-  "/b",
-  "/c"
+  "a",
+  "b",
+  "c"
 ]
-$ fq -n -s -d raw . /a /b /c
+$ fq -n -s -d raw . a b c
 null
-$ fq . /a
+$ fq . a
 exitcode: 4
 stderr:
-error: /a: probe: failed to decode (try -d FORMAT)
-$ fq -i -d raw . /a /b /c
+error: a: probe: failed to decode (try -d FORMAT)
+$ fq -i -d raw . a b c
 raw, ...[0:3][]> ._format
 "raw"
 "raw"
 "raw"
 raw, ...[0:3][]> ^D
-$ fq -i -s -d raw . /a /b /c
+$ fq -i -s -d raw . a b c
 [raw, ...][0:3]> .[]._format
 "raw"
 "raw"

--- a/pkg/interp/testdata/match.fqtest
+++ b/pkg/interp/testdata/match.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .frames[1].data | tobytes | match("3\u0085"; "b")
 {
   "captures": [],

--- a/pkg/interp/testdata/options.fqtest
+++ b/pkg/interp/testdata/options.fqtest
@@ -120,7 +120,7 @@ $ fq -o compact=true -n options.compact
 true
 $ fq -o compact=aaa -n options.compact
 false
-$ fq -n -o 'decode_file=[["a", "/test.mp3"]]' '$a | format'
+$ fq -n -o 'decode_file=[["a", "test.mp3"]]' '$a | format'
 "mp3"
 $ fq -o decode_progress=false -n options.decode_progress
 false
@@ -140,7 +140,7 @@ $ fq -o expr_file=test.jq -n options.expr_file
 exitcode: 2
 stderr:
 error: test.jq: no such file or directory
-$ fq -o 'filenames=["/test.mp3"]' format
+$ fq -o 'filenames=["test.mp3"]' format
 "mp3"
 $ fq -o 'force=true' -n options.force
 true

--- a/pkg/interp/testdata/repl.fqtest
+++ b/pkg/interp/testdata/repl.fqtest
@@ -96,13 +96,13 @@ $ fq -i '[1,2,3]'
 [1,2,3]
 > [number, ...][0:3]> ^D
 [number, ...][0:3]> ^D
-$ fq -i -d mp3 '.headers[0]' /test.mp3
+$ fq -i -d mp3 '.headers[0]' test.mp3
 .headers[0] id3v2> ^D
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers[0] | repl
 > .headers[0] id3v2> ^D
 mp3> ^D
-$ fq -i -d json . /test.mp3
+$ fq -i -d json . test.mp3
 json!> ^D
 $ fq -i -n '"[]" | json'
 json> ^D

--- a/pkg/interp/testdata/slurp.fqtest
+++ b/pkg/interp/testdata/slurp.fqtest
@@ -85,7 +85,7 @@ null> spew
   ]
 }
 null> ^D
-$ fq -d mp3 -i . /test.mp3
+$ fq -d mp3 -i . test.mp3
 mp3> .frames[0] | slurp("f")
 mp3> $f[]
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.frames[0]{}: frame (mp3_frame)

--- a/pkg/interp/testdata/string_input.fqtest
+++ b/pkg/interp/testdata/string_input.fqtest
@@ -4,15 +4,15 @@ a
 b
 /c:
 c
-$ fq -R . /a /c
+$ fq -R . a c
 "a"
 "b"
 "c"
-$ fq -Rs . /a /c
+$ fq -Rs . a c
 "a\nb\nc\n"
-$ fq -nRs input /a /c
+$ fq -nRs input a c
 "a\nb\nc\n"
-$ fq -nRs inputs /a /c
+$ fq -nRs inputs a c
 "a\nb\nc\n"
 $ fq -R
 "a"

--- a/pkg/interp/testdata/value.fqtest
+++ b/pkg/interp/testdata/value.fqtest
@@ -1,13 +1,13 @@
 # ffmpeg -f lavfi -i sine -t 10ms test.mp3
 # test alt //
-$ fq -d mp3 '.headers[].frames[0].flags.unsync // 123' /test.mp3
+$ fq -d mp3 '.headers[].frames[0].flags.unsync // 123' test.mp3
 123
-$ fq -d mp3 '.headers[].frames[0].size // 123' /test.mp3
+$ fq -d mp3 '.headers[].frames[0].size // 123' test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x00|                                          00 00|              ..|.headers[0].frames[0].size: 15
 0x10|00 0f                                          |..              |
 # test each in decoded order
-$ fq -d mp3 '.headers[0][]' /test.mp3
+$ fq -d mp3 '.headers[0][]' test.mp3
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|49 44 33                                       |ID3             |.headers[0].magic: "ID3" (valid)
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
@@ -28,7 +28,7 @@ $ fq -d mp3 '.headers[0][]' /test.mp3
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|         00 00 00 00 00 00 00 00 00 00         |   ..........   |.headers[0].padding: raw bits (all zero)
 # TODO: proper buffer_root test
-$ fq -d mp3 -i . /test.mp3
+$ fq -d mp3 -i . test.mp3
 mp3> .frames[0].header.mpeg_version | (topath | path_to_expr), tovalue, toactual, tosym, todescription
 ".frames[0].header.mpeg_version"
 "1"
@@ -80,7 +80,7 @@ error: expected decode value but got: number (123)
 mp3> 123 | parents
 error: expected decode value but got: number (123)
 mp3> ^D
-$ fq -d mp3 -i . /test.mp3
+$ fq -d mp3 -i . test.mp3
 mp3> . as $c | ("headers", 0, "abc") as $n | $n, try ($c | has($n)) catch .
 "headers"
 true
@@ -204,7 +204,7 @@ true
 "_abc"
 "expected a extkey but got: _abc"
 mp3> ^D
-$ fq -d mp3 -i . /test.mp3
+$ fq -d mp3 -i . test.mp3
 mp3> ._start
 0
 mp3> ._stop
@@ -214,7 +214,7 @@ mp3> ._len
 mp3> ._name
 ""
 mp3> ._root
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3)
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  headers[0:1]:
 *    |until 0x2c.7 (45)                              |                |
 0x020|                                       ff fb 40|             ..@|  frames[0:3]:
@@ -222,7 +222,7 @@ mp3> ._root
 *    |until 0x283.7 (end) (599)                      |                |
      |                                               |                |  footers[0:0]:
 mp3> ._buffer_root
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3)
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  headers[0:1]:
 *    |until 0x2c.7 (45)                              |                |
 0x020|                                       ff fb 40|             ..@|  frames[0:3]:
@@ -230,7 +230,7 @@ mp3> ._buffer_root
 *    |until 0x283.7 (end) (599)                      |                |
      |                                               |                |  footers[0:0]:
 mp3> ._format_root
-     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: /test.mp3 (mp3)
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp3)
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  headers[0:1]:
 *    |until 0x2c.7 (45)                              |                |
 0x020|                                       ff fb 40|             ..@|  frames[0:3]:
@@ -242,7 +242,7 @@ null
 mp3> ._sym
 null
 mp3> todescription
-"/test.mp3"
+"test.mp3"
 mp3> topath
 []
 mp3> ._bits

--- a/pkg/interp/testdata/value_array.fqtest
+++ b/pkg/interp/testdata/value_array.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers | ., tovalue, type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.headers[0:1]:
 0x00|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  [0]{}: header (id3v2)

--- a/pkg/interp/testdata/value_boolean.fqtest
+++ b/pkg/interp/testdata/value_boolean.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers[0].flags.unsynchronisation | ., tovalue, type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|               00                              |     .          |.headers[0].flags.unsynchronisation: false

--- a/pkg/interp/testdata/value_null.fqtest
+++ b/pkg/interp/testdata/value_null.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers[0].padding | ., tovalue, type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|         00 00 00 00 00 00 00 00 00 00         |   ..........   |.headers[0].padding: raw bits (all zero)

--- a/pkg/interp/testdata/value_number.fqtest
+++ b/pkg/interp/testdata/value_number.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers[0].version | ., tovalue, type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|         04                                    |   .            |.headers[0].version: 4

--- a/pkg/interp/testdata/value_object.fqtest
+++ b/pkg/interp/testdata/value_object.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers[0].flags | ., tovalue, type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.headers[0].flags{}:
 0x0|               00                              |     .          |  unsynchronisation: false

--- a/pkg/interp/testdata/value_string.fqtest
+++ b/pkg/interp/testdata/value_string.fqtest
@@ -1,4 +1,4 @@
-$ fq -i -d mp3 . /test.mp3
+$ fq -i -d mp3 . test.mp3
 mp3> .headers[0].magic | ., tovalue, type, length?
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|49 44 33                                       |ID3             |.headers[0].magic: "ID3" (valid)


### PR DESCRIPTION
Make cwd for a test script the directory where the script is.
Use relative paths