### PR TITLE
dump: Skip JQValueEx if there are not options

### DIFF
--- a/pkg/interp/decode.go
+++ b/pkg/interp/decode.go
@@ -316,6 +316,9 @@ func valueHas(key any, a func(name string) any, b func(key any) any) any {
 func toValue(optsFn func() Options, v any) (any, bool) {
 	switch v := v.(type) {
 	case JQValueEx:
+		if optsFn == nil {
+			return v.JQValueToGoJQ(), true
+		}
 		return v.JQValueToGoJQEx(optsFn), true
 	case gojq.JQValue:
 		return v.JQValueToGoJQ(), true

--- a/pkg/interp/encoding.go
+++ b/pkg/interp/encoding.go
@@ -181,7 +181,7 @@ func init() {
 			false,
 			opts.Indent,
 			func(v any) any {
-				if v, ok := toValue(func() Options { return Options{} }, v); ok {
+				if v, ok := toValue(nil, v); ok {
 					return v
 				}
 				panic(fmt.Sprintf("toValue not a JQValue value: %#v", v))

--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -200,6 +200,7 @@ type Display interface {
 }
 
 type JQValueEx interface {
+	gojq.JQValue
 	JQValueToGoJQEx(optsFn func() Options) any
 }
 


### PR DESCRIPTION
I used to tojson and would crash in binary values are there were
not optins deciding how to format the strinh. Now just treat as utf8 string.