### PR TITLE
decode: Cleanup Try<f>/<f> pairs

### DIFF
--- a/format/avro/avro_ocf.go
+++ b/format/avro/avro_ocf.go
@@ -94,7 +94,7 @@ func decodeBlockCodec(d *decode.D, dataSize int64, codec string) *bytes.Buffer {
 	bb := &bytes.Buffer{}
 	if codec == "deflate" {
 		br := d.FieldRawLen("compressed", dataSize*8)
-		d.MustCopy(bb, flate.NewReader(bitio.NewIOReader(br)))
+		d.Copy(bb, flate.NewReader(bitio.NewIOReader(br)))
 	} else if codec == "snappy" {
 		// Everything but last 4 bytes which are the checksum
 		n := dataSize - 4
@@ -110,11 +110,11 @@ func decodeBlockCodec(d *decode.D, dataSize int64, codec string) *bytes.Buffer {
 		if err != nil {
 			d.Fatalf("failed decompressing data: %v", err)
 		}
-		d.MustCopy(bb, bytes.NewReader(decompressed))
+		d.Copy(bb, bytes.NewReader(decompressed))
 
 		// Check the checksum
 		crc32W := crc32.NewIEEE()
-		d.MustCopy(crc32W, bytes.NewReader(bb.Bytes()))
+		d.Copy(crc32W, bytes.NewReader(bb.Bytes()))
 		d.FieldU32("crc", d.ValidateUBytes(crc32W.Sum(nil)), scalar.ActualHex)
 	} else {
 		// Unknown codec, just dump the compressed data.

--- a/format/bzip2/bzip2.go
+++ b/format/bzip2/bzip2.go
@@ -116,7 +116,7 @@ func bzip2Decode(d *decode.D, in any) any {
 		}
 
 		blockCRC32W := crc32.NewIEEE()
-		d.MustCopy(blockCRC32W, bitFlipReader{bitio.NewIOReader(uncompressedBR)})
+		d.Copy(blockCRC32W, bitFlipReader{bitio.NewIOReader(uncompressedBR)})
 		blockCRC32N := bits.Reverse32(binary.BigEndian.Uint32(blockCRC32W.Sum(nil)))
 		_ = blockCRCValue.TryScalarFn(d.ValidateU(uint64(blockCRC32N)))
 		streamCRCN = blockCRC32N ^ ((streamCRCN << 1) | (streamCRCN >> 31))

--- a/format/cbor/cbor.go
+++ b/format/cbor/cbor.go
@@ -140,7 +140,7 @@ func decodeCBORValue(d *decode.D) any {
 				return nil
 			}
 
-			buf := d.MustReadAllBits(d.FieldRawLen("value", int64(count)*8))
+			buf := d.ReadAllBits(d.FieldRawLen("value", int64(count)*8))
 
 			return buf
 		}},

--- a/format/flac/flac.go
+++ b/format/flac/flac.go
@@ -72,7 +72,7 @@ func flacDecode(d *decode.D, in any) any {
 			frameStreamSamplesBuf := ffo.SamplesBuf[0 : samplesInFrame*uint64(ffo.Channels*ffo.BitsPerSample/8)]
 			framesNDecodedSamples += ffo.Samples
 
-			d.MustCopy(md5Samples, bytes.NewReader(frameStreamSamplesBuf))
+			d.Copy(md5Samples, bytes.NewReader(frameStreamSamplesBuf))
 			streamDecodedSamples += ffo.Samples
 
 			// reuse buffer if possible

--- a/format/flac/flac_frame.go
+++ b/format/flac/flac_frame.go
@@ -319,7 +319,7 @@ func frameDecode(d *decode.D, in any) any {
 		})
 
 		headerCRC := &checksum.CRC{Bits: 8, Table: checksum.ATM8Table}
-		d.MustCopyBits(headerCRC, d.BitBufRange(frameStart, d.Pos()-frameStart))
+		d.CopyBits(headerCRC, d.BitBufRange(frameStart, d.Pos()-frameStart))
 		d.FieldU8("crc", d.ValidateUBytes(headerCRC.Sum(nil)), scalar.ActualHex)
 	})
 
@@ -565,7 +565,7 @@ func frameDecode(d *decode.D, in any) any {
 	d.FieldU("byte_align", d.ByteAlignBits(), d.AssertU(0))
 	// <16> CRC-16 (polynomial = x^16 + x^15 + x^2 + x^0, initialized with 0) of everything before the crc, back to and including the frame header sync code
 	footerCRC := &checksum.CRC{Bits: 16, Table: checksum.ANSI16Table}
-	d.MustCopyBits(footerCRC, d.BitBufRange(frameStart, d.Pos()-frameStart))
+	d.CopyBits(footerCRC, d.BitBufRange(frameStart, d.Pos()-frameStart))
 	d.FieldRawLen("footer_crc", 16, d.ValidateBitBuf(footerCRC.Sum(nil)), scalar.RawHex)
 
 	streamSamples := len(channelSamples[0])

--- a/format/flac/flac_streaminfo.go
+++ b/format/flac/flac_streaminfo.go
@@ -27,7 +27,7 @@ func streaminfoDecode(d *decode.D, in any) any {
 	bitsPerSample := d.FieldU5("bits_per_sample", scalar.ActualUAdd(1))
 	totalSamplesInStream := d.FieldU("total_samples_in_stream", 36)
 	md5BR := d.FieldRawLen("md5", 16*8, scalar.RawHex)
-	md5b := d.MustReadAllBits(md5BR)
+	md5b := d.ReadAllBits(md5BR)
 
 	return format.FlacStreaminfoOut{
 		StreamInfo: format.FlacStreamInfo{

--- a/format/gif/gif.go
+++ b/format/gif/gif.go
@@ -93,7 +93,7 @@ func gifDecode(d *decode.D, in any) any {
 									d.FieldU8("terminator")
 									seenTerminator = true
 								}
-								d.MustCopyBits(dataBytes, d.MustCloneReadSeeker(b))
+								d.CopyBits(dataBytes, d.CloneReadSeeker(b))
 							})
 						}
 					})

--- a/format/gzip/gzip.go
+++ b/format/gzip/gzip.go
@@ -115,7 +115,7 @@ func gzDecode(d *decode.D, in any) any {
 			d.FieldRawLen("compressed", readCompressedSize)
 			crc32W := crc32.NewIEEE()
 			// TODO: cleanup clone
-			d.MustCopyBits(crc32W, d.MustCloneReadSeeker(uncompressedBR))
+			d.CopyBits(crc32W, d.CloneReadSeeker(uncompressedBR))
 			d.FieldU32("crc32", d.ValidateUBytes(crc32W.Sum(nil)), scalar.ActualHex)
 			d.FieldU32("isize")
 		}

--- a/format/id3/id3v2.go
+++ b/format/id3/id3v2.go
@@ -544,7 +544,7 @@ func decodeFrame(d *decode.D, version int) uint64 {
 	if unsyncFlag {
 		// TODO: DecodeFn
 		// TODO: unknown after frame decode
-		unsyncedBR := d.MustNewBitBufFromReader(unsyncReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), int64(dataSize)*8))})
+		unsyncedBR := d.NewBitBufFromReader(unsyncReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), int64(dataSize)*8))})
 		d.FieldFormatBitBuf("unsync", unsyncedBR, decode.FormatFn(func(d *decode.D, in any) any {
 			if fn, ok := frames[idNormalized]; ok {
 				fn(d)

--- a/format/inet/ipv4_packet.go
+++ b/format/inet/ipv4_packet.go
@@ -94,8 +94,8 @@ func decodeIPv4(d *decode.D, in any) any {
 	headerEnd := d.Pos()
 
 	ipv4Checksum := &checksum.IPv4{}
-	d.MustCopy(ipv4Checksum, bitio.NewIOReader(d.BitBufRange(0, checksumStart)))
-	d.MustCopy(ipv4Checksum, bitio.NewIOReader(d.BitBufRange(checksumEnd, headerEnd-checksumEnd)))
+	d.Copy(ipv4Checksum, bitio.NewIOReader(d.BitBufRange(0, checksumStart)))
+	d.Copy(ipv4Checksum, bitio.NewIOReader(d.BitBufRange(checksumEnd, headerEnd-checksumEnd)))
 	_ = d.FieldMustGet("header_checksum").TryScalarFn(d.ValidateUBytes(ipv4Checksum.Sum(nil)), scalar.ActualHex)
 
 	dataLen := int64(totalLength-(ihl*4)) * 8

--- a/format/jpeg/jpeg.go
+++ b/format/jpeg/jpeg.go
@@ -306,7 +306,7 @@ func jpegDecode(d *decode.D, in any) any {
 									// TODO: FieldBitsLen? concat bitbuf?
 									chunk := d.FieldRawLen("data", d.BitsLeft())
 									// TODO: redo this? multi reader?
-									chunkBytes := d.MustReadAllBits(chunk)
+									chunkBytes := d.ReadAllBits(chunk)
 
 									if extendedXMP == nil {
 										extendedXMP = make([]byte, fullLength)

--- a/format/mp4/boxes.go
+++ b/format/mp4/boxes.go
@@ -1086,7 +1086,7 @@ func init() {
 			d.FieldU24("flags")
 			systemIDBR := d.FieldRawLen("system_id", 16*8, systemIDNames)
 			// TODO: make nicer
-			systemID := d.MustReadAllBits(systemIDBR)
+			systemID := d.ReadAllBits(systemIDBR)
 			switch version {
 			case 0:
 			case 1:

--- a/format/mpeg/avc_nalu.go
+++ b/format/mpeg/avc_nalu.go
@@ -102,7 +102,7 @@ func avcNALUDecode(d *decode.D, in any) any {
 	d.FieldBool("forbidden_zero_bit")
 	d.FieldU2("nal_ref_idc")
 	nalType := d.FieldU5("nal_unit_type", avcNALNames)
-	unescapedBR := d.MustNewBitBufFromReader(decode.NALUnescapeReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), d.BitsLeft()))})
+	unescapedBR := d.NewBitBufFromReader(decode.NALUnescapeReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), d.BitsLeft()))})
 
 	switch nalType {
 	case avcNALCodedSliceNonIDR,

--- a/format/mpeg/hevc_nalu.go
+++ b/format/mpeg/hevc_nalu.go
@@ -87,7 +87,7 @@ func hevcNALUDecode(d *decode.D, in any) any {
 	nalType := d.FieldU6("nal_unit_type", hevcNALNames)
 	d.FieldU6("nuh_layer_id")
 	d.FieldU3("nuh_temporal_id_plus1")
-	unescapedBR := d.MustNewBitBufFromReader(decode.NALUnescapeReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), d.BitsLeft()))})
+	unescapedBR := d.NewBitBufFromReader(decode.NALUnescapeReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), d.BitsLeft()))})
 
 	switch nalType {
 	case hevcNALNUTVPS:

--- a/format/mpeg/mp3_frame.go
+++ b/format/mpeg/mp3_frame.go
@@ -381,8 +381,8 @@ func frameDecode(d *decode.D, in any) any {
 
 	crcHash := &checksum.CRC{Bits: 16, Current: 0xffff, Table: checksum.ANSI16Table}
 	// 2 bytes after sync and some other fields + all of side info
-	d.MustCopyBits(crcHash, d.BitBufRange(2*8, 2*8))
-	d.MustCopyBits(crcHash, d.BitBufRange(6*8, sideInfoBytes*8))
+	d.CopyBits(crcHash, d.BitBufRange(2*8, 2*8))
+	d.CopyBits(crcHash, d.BitBufRange(6*8, sideInfoBytes*8))
 
 	if crcValue != nil {
 		_ = crcValue.TryScalarFn(d.ValidateUBytes(crcHash.Sum(nil)))

--- a/format/mpeg/mpeg_pes_packet.go
+++ b/format/mpeg/mpeg_pes_packet.go
@@ -190,7 +190,7 @@ func pesPacketDecode(d *decode.D, in any) any {
 
 					v = subStreamPacket{
 						number: int(substreamNumber),
-						buf:    d.MustReadAllBits(substreamBR),
+						buf:    d.ReadAllBits(substreamBR),
 					}
 				})
 			})

--- a/format/ogg/ogg_page.go
+++ b/format/ogg/ogg_page.go
@@ -44,7 +44,7 @@ func pageDecode(d *decode.D, in any) any {
 	})
 	d.FieldArray("segments", func(d *decode.D) {
 		for _, ss := range segmentTable {
-			bs := d.MustReadAllBits(d.FieldRawLen("segment", int64(ss)*8))
+			bs := d.ReadAllBits(d.FieldRawLen("segment", int64(ss)*8))
 			p.Segments = append(p.Segments, bs)
 		}
 	})
@@ -52,9 +52,9 @@ func pageDecode(d *decode.D, in any) any {
 
 	pageChecksumValue := d.FieldGet("crc")
 	pageCRC := &checksum.CRC{Bits: 32, Table: checksum.Poly04c11db7Table}
-	d.MustCopy(pageCRC, bitio.NewIOReader(d.BitBufRange(startPos, pageChecksumValue.Range.Start-startPos)))                      // header before checksum
-	d.MustCopy(pageCRC, bytes.NewReader([]byte{0, 0, 0, 0}))                                                                     // zero checksum bits
-	d.MustCopy(pageCRC, bitio.NewIOReader(d.BitBufRange(pageChecksumValue.Range.Stop(), endPos-pageChecksumValue.Range.Stop()))) // rest of page
+	d.Copy(pageCRC, bitio.NewIOReader(d.BitBufRange(startPos, pageChecksumValue.Range.Start-startPos)))                      // header before checksum
+	d.Copy(pageCRC, bytes.NewReader([]byte{0, 0, 0, 0}))                                                                     // zero checksum bits
+	d.Copy(pageCRC, bitio.NewIOReader(d.BitBufRange(pageChecksumValue.Range.Stop(), endPos-pageChecksumValue.Range.Stop()))) // rest of page
 	_ = pageChecksumValue.TryScalarFn(d.ValidateUBytes(pageCRC.Sum(nil)))
 
 	return p

--- a/format/pcap/pcap.go
+++ b/format/pcap/pcap.go
@@ -78,7 +78,7 @@ func decodePcap(d *decode.D, in any) any {
 					d.Errorf("incl_len %d > orig_len %d", inclLen, origLen)
 				}
 
-				bs := d.MustReadAllBits(d.BitBufRange(d.Pos(), int64(inclLen)*8))
+				bs := d.ReadAllBits(d.BitBufRange(d.Pos(), int64(inclLen)*8))
 
 				if fn, ok := linkToDecodeFn[linkType]; ok {
 					// TODO: report decode errors

--- a/format/pcap/pcapng.go
+++ b/format/pcap/pcapng.go
@@ -230,7 +230,7 @@ var blockFns = map[uint64]func(d *decode.D, dc *decodeContext){
 		capturedLength := d.FieldU32("capture_packet_length")
 		d.FieldU32("original_packet_length")
 
-		bs := d.MustReadAllBits(d.BitBufRange(d.Pos(), int64(capturedLength)*8))
+		bs := d.ReadAllBits(d.BitBufRange(d.Pos(), int64(capturedLength)*8))
 
 		linkType := dc.interfaceTypes[int(interfaceID)]
 

--- a/format/png/png.go
+++ b/format/png/png.go
@@ -228,7 +228,7 @@ func pngDecode(d *decode.D, in any) any {
 		})
 
 		chunkCRC := crc32.NewIEEE()
-		d.MustCopy(chunkCRC, bitio.NewIOReader(d.BitBufRange(crcStartPos, d.Pos()-crcStartPos)))
+		d.Copy(chunkCRC, bitio.NewIOReader(d.BitBufRange(crcStartPos, d.Pos()-crcStartPos)))
 		d.FieldU32("crc", d.ValidateUBytes(chunkCRC.Sum(nil)), scalar.ActualHex)
 	})
 

--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -459,7 +459,7 @@ func rtmpDecode(d *decode.D, in any) any {
 				}
 
 				if payloadLength > 0 {
-					d.MustCopyBits(&m.b, d.FieldRawLen("data", payloadLength))
+					d.CopyBits(&m.b, d.FieldRawLen("data", payloadLength))
 				}
 
 				if m.l == uint64(m.b.Len()) {

--- a/pkg/decode/read.go
+++ b/pkg/decode/read.go
@@ -20,7 +20,7 @@ func (d *D) tryUEndian(nBits int, endian Endian) (uint64, error) {
 	if nBits < 0 {
 		return 0, fmt.Errorf("tryUEndian nBits must be >= 0 (%d)", nBits)
 	}
-	n, err := d.bits(nBits)
+	n, err := d.TryBits(nBits)
 	if err != nil {
 		return 0, err
 	}
@@ -88,7 +88,7 @@ func (d *D) tryFEndian(nBits int, endian Endian) (float64, error) {
 	if nBits < 0 {
 		return 0, fmt.Errorf("tryFEndian nBits must be >= 0 (%d)", nBits)
 	}
-	n, err := d.bits(nBits)
+	n, err := d.TryBits(nBits)
 	if err != nil {
 		return 0, err
 	}
@@ -111,7 +111,7 @@ func (d *D) tryFPEndian(nBits int, fBits int, endian Endian) (float64, error) {
 	if nBits < 0 {
 		return 0, fmt.Errorf("tryFPEndian nBits must be >= 0 (%d)", nBits)
 	}
-	n, err := d.bits(nBits)
+	n, err := d.TryBits(nBits)
 	if err != nil {
 		return 0, err
 	}
@@ -158,7 +158,7 @@ func (d *D) tryTextLenPrefixed(lenBits int, fixedBytes int, e encoding.Encoding)
 	}
 
 	p := d.Pos()
-	l, err := d.bits(lenBits)
+	l, err := d.TryBits(lenBits)
 	if err != nil {
 		return "", err
 	}
@@ -226,7 +226,7 @@ func (d *D) tryUnary(ov uint64) (uint64, error) {
 	p := d.Pos()
 	var n uint64
 	for {
-		b, err := d.bits(1)
+		b, err := d.TryBits(1)
 		if err != nil {
 			d.SeekAbs(p)
 			return 0, err
@@ -240,7 +240,7 @@ func (d *D) tryUnary(ov uint64) (uint64, error) {
 }
 
 func (d *D) tryBool() (bool, error) {
-	n, err := d.bits(1)
+	n, err := d.TryBits(1)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Decode API design is that Try* returns error non-Try panics.
Also rename Must* as they should panic and introduce some new Try* functions
that were missing.