### PR TITLE
interp: Rename --decode-file to --argdecode to be more consistent

### DIFF
--- a/pkg/interp/interp.jq
+++ b/pkg/interp/interp.jq
@@ -165,13 +165,13 @@ def _cli_eval($expr; $opts):
 
 
 def _main:
-  def _map_decode_file:
+  def _map_argdecode:
     map(
       ( . as $a
       | .[1] |=
         try (open | decode)
         catch
-          ( "--decode-file \($a[0]): \(.)"
+          ( "--argdecode \($a[0]): \(.)"
           | halt_error(_exit_code_args_error)
           )
       )
@@ -221,7 +221,7 @@ def _main:
             ( $opts.arg +
               $opts.argjson +
               $opts.raw_file +
-              ($opts.decode_file | if . then _map_decode_file end)
+              ($opts.argdecode | if . then _map_argdecode end)
             | map({key: .[0], value: .[1]})
             | from_entries
             )

--- a/pkg/interp/options.jq
+++ b/pkg/interp/options.jq
@@ -7,6 +7,7 @@ def _opt_build_default_fixed:
   | {
       addrbase:       16,
       arg:            [],
+      argdecode:      [],
       argjson:        [],
       array_truncate: 50,
       bits_format:    "snippet",
@@ -42,7 +43,6 @@ def _opt_build_default_fixed:
       },
       compact:            false,
       completion_timeout: (env.COMPLETION_TIMEOUT | if . != null then tonumber else 1 end),
-      decode_file:        [],
       decode_format:      "probe",
       decode_progress:    (env.NO_DECODE_PROGRESS == null),
       depth:              0,
@@ -72,6 +72,7 @@ def _opt_options:
   {
     addrbase:           "number",
     arg:                "array_string_pair",
+    argdecode:          "array_string_pair",
     argjson:            "array_string_pair",
     array_truncate:     "number",
     bits_format:        "string",
@@ -80,7 +81,6 @@ def _opt_options:
     colors:             "csv_kv_obj",
     compact:            "boolean",
     completion_timeout: "number",
-    decode_file:        "array_string_pair",
     decode_format:      "string",
     decode_progress:    "boolean",
     depth:              "number",
@@ -359,6 +359,13 @@ def _opt_cli_opts:
       description: "Set variable $NAME to string VALUE",
       pairs: "NAME VALUE"
     },
+    "argdecode": {
+      long: "--argdecode",
+      # TODO: remove at some point
+      aliases: ["--decode-file"],
+      description: "Set variable $NAME to decode of PATH",
+      pairs: "NAME PATH"
+    },
     "argjson": {
       long: "--argjson",
       description: "Set variable $NAME to JSON",
@@ -381,11 +388,6 @@ def _opt_cli_opts:
       long: "--decode",
       description: "Decode format (probe)",
       string: "NAME"
-    },
-    "decode_file": {
-      long: "--decode-file",
-      description: "Set variable $NAME to decode of file",
-      pairs: "NAME PATH"
     },
     "expr_file": {
       short: "-f",

--- a/pkg/interp/testdata/args.fqtest
+++ b/pkg/interp/testdata/args.fqtest
@@ -17,26 +17,26 @@ Example usages:
   fq 'grep("^main$") | parent' /bin/ls
   fq 'grep_by(format == "exif") | d' *.png *.jpeg
 
---arg NAME VALUE         Set variable $NAME to string VALUE
---argjson NAME JSON      Set variable $NAME to JSON
---color-output,-C        Force color output
---compact-output,-c      Compact output
---decode,-d NAME         Decode format (probe)
---decode-file NAME PATH  Set variable $NAME to decode of file
---from-file,-f PATH      Read EXPR from file
---help,-h [TOPIC]        Show help for TOPIC (ex: --help, --help formats)
---include-path,-L PATH   Include search path
---join-output,-j         No newline between outputs
---monochrome-output,-M   Force monochrome output
---null-input,-n          Null input (use input and inputs functions to read)
---null-output,-0         Null byte between outputs
---option,-o KEY=VALUE    Set option (ex: -o color=true, see --help options)
---raw-file NAME PATH     Set variable $NAME to string content of file
---raw-input,-R           Read raw input strings (don't decode)
---raw-output,-r          Raw string output (without quotes)
---repl,-i                Interactive REPL
---slurp,-s               Read (slurp) all inputs into an array
---version,-v             Show version
+--arg NAME VALUE        Set variable $NAME to string VALUE
+--argdecode NAME PATH   Set variable $NAME to decode of PATH
+--argjson NAME JSON     Set variable $NAME to JSON
+--color-output,-C       Force color output
+--compact-output,-c     Compact output
+--decode,-d NAME        Decode format (probe)
+--from-file,-f PATH     Read EXPR from file
+--help,-h [TOPIC]       Show help for TOPIC (ex: --help, --help formats)
+--include-path,-L PATH  Include search path
+--join-output,-j        No newline between outputs
+--monochrome-output,-M  Force monochrome output
+--null-input,-n         Null input (use input and inputs functions to read)
+--null-output,-0        Null byte between outputs
+--option,-o KEY=VALUE   Set option (ex: -o color=true, see --help options)
+--raw-file NAME PATH    Set variable $NAME to string content of file
+--raw-input,-R          Read raw input strings (don't decode)
+--raw-output,-r         Raw string output (without quotes)
+--repl,-i               Interactive REPL
+--slurp,-s              Read (slurp) all inputs into an array
+--version,-v            Show version
 $ fq -i
 null> ^D
 $ fq -i . test.mp3
@@ -60,6 +60,7 @@ $ fq -nc "[1,2,3]"
 $ fq --help options
 addrbase            16
 arg                 []
+argdecode           []
 argjson             []
 array_truncate      50
 bits_format         snippet
@@ -68,7 +69,6 @@ color               false
 colors              array=white,dumpaddr=yellow,dumpheader=yellow+underline,error=brightred,false=yellow,index=white,null=brightblack,number=cyan,object=white,objectkey=brightblue,prompt_repl_level=brightblack,prompt_value=white,string=green,true=yellow,value=white
 compact             false
 completion_timeout  10
-decode_file         []
 decode_format       probe
 decode_progress     false
 depth               0

--- a/pkg/interp/testdata/argvars.fqtest
+++ b/pkg/interp/testdata/argvars.fqtest
@@ -2,7 +2,7 @@
 aaa
 /b.json:
 bbb
-$ fq -i -n --raw-file filea a.json --raw-file fileb b.json --arg arga aa --arg argb bb --argjson argjsona 123 --argjson argjsonb '[true,123,{},"abc"]' --decode-file decodefilea test.mp3 --decode-file decodefileb test.mp3
+$ fq -i -n --raw-file filea a.json --raw-file fileb b.json --arg arga aa --arg argb bb --argjson argjsona 123 --argjson argjsonb '[true,123,{},"abc"]' --argdecode argdecodea test.mp3 --argdecode argdecodeb test.mp3
 null> $filea
 "aaa\n"
 null> $fileb
@@ -20,20 +20,20 @@ null> $argjsonb
   {},
   "abc"
 ]
-null> $decodefileb | format
+null> $argdecodea | format
 "mp3"
-null> $decodefileb | format
+null> $argdecodeb | format
 "mp3"
 null> ^D
 $ fq -n --raw-file filea nonexisting
 exitcode: 2
 stderr:
 error: nonexisting: no such file or directory
-$ fq -n --decode-file filea nonexisting
+$ fq -n --argdecode filea nonexisting
 exitcode: 2
 stderr:
-error: --decode-file filea: no such file or directory
-$ fq -n -d mp4 --decode-file filea test.mp3 '$filea'
+error: --argdecode filea: no such file or directory
+$ fq -n -d mp4 --argdecode filea test.mp3 '$filea'
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp4)
      |                                               |                |  error: mp4: error at position 0x8: no styp, ftyp, free or moov box found
 0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  unknown0: raw bits

--- a/pkg/interp/testdata/options.fqtest
+++ b/pkg/interp/testdata/options.fqtest
@@ -2,6 +2,7 @@ $ fq -n options
 {
   "addrbase": 16,
   "arg": [],
+  "argdecode": [],
   "argjson": [],
   "array_truncate": 50,
   "bits_format": "snippet",
@@ -57,7 +58,6 @@ $ fq -n options
   },
   "compact": false,
   "completion_timeout": 10,
-  "decode_file": [],
   "decode_format": "probe",
   "decode_progress": false,
   "depth": 0,
@@ -120,7 +120,7 @@ $ fq -o compact=true -n options.compact
 true
 $ fq -o compact=aaa -n options.compact
 false
-$ fq -n -o 'decode_file=[["a", "test.mp3"]]' '$a | format'
+$ fq -n -o 'argdecode=[["a", "test.mp3"]]' '$a | format'
 "mp3"
 $ fq -o decode_progress=false -n options.decode_progress
 false


### PR DESCRIPTION
There is still an alias for --decode-file