### PR TITLE
Update make-golangci-lint from 1.47.0 to 1.47.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ gogenerate:
 lint:
 # bump: make-golangci-lint /golangci-lint@v([\d.]+)/ git:https://github.com/golangci/golangci-lint.git|^1
 # bump: make-golangci-lint link "Release notes" https://github.com/golangci/golangci-lint/releases/tag/v$LATEST
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.0 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.1 run
 
 .PHONY: depgraph.svg
 depgraph.svg:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v1.47.1)  
