### PR TITLE
xml,html: Always include attrs and children in array mode

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -495,7 +495,7 @@ zip> ^D
 
 - `fromxml`/`fromxml($opts)` Parse XML into jq value.<br>
   `{seq: true}` preserve element ordering if more than one sibling.<br>
-  `{array: true}` use nested arrays to represent elements.<br>
+  `{array: true}` use nested `[name, attributes, children]` arrays to represent elements. Attributes will be `null` if none and children will be `[]` if none, this is to make it easier to work it. `toxml` does not require this.<br>
 - `fromhtml`/`fromhtml($opts)` Parse HTML into jq value.<br>
   Similar to `fromxml` but parses html5 in non-script mode. Will always have a `html` root with `head` and `body` elements.<br>
   `{array: true}` use nested arrays to represent elements.<br>

--- a/format/xml/html.go
+++ b/format/xml/html.go
@@ -29,7 +29,7 @@ func init() {
 	interp.RegisterFS(htmlFS)
 }
 
-func fromHTMLObject(n *html.Node, hi format.HTMLIn) any {
+func fromHTMLToObject(n *html.Node, hi format.HTMLIn) any {
 	var f func(n *html.Node, seq int) any
 	f = func(n *html.Node, seq int) any {
 		attrs := map[string]any{}
@@ -114,7 +114,7 @@ func fromHTMLObject(n *html.Node, hi format.HTMLIn) any {
 	return f(n, -1)
 }
 
-func fromHTMLArray(n *html.Node) any {
+func fromHTMLToArray(n *html.Node) any {
 	var f func(n *html.Node) any
 	f = func(n *html.Node) any {
 		attrs := map[string]any{}
@@ -165,10 +165,11 @@ func fromHTMLArray(n *html.Node) any {
 		elm := []any{n.Data}
 		if len(attrs) > 0 {
 			elm = append(elm, attrs)
+		} else {
+			// make attrs null if there were none, jq allows index into null
+			elm = append(elm, nil)
 		}
-		if len(nodes) > 0 {
-			elm = append(elm, nodes)
-		}
+		elm = append(elm, nodes)
 
 		return elm
 	}
@@ -189,9 +190,9 @@ func decodeHTML(d *decode.D, in any) any {
 	}
 
 	if hi.Array {
-		r = fromHTMLArray(n)
+		r = fromHTMLToArray(n)
 	} else {
-		r = fromHTMLObject(n, hi)
+		r = fromHTMLToObject(n, hi)
 	}
 	if err != nil {
 		d.Fatalf("%s", err)

--- a/format/xml/testdata/html.fqtest
+++ b/format/xml/testdata/html.fqtest
@@ -384,27 +384,34 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "all.xml"
 [
   "html",
+  null,
   [
     [
-      "head"
+      "head",
+      null,
+      []
     ],
     [
       "body",
+      null,
       [
         [
           "elm",
+          null,
           [
             [
               "first",
               {
                 "#comment": "comment"
-              }
+              },
+              []
             ],
             [
               "middle",
               {
                 "#text": "text"
-              }
+              },
+              []
             ],
             [
               "last",
@@ -413,7 +420,8 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
                 "#text": "text1\n        \n        text2",
                 "attr1": "v1",
                 "attr2": "v2"
-              }
+              },
+              []
             ]
           ]
         ]
@@ -436,18 +444,26 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "multi_diff.xml"
 [
   "html",
+  null,
   [
     [
-      "head"
+      "head",
+      null,
+      []
     ],
     [
       "body",
+      null,
       [
         [
-          "elm1"
+          "elm1",
+          null,
+          []
         ],
         [
-          "elm2"
+          "elm2",
+          null,
+          []
         ]
       ]
     ]
@@ -463,18 +479,26 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "multi_same.xml"
 [
   "html",
+  null,
   [
     [
-      "head"
+      "head",
+      null,
+      []
     ],
     [
       "body",
+      null,
       [
         [
-          "elm"
+          "elm",
+          null,
+          []
         ],
         [
-          "elm"
+          "elm",
+          null,
+          []
         ]
       ]
     ]
@@ -490,12 +514,16 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "ns.xml"
 [
   "html",
+  null,
   [
     [
-      "head"
+      "head",
+      null,
+      []
     ],
     [
       "body",
+      null,
       [
         [
           "elm",
@@ -509,7 +537,8 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
               {
                 "#text": "1",
                 "ns1:attr1": "v1"
-              }
+              },
+              []
             ],
             [
               "ns2:aaa",
@@ -522,19 +551,22 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
                   "ns1:ccc",
                   {
                     "ns1:attr3": "v3"
-                  }
+                  },
+                  []
                 ],
                 [
                   "ns2:ccc",
                   {
                     "ns2:attr4": "v4"
-                  }
+                  },
+                  []
                 ],
                 [
                   "ns3:ccc",
                   {
                     "ns2:attr5": "v5"
-                  }
+                  },
+                  []
                 ]
               ]
             ],
@@ -542,7 +574,8 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
               "aaa",
               {
                 "#text": "3"
-              }
+              },
+              []
             ]
           ]
         ]
@@ -567,15 +600,21 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "simple.xml"
 [
   "html",
+  null,
   [
     [
-      "head"
+      "head",
+      null,
+      []
     ],
     [
       "body",
+      null,
       [
         [
-          "elm"
+          "elm",
+          null,
+          []
         ]
       ]
     ]
@@ -590,19 +629,24 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "escape.xml"
 [
   "html",
+  null,
   [
     [
-      "head"
+      "head",
+      null,
+      []
     ],
     [
       "body",
+      null,
       [
         [
           "a",
           {
             "#text": "&<>",
             "attr": "&<>"
-          }
+          },
+          []
         ]
       ]
     ]
@@ -617,23 +661,29 @@ null> spew("files") | .name, (.str | fromhtml({array: true}) | ., (toxml({indent
 "noscript.html"
 [
   "html",
+  null,
   [
     [
       "head",
+      null,
       [
         [
-          "noscript"
+          "noscript",
+          null,
+          []
         ]
       ]
     ],
     [
       "body",
+      null,
       [
         [
           "a",
           {
             "#text": "text"
-          }
+          },
+          []
         ]
       ]
     ]

--- a/format/xml/testdata/xml.fqtest
+++ b/format/xml/testdata/xml.fqtest
@@ -181,18 +181,21 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
 "all.xml"
 [
   "elm",
+  null,
   [
     [
       "first",
       {
         "#comment": "comment"
-      }
+      },
+      []
     ],
     [
       "middle",
       {
         "#text": "text"
-      }
+      },
+      []
     ],
     [
       "last",
@@ -201,7 +204,8 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
         "#text": "text1\n        \n        text2",
         "attr1": "v1",
         "attr2": "v2"
-      }
+      },
+      []
     ]
   ]
 ]
@@ -214,7 +218,9 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
 </elm>
 "decl.xml"
 [
-  "elm"
+  "elm",
+  null,
+  []
 ]
 <elm></elm>
 "multi_diff.xml"
@@ -234,7 +240,8 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
       {
         "#text": "1",
         "ns1:attr1": "v1"
-      }
+      },
+      []
     ],
     [
       "ns2:aaa",
@@ -247,19 +254,22 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
           "ns1:ccc",
           {
             "ns1:attr3": "v3"
-          }
+          },
+          []
         ],
         [
           "ns2:ccc",
           {
             "ns2:attr4": "v4"
-          }
+          },
+          []
         ],
         [
           "ccc",
           {
             "ns2:attr5": "v5"
-          }
+          },
+          []
         ]
       ]
     ],
@@ -267,7 +277,8 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
       "aaa",
       {
         "#text": "3"
-      }
+      },
+      []
     ]
   ]
 ]
@@ -282,7 +293,9 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
 </elm>
 "simple.xml"
 [
-  "elm"
+  "elm",
+  null,
+  []
 ]
 <elm></elm>
 "escape.xml"
@@ -291,7 +304,8 @@ null> spew("files") | .name, try (.str | fromxml({array: true}) | ., (toxml({ind
   {
     "#text": "&<>",
     "attr": "&<>"
-  }
+  },
+  []
 ]
 <a attr="&amp;&lt;&gt;">&amp;&lt;&gt;</a>
 null> {doc: {a: "", "#text": "text", "#comment": "comment", "-attr": "value"}} | toxml, toxml({indent: 1}), toxml({indent: 8}) | println


### PR DESCRIPTION
Was hard to use when you dont know what indexes things will have. They are sill optioal for toxml