### PR TITLE
decode,scalar: Map empty string also else sym might ends up nil

### DIFF
--- a/pkg/scalar/scalar.go
+++ b/pkg/scalar/scalar.go
@@ -106,13 +106,11 @@ var ActualTrimSpace = ActualStrFn(strings.TrimSpace)
 func strMapToSym(fn func(s string) (any, error)) Mapper {
 	return Fn(func(s S) (S, error) {
 		ts := strings.TrimSpace(s.ActualStr())
-		if ts != "" {
-			n, err := fn(ts)
-			if err != nil {
-				return s, err
-			}
-			s.Sym = n
+		n, err := fn(ts)
+		if err != nil {
+			return s, err
 		}
+		s.Sym = n
 		return s, nil
 	})
 }


### PR DESCRIPTION
Later mappers should be able to rely on sym being a value of a certain type.
In this crash case tar.go  had this:
d.FieldUTF8NullFixedLen("mtime", 12, scalar.SymUParseUint(8), scalar.DescriptionSymUUnixTime)
If mtime was empty string SymUParseUint was not even called so did not bail out running
all mappers.