### PR TITLE
gojq: Update fq fork, new scope function, rawstring, stricter integers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	// fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-	github.com/wader/gojq v0.12.1-0.20220726134752-5daae754d327
+	github.com/wader/gojq v0.12.1-0.20220814141533-c1d17992747a
 	// fork of github.com/chzyer/readline, see github.com/wader/readline fq branch
 	github.com/wader/readline v0.0.0-20220704090837-31be50517a56
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/wader/gojq v0.12.1-0.20220726134752-5daae754d327 h1:HajMOMaPJWLIWdDGLIeOhNPIY8AZEe3ANiswa4/jRsI=
-github.com/wader/gojq v0.12.1-0.20220726134752-5daae754d327/go.mod h1:HM2cB+ANeJ4kBhxQp/4cNKewKjvYHACuCpBneQBgHkg=
+github.com/wader/gojq v0.12.1-0.20220814141533-c1d17992747a h1:YoM3RTILhaEOtW/9F4jSv1RNiomrHr5Dn+tUQPvI5GY=
+github.com/wader/gojq v0.12.1-0.20220814141533-c1d17992747a/go.mod h1:HM2cB+ANeJ4kBhxQp/4cNKewKjvYHACuCpBneQBgHkg=
 github.com/wader/readline v0.0.0-20220704090837-31be50517a56 h1:MEvdJFQfJD9D5nH2C5aXW+jWGcU1YmL8fJWIDsXvrJw=
 github.com/wader/readline v0.0.0-20220704090837-31be50517a56/go.mod h1:Zgz8IJWvJoe7NK23CCPpC109XMCqJCpUhpHcnnA4XaM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/interp/repl.jq
+++ b/pkg/interp/repl.jq
@@ -34,11 +34,14 @@ def _complete_keywords:
   ];
 
 def _complete_scope:
-  [scope[], _complete_keywords[]];
+  [ (scope | map(split("/")[0]) | unique)
+  , _complete_keywords
+  ] | add;
 def _complete_keys:
   # uses try as []? will not catch errors
   [try keys[] catch empty, try _extkeys[] catch empty];
 
+# TODO: "def zzz: null; abc" scope won't see zzz after completion rewrite as def will be inside map(def zzz: null; abc | ...)
 # TODO: handle variables via ast walk?
 # TODO: refactor this
 # TODO: completionMode

--- a/pkg/interp/testdata/gojq.fqtest
+++ b/pkg/interp/testdata/gojq.fqtest
@@ -287,3 +287,23 @@ $ fq -r '.headers[0] | toxml({indent: 2})' test.mp3
   <size>35</size>
   <version>4</version>
 </doc>
+$ fq -i
+null> 0b0_1
+1
+null> 0b1_0000_0000_0000_0000_0000_0000_0000_0000
+4294967296
+null> 0b0_1x
+           ^ unexpected token "x"
+null> 0o012_34567
+342391
+null> 0o7_0000_0000_0000_0000_0000_0000_0000_0000
+554597137599850363154807652352
+null> 0o012_34567x
+                 ^ unexpected token "x"
+null> 0x012_3456789abcdef
+81985529216486895
+null> 0xf_0000_0000_0000_0000_0000_0000_0000_0000
+5104235503814076951950619111476523171840
+null> 0x012_3456789abcdefx
+                         ^ unexpected token "x"
+null> ^D


### PR DESCRIPTION
Update repl completion for new scope/0 function, now reports name/arity and is more correct
Support for experimental `rawstring` literals, similar to go raw string literals
Sticter number literals, now 0b,0o and 0x fail it they have invalud symbols, ex: 0b123