### PR TITLE
interp: Add --unicode-output/-U to force use of unicode

### DIFF
--- a/pkg/interp/options.jq
+++ b/pkg/interp/options.jq
@@ -203,7 +203,12 @@ def _opt_eval($rest):
         then true
         else null
         end
-      )
+      ),
+      unicode: (
+        if .unicode_output == true then true
+        else null
+        end
+      ),
     }
   | with_entries(select(.value != null))
   );
@@ -471,6 +476,12 @@ def _opt_cli_opts:
       short: "-s",
       long: "--slurp",
       description: "Slurp all inputs into an array or string (-Rs)",
+      bool: true
+    },
+    "unicode_output": {
+      short: "-U",
+      long: "--unicode-output",
+      description: "Force unicode output",
       bool: true
     },
     "show_version": {

--- a/pkg/interp/testdata/args.fqtest
+++ b/pkg/interp/testdata/args.fqtest
@@ -39,6 +39,7 @@ Example usages:
 --raw-output,-r         Raw string output (without quotes)
 --repl,-i               Interactive REPL
 --slurp,-s              Slurp all inputs into an array or string (-Rs)
+--unicode-output,-U     Force unicode output
 --version,-v            Show version
 $ fq -i
 null> ^D

--- a/pkg/interp/testdata/unicode.fqtest
+++ b/pkg/interp/testdata/unicode.fqtest
@@ -1,0 +1,9 @@
+$ _STDOUT_IS_TERMINAL=0 NO_COLOR= CLIUNICODE=1 fq -n '[123] | hexdump'
+   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
+0x0|7b|                                            |{|              |.: raw bits 0x0-0x0.7 (1)
+$ _STDOUT_IS_TERMINAL=1 NO_COLOR= CLIUNICODE=1 fq -n '[123] | hexdump'
+   │[33;4m00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f[39;24m│[33;4m0123456789abcdef[39;24m│
+[33m0x0[39m│[37m7b[39m│                                            │[37m{[39m│              │.: [32mraw bits[39m 0x0-0x0.7 (1)
+$ NO_COLOR=1 fq -Un '[123] | hexdump'
+   │00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f│0123456789abcdef│
+0x0│7b│                                            │{│              │.: raw bits 0x0-0x0.7 (1)


### PR DESCRIPTION
Currently only used to make dump output a bit nicer.