### PR TITLE
Fix decoding of FLAC raw entropy partition

### DIFF
--- a/format/flac/flac.go
+++ b/format/flac/flac.go
@@ -2,9 +2,6 @@ package flac
 
 // https://xiph.org/flac/format.html
 // https://wiki.hydrogenaud.io/index.php?title=FLAC_decoder_testbench
-// TODO:
-// 16 - Part 6 of Ladybug Castle (partition order 8 with escape codes)
-// 32 - Part 5 of The Four of Us Are Dying (partition order 8 with escape codes)
 
 import (
 	"bytes"

--- a/format/flac/flac_frame.go
+++ b/format/flac/flac_frame.go
@@ -463,7 +463,13 @@ func frameDecode(d *decode.D, in interface{}) interface{} {
 
 								if riceParameter == riceEscape {
 									escapeSampleSize := int(d.FieldU5("escape_sample_size"))
-									d.FieldRawLen("samples", int64(count*escapeSampleSize))
+									d.RangeFn(d.Pos(), int64(count*escapeSampleSize), func(d *decode.D) {
+										d.FieldRawLen("samples", int64(count*escapeSampleSize))
+									})
+									for j := 0; j < count; j++ {
+										samples[n] = d.S(escapeSampleSize)
+										n++
+									}
 								} else {
 									samplesStart := d.Pos()
 									for j := 0; j < count; j++ {


### PR DESCRIPTION
As was mentioned in the TODO of format/flac/flac.go

Please review. Go is new to me, and I don't understand the syntaxis used here, simple copy-paste-trial-error approach.

I think the problem was that (as in [flac.tcl, samples were read unsigned, but](https://github.com/wader/flac.tcl/pull/2)) samples were read unsigned instead of signed, but I really don't understand what `d.FieldRawLen` does, so maybe it didn't read any samples at all?