### PR TITLE
ci: Skip -race for windows and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             go_test_race_flags: ""
           - os: macos-latest
             goarch: amd64
-            go_test_race_flags: -race
+            go_test_race_flags: ""
           - os: windows-latest
             goarch: amd64
-            go_test_race_flags: -race
+            go_test_race_flags: ""
     runs-on: ${{ matrix.os }}
     steps:
       # only run cli binary tests on linux


### PR DESCRIPTION
Is slower and think should be ok