### PR TITLE
bitcoin_blkdat,bitcoin_block: Make sure there is a header if blkdat

### DIFF
--- a/format/all/help.fqtest
+++ b/format/all/help.fqtest
@@ -188,11 +188,17 @@ out   # Decode value as bitcoin_blkdat
 out   ... | bitcoin_blkdat
 "help(bitcoin_block)"
 out bitcoin_block: Bitcoin block decoder
+out Options:
+out   has_header=false  Has blkdat header
 out Examples:
 out   # Decode file as bitcoin_block
 out   $ fq -d bitcoin_block . file
 out   # Decode value as bitcoin_block
 out   ... | bitcoin_block
+out   # Decode file using bitcoin_block options
+out   $ fq -d bitcoin_block -o has_header=false . file
+out   # Decode value as bitcoin_block
+out   ... | bitcoin_block({has_header:false})
 "help(bitcoin_script)"
 out bitcoin_script: Bitcoin script decoder
 out Examples:

--- a/format/bitcoin/bitcoin_blkdat.go
+++ b/format/bitcoin/bitcoin_blkdat.go
@@ -25,7 +25,7 @@ func init() {
 func decodeBlkDat(d *decode.D, in interface{}) interface{} {
 	validBlocks := 0
 	for !d.End() {
-		d.FieldFormat("block", bitcoinBlockFormat, nil)
+		d.FieldFormat("block", bitcoinBlockFormat, format.BitCoinBlockIn{HasHeader: true})
 		validBlocks++
 	}
 

--- a/format/format.go
+++ b/format/format.go
@@ -310,3 +310,7 @@ type CSVLIn struct {
 	Comma   string `doc:"Separator character"`
 	Comment string `doc:"Comment line character"`
 }
+
+type BitCoinBlockIn struct {
+	HasHeader bool `doc:"Has blkdat header"`
+}


### PR DESCRIPTION
Makes bitcoin_blkdat fails fast as it is part of probe group.
Speeds up reading a big JSON file etc.