### PR TITLE
interp,decode: For struct use map to lookup field

### DIFF
--- a/pkg/decode/value.go
+++ b/pkg/decode/value.go
@@ -13,7 +13,7 @@ type Compound struct {
 	IsArray     bool
 	RangeSorted bool
 	Children    []*Value
-	Keys        map[string]struct{}
+	ByName      map[string]*Value
 	Description string
 }
 

--- a/pkg/interp/decode.go
+++ b/pkg/interp/decode.go
@@ -709,12 +709,12 @@ func (v StructDecodeValue) JQValueKey(name string) any {
 	if strings.HasPrefix(name, "_") {
 		return v.decodeValueBase.JQValueKey(name)
 	}
-
-	for _, f := range v.Compound.Children {
-		if f.Name == name {
+	if v.Compound.ByName != nil {
+		if f, ok := v.Compound.ByName[name]; ok {
 			return makeDecodeValue(f)
 		}
 	}
+
 	return nil
 }
 func (v StructDecodeValue) JQValueEach() any {


### PR DESCRIPTION
Will make it faster for struct with logs of fields and seems to
not cuase any significant difference for small structs.

All this really needs a rewrite somehow, maybe refactor into interfaces somehow? getting messy.