### PR TITLE
test: Skip go test with -race by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,17 @@ jobs:
         include:
           - os: ubuntu-latest
             goarch: amd64
-            go_test_race_flags: -race
+            test_target: test-race
           # build and test on 32 bit, does not support race
           - os: ubuntu-latest
             goarch: "386"
-            go_test_race_flags: ""
+            test_target: test
           - os: macos-latest
             goarch: amd64
-            go_test_race_flags: ""
+            test_target: test
           - os: windows-latest
             goarch: amd64
-            go_test_race_flags: ""
+            test_target: test
     runs-on: ${{ matrix.os }}
     steps:
       # only run cli binary tests on linux
@@ -51,5 +51,4 @@ jobs:
       - name: Test
         env:
           GOARCH: ${{ matrix.goarch }}
-          GO_TEST_RACE_FLAGS: ${{ matrix.go_test_race_flags }}
-        run: make test
+        run: make ${{ matrix.test_target }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 GO_BUILD_FLAGS ?= -trimpath
 GO_BUILD_LDFLAGS ?= -s -w
-GO_TEST_RACE_FLAGS ?=-race
 
 all: test fq
 
@@ -11,11 +10,18 @@ fq:
 .PHONY: test
 test: testgo testjq testcli
 
+.PHONY: test-race
+test-race: testgo-race testjq testcli
+
 .PHONY: testgo
 # figure out all go pakges with test files
 testgo: PKGS=$(shell find . -name "*_test.go" | xargs -n 1 dirname | sort | uniq)
 testgo:
-	go test -timeout 20m ${GO_TEST_RACE_FLAGS} ${VERBOSE} ${COVER} ${PKGS}
+	go test -timeout 20m ${RACE} ${VERBOSE} ${COVER} ${PKGS}
+
+.PHONY: testgo-race
+testgo-race: RACE=-race
+testgo-race: testgo
 
 .PHONY: testjq
 testjq: fq


### PR DESCRIPTION
This patch will allow running `make test` directly on platforms that Go's race detector doesn't support, for example, ARM and RISC-V.