### PR TITLE
Update make-golangci-lint to 1.50.0 from 1.49.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ gogenerate:
 lint:
 # bump: make-golangci-lint /golangci-lint@v([\d.]+)/ git:https://github.com/golangci/golangci-lint.git|^1
 # bump: make-golangci-lint link "Release notes" https://github.com/golangci/golangci-lint/releases/tag/v$LATEST
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0 run
 
 .PHONY: depgraph.svg
 depgraph.svg:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v1.50.0)  
