### PR TITLE
Update github-golangci-lint to 1.50.1 from 1.50.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: 1.50.0
+  GOLANGCILINT_VERSION: 1.50.1
 
 jobs:
   lint:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v1.50.1)  
