### PR TITLE
gojq: Update rebased fq fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	// fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-	github.com/wader/gojq v0.12.1-0.20220929141349-8874f5c7907c
+	github.com/wader/gojq v0.12.1-0.20221030123557-e1510a9e80c3
 	// fork of github.com/chzyer/readline, see github.com/wader/readline fq branch
 	github.com/wader/readline v0.0.0-20220928125628-732951d41240
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/wader/gojq v0.12.1-0.20220929141349-8874f5c7907c h1:aQz+gw5Xe2x++st4HBIaMHPPTIyPtESG2HMZJmOaRkc=
-github.com/wader/gojq v0.12.1-0.20220929141349-8874f5c7907c/go.mod h1:/+WKHSfP8sgyJDXeD9VjxlGjExGfjPUy0zm/Zy3Ind0=
+github.com/wader/gojq v0.12.1-0.20221030123557-e1510a9e80c3 h1:O+cdsjdniOlgdSdruQCNnLTuVvubmvywif6c7J8P3fU=
+github.com/wader/gojq v0.12.1-0.20221030123557-e1510a9e80c3/go.mod h1:/+WKHSfP8sgyJDXeD9VjxlGjExGfjPUy0zm/Zy3Ind0=
 github.com/wader/readline v0.0.0-20220928125628-732951d41240 h1:fqNaldd6kVsMNGXLXH4TtB1kJtaPQOzGwqNYgswIM94=
 github.com/wader/readline v0.0.0-20220928125628-732951d41240/go.mod h1:Zgz8IJWvJoe7NK23CCPpC109XMCqJCpUhpHcnnA4XaM=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=


### PR DESCRIPTION
From upstream:
improve performance of assignment operators and del function improve jq compatibility of walk function (fix #195)