### PR TITLE
interp: Fix panic when trigger before any context has been pushed

### DIFF
--- a/internal/ctxstack/ctxstacl_test.go
+++ b/internal/ctxstack/ctxstacl_test.go
@@ -1,0 +1,35 @@
+package ctxstack_test
+
+import (
+	"testing"
+
+	"github.com/wader/fq/internal/ctxstack"
+)
+
+func TestCancelBeforePush(t *testing.T) {
+	// TODO: nicer way to test trigger before any push
+	waitTriggerFn := make(chan struct{})
+	triggerCh := make(chan struct{})
+	waitCh := make(chan struct{})
+	hasTriggeredOnce := false
+
+	ctxstack.New(func(stopCh chan struct{}) {
+		if hasTriggeredOnce {
+			close(stopCh)
+			close(waitCh)
+			return
+		}
+
+		close(waitTriggerFn)
+		<-triggerCh
+
+		hasTriggeredOnce = true
+	})
+
+	// wait for trigger func to be called
+	<-waitTriggerFn
+	// make trigger func return and cancel
+	close(triggerCh)
+
+	<-waitCh
+}


### PR DESCRIPTION
Make sure there is a top cancel function before calling it. Fixes panic caused when interrupting decode before interp context has been pushed.

Also cleanup confusing naming a bit.

Thanks @pldin601 for reporting