### PR TITLE
interp: Change default bits_format=string

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -699,6 +699,22 @@ Text encodings
 - `toutf16be` Encode string as UTF16 big-endian into binary.
 - `fromutf16be` Decode binary as UTF16 big-endian into string.
 
+## Options
+
+fq has some general options in addition to decode and decoders specific options. They all use the same `-o <name>=<value>` argument.
+
+`<value>` is fuzzily parsed based on the type of the option. Ex: a string can specified as `-o name=string` or `-o name="string"`.
+
+### `bits_format`
+
+How to represent raw bits as JSON.
+
+- `-o bits_foramt=string` String with raw bytes (zero bit padded). The string is binary safe internally in fq but bytes not represetable as UTF-8 will be lost if turn to JSON.
+- `-o bits_format=md5` MD5 hex string (zero bit padded).
+- `-o bits_format=base64` Base64 string.
+- `-p bits_foramt=truncate` Truncated string.
+- `-o bits_format=snippet` Truncated Base64 string prefixed with bit length.
+
 ## Color and unicode output
 
 fq by default tries to use colors if possible, this can be disabled with `-M`. You can also

--- a/format/asn1/testdata/test.pem.fqtest
+++ b/format/asn1/testdata/test.pem.fqtest
@@ -52,5 +52,5 @@ $ fq -d bytes 'frompem | asn1_ber | dv, torepr' test.pem
     ],
     null
   ],
-  "<140>MIGJAoGBAMxh+e9a0Lwh3ls8pp7nJdLFBO35mm6XoCedlZ8jZO0hqu+McEVS1dGj3rLuGgvhVY48oYKxGowUOStt5SNGvHyIv3Xj+yufJ/qyH1zxmTTjEQ6krXKm8HP4qzi5k5u2OeeK1/Q0EZ2MwrG95Or5UTsFZQjJCO1DyZsM6yIsu+HvAgMBAAE="
+  "0\ufffd\ufffd\u0002\ufffd\ufffd\u0000\ufffda\ufffd\ufffdZм!\ufffd[<\ufffd\ufffd\ufffd%\ufffd\ufffd\u0004\ufffd\ufffd\ufffdn\ufffd\ufffd'\ufffd\ufffd\ufffd#d\ufffd!\ufffd\ufffd\ufffdpER\ufffdѣ޲\ufffd\u001a\u000b\ufffdU\ufffd<\ufffd\ufffd\ufffd\u001a\ufffd\u00149+m\ufffd#F\ufffd|\ufffd\ufffdu\ufffd\ufffd+\ufffd'\ufffd\ufffd\u001f\\\ufffd\ufffd4\ufffd\u0011\u000e\ufffd\ufffdr\ufffd\ufffds\ufffd\ufffd8\ufffd\ufffd\ufffd\ufffd9\ufffd\ufffd\ufffd\ufffd4\u0011\ufffd\ufffd±\ufffd\ufffd\ufffd\ufffdQ;\u0005e\b\ufffd\b\ufffdCɛ\f\ufffd\",\ufffd\ufffd\ufffd\u0002\u0003\u0001\u0000\u0001"
 ]

--- a/format/cbor/testdata/appendix_a.fqtest
+++ b/format/cbor/testdata/appendix_a.fqtest
@@ -9,7 +9,7 @@ json> map(select(.decoded) | (.cbor | frombase64 | cbor | torepr) as $a | select
     "actual": {
       "major_type": "bytes",
       "short_count": 9,
-      "value": "<9>AQAAAAAAAAAA"
+      "value": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
     },
     "test": {
       "cbor": "wkkBAAAAAAAAAAA=",
@@ -22,7 +22,7 @@ json> map(select(.decoded) | (.cbor | frombase64 | cbor | torepr) as $a | select
     "actual": {
       "major_type": "bytes",
       "short_count": 9,
-      "value": "<9>AQAAAAAAAAAA"
+      "value": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
     },
     "test": {
       "cbor": "w0kBAAAAAAAAAAA=",

--- a/format/json/testdata/tofromjson.fqtest
+++ b/format/json/testdata/tofromjson.fqtest
@@ -52,7 +52,7 @@ $ fq . json.gz
 0x010|                                 0b 00 00 00|  |           ....||  isize: 11
 $ fq tovalue json.gz
 {
-  "compressed": "<13>q1ZKVLJSMDQyruUCAA==",
+  "compressed": "\ufffdVJT\ufffdR042\ufffd\ufffd\u0002\u0000",
   "compression_method": "deflate",
   "crc32": 2631052320,
   "extra_flags": 0,
@@ -64,7 +64,7 @@ $ fq tovalue json.gz
     "reserved": 0,
     "text": false
   },
-  "identification": "<2>H4s=",
+  "identification": "\u001f\ufffd",
   "isize": 11,
   "mtime": 1627916901,
   "os": "unix",

--- a/pkg/interp/options.jq
+++ b/pkg/interp/options.jq
@@ -10,7 +10,7 @@ def _opt_build_default_fixed:
       argdecode:      [],
       argjson:        [],
       array_truncate: 50,
-      bits_format:    "snippet",
+      bits_format:    "string",
       # 0-0xff=brightwhite,0=brightblack,32-126:9-13=white
       byte_colors:    [
         { ranges: [[0,255]],

--- a/pkg/interp/testdata/args.fqtest
+++ b/pkg/interp/testdata/args.fqtest
@@ -71,7 +71,7 @@ arg                 []
 argdecode           []
 argjson             []
 array_truncate      50
-bits_format         snippet
+bits_format         string
 byte_colors         0-255=brightwhite,0=brightblack,32-126:9-13=white
 color               false
 colors              array=white,dumpaddr=yellow,dumpheader=yellow+underline,error=brightred,false=yellow,index=white,null=brightblack,number=cyan,object=white,objectkey=brightblue,prompt_repl_level=brightblack,prompt_value=white,string=green,true=yellow,value=white

--- a/pkg/interp/testdata/binary.fqtest
+++ b/pkg/interp/testdata/binary.fqtest
@@ -537,4 +537,25 @@ null> "å(?<n>å)(å)" as $p | "cbbcåååccåååcbc", "åååcbbc", "cbbcåå�
 "binary_byte"
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|            c3 a5 c3 a5 c3 a5|                 |    ......|     |.: raw bits 0x4-0x9.7 (6)
+null> [range(256)] | . as $b | tobytes | tostring | tobytes | $b == explode, dd, tostring, tovalue
+true
+     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
+0x000|00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|................|.: raw bits 0x0-0xff.7 (256)
+0x010|10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f|................|
+0x020|20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f| !"#$%&'()*+,-./|
+0x030|30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f|0123456789:;<=>?|
+0x040|40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f|@ABCDEFGHIJKLMNO|
+0x050|50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f|PQRSTUVWXYZ[\]^_|
+0x060|60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f|`abcdefghijklmno|
+0x070|70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f|pqrstuvwxyz{|}~.|
+0x080|80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f|................|
+0x090|90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f|................|
+0x0a0|a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af|................|
+0x0b0|b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf|................|
+0x0c0|c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf|................|
+0x0d0|d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df|................|
+0x0e0|e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef|................|
+0x0f0|f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff|................|
+"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd"
+"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd"
 null> ^D

--- a/pkg/interp/testdata/options.fqtest
+++ b/pkg/interp/testdata/options.fqtest
@@ -5,7 +5,7 @@ $ fq -n options
   "argdecode": [],
   "argjson": [],
   "array_truncate": 50,
-  "bits_format": "snippet",
+  "bits_format": "string",
   "byte_colors": [
     {
       "ranges": [

--- a/pkg/interp/testdata/tovalue.fqtest
+++ b/pkg/interp/testdata/tovalue.fqtest
@@ -1,6 +1,6 @@
 # TODO: use test format
 $ fq -i
 null> "aaa" | mp3_frame | .unknown0 | tovalue, tovalue({sizebase: 2})
-"<3>YWFh"
-"<0b11>YWFh"
+"aaa"
+"aaa"
 null> ^D

--- a/pkg/interp/testdata/value_array.fqtest
+++ b/pkg/interp/testdata/value_array.fqtest
@@ -34,7 +34,7 @@ mp3> .headers | ., tovalue, toactual, tosym, type, length?
       }
     ],
     "magic": "ID3",
-    "padding": "<10>AAAAAAAAAAAAAA==",
+    "padding": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
     "revision": 0,
     "size": 35,
     "version": 4
@@ -104,7 +104,7 @@ mp3> .headers[-1000:2000] | ., type, length?
       }
     ],
     "magic": "ID3",
-    "padding": "<10>AAAAAAAAAAAAAA==",
+    "padding": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
     "revision": 0,
     "size": 35,
     "version": 4
@@ -195,7 +195,7 @@ mp3> .headers[0] = 1
   "footers": [],
   "frames": [
     {
-      "audio_data": "<5>AAAAAAA=",
+      "audio_data": "\u0000\u0000\u0000\u0000\u0000",
       "crc_calculated": "827a",
       "header": {
         "bitrate": 56000,
@@ -389,7 +389,7 @@ mp3> .headers[0] = 1
       }
     },
     {
-      "audio_data": "<187>B6rDjjOF02TxocEIHFgfXh8YHEYEHonlsy5aD6g7E2vw+GBQFAQDAoJEDE5o0aNsH3iAEAQxOD/BB050+c5fznL+7p93Lg+D4Ph8EAxKAMH9IAH///555554T7EPKQdc5TdRYNYihmqWGn6jVTNuL+Em0eAKJCYbPQRwVHtKrRk2Hogmi3/vFJwLDWJ//++4IUY5R/oJnyoaCgV9HgUESINnfuTyoCETQkEv/+OQSYPWtQkEQMCZSqCIEQ==",
+      "audio_data": "\u0007\ufffdÎ3\ufffd\ufffdd\ufffd\ufffd\ufffd\b\u001cX\u001f^\u001f\u0018\u001cF\u0004\u001e\ufffd\ufffd\ufffd.Z\u000f\ufffd;\u0013k\ufffd\ufffd`P\u0014\u0004\u0003\u0002\ufffdD\fNhѣl\u001fx\ufffd\u0010\u000418?\ufffd\u0007Nt\ufffd\ufffd_\ufffdr\ufffd\ufffd\ufffdw.\u000f\ufffd\ufffd\ufffd|\u0010\fJ\u0000\ufffd\ufffd \u0001\ufffd\ufffd\ufffdy\ufffd\ufffdxO\ufffd\u000f)\u0007\\\ufffd7Q`\ufffd\"\ufffdj\ufffd\u001a~\ufffdU3n/\ufffd&\ufffd\ufffd\n$&\u001b=\u0004pT{J\ufffd\u00196\u001e\ufffd&\ufffd\u007f\ufffd\u0014\ufffd\u000b\rb\u007f\ufffd\ufffd\ufffd!F9G\ufffd\t\ufffd*\u001a\n\u0005}\u001e\u0005\u0004H\ufffdg~\ufffd\ufffd\ufffd!\u0013BA/\ufffd\ufffd\ufffdI\ufffdֵ\t\u0004@\ufffd\ufffdJ\ufffd\ufffd\u0011",
       "crc_calculated": "e5b0",
       "header": {
         "bitrate": 64000,
@@ -454,7 +454,7 @@ mp3> .headers[0] = 1
       }
     },
     {
-      "audio_data": "<188>EUs2SgiDWMkg1ClSmMjI+ROAQCS8kSNCUFYNGBEDQd6wVWCsRHiwdgr6P4lOlXKBqDUqdWdiL/BXlj3Ev//xEkxBTUUzLjEwMKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo=",
+      "audio_data": "\u0011K6J\b\ufffdX\ufffd \ufffd)R\ufffd\ufffd\ufffd\ufffd\u0013\ufffd@$\ufffd\ufffd#BPV\r\u0018\u0011\u0003AްU`\ufffdDx\ufffdv\n\ufffd?\ufffdN\ufffdr\ufffd\ufffd5*ugb/\ufffdW\ufffd=Ŀ\ufffd\ufffd\u0012LAME3.100\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
       "crc_calculated": "61fd",
       "header": {
         "bitrate": 64000,
@@ -528,7 +528,7 @@ mp3> .headers[0] |= empty
   "footers": [],
   "frames": [
     {
-      "audio_data": "<5>AAAAAAA=",
+      "audio_data": "\u0000\u0000\u0000\u0000\u0000",
       "crc_calculated": "827a",
       "header": {
         "bitrate": 56000,
@@ -722,7 +722,7 @@ mp3> .headers[0] |= empty
       }
     },
     {
-      "audio_data": "<187>B6rDjjOF02TxocEIHFgfXh8YHEYEHonlsy5aD6g7E2vw+GBQFAQDAoJEDE5o0aNsH3iAEAQxOD/BB050+c5fznL+7p93Lg+D4Ph8EAxKAMH9IAH///555554T7EPKQdc5TdRYNYihmqWGn6jVTNuL+Em0eAKJCYbPQRwVHtKrRk2Hogmi3/vFJwLDWJ//++4IUY5R/oJnyoaCgV9HgUESINnfuTyoCETQkEv/+OQSYPWtQkEQMCZSqCIEQ==",
+      "audio_data": "\u0007\ufffdÎ3\ufffd\ufffdd\ufffd\ufffd\ufffd\b\u001cX\u001f^\u001f\u0018\u001cF\u0004\u001e\ufffd\ufffd\ufffd.Z\u000f\ufffd;\u0013k\ufffd\ufffd`P\u0014\u0004\u0003\u0002\ufffdD\fNhѣl\u001fx\ufffd\u0010\u000418?\ufffd\u0007Nt\ufffd\ufffd_\ufffdr\ufffd\ufffd\ufffdw.\u000f\ufffd\ufffd\ufffd|\u0010\fJ\u0000\ufffd\ufffd \u0001\ufffd\ufffd\ufffdy\ufffd\ufffdxO\ufffd\u000f)\u0007\\\ufffd7Q`\ufffd\"\ufffdj\ufffd\u001a~\ufffdU3n/\ufffd&\ufffd\ufffd\n$&\u001b=\u0004pT{J\ufffd\u00196\u001e\ufffd&\ufffd\u007f\ufffd\u0014\ufffd\u000b\rb\u007f\ufffd\ufffd\ufffd!F9G\ufffd\t\ufffd*\u001a\n\u0005}\u001e\u0005\u0004H\ufffdg~\ufffd\ufffd\ufffd!\u0013BA/\ufffd\ufffd\ufffdI\ufffdֵ\t\u0004@\ufffd\ufffdJ\ufffd\ufffd\u0011",
       "crc_calculated": "e5b0",
       "header": {
         "bitrate": 64000,
@@ -787,7 +787,7 @@ mp3> .headers[0] |= empty
       }
     },
     {
-      "audio_data": "<188>EUs2SgiDWMkg1ClSmMjI+ROAQCS8kSNCUFYNGBEDQd6wVWCsRHiwdgr6P4lOlXKBqDUqdWdiL/BXlj3Ev//xEkxBTUUzLjEwMKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo=",
+      "audio_data": "\u0011K6J\b\ufffdX\ufffd \ufffd)R\ufffd\ufffd\ufffd\ufffd\u0013\ufffd@$\ufffd\ufffd#BPV\r\u0018\u0011\u0003AްU`\ufffdDx\ufffdv\n\ufffd?\ufffdN\ufffdr\ufffd\ufffd5*ugb/\ufffdW\ufffd=Ŀ\ufffd\ufffd\u0012LAME3.100\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
       "crc_calculated": "61fd",
       "header": {
         "bitrate": 64000,

--- a/pkg/interp/testdata/value_null.fqtest
+++ b/pkg/interp/testdata/value_null.fqtest
@@ -2,8 +2,8 @@ $ fq -i -d mp3 . test.mp3
 mp3> .headers[0].padding | ., tovalue, toactual, tosym, type, length?
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x20|         00 00 00 00 00 00 00 00 00 00         |   ..........   |.headers[0].padding: raw bits (all zero)
-"<10>AAAAAAAAAAAAAA=="
-"<10>AAAAAAAAAAAAAA=="
+"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
 null
 "string"
 10

--- a/pkg/interp/testdata/value_object.fqtest
+++ b/pkg/interp/testdata/value_object.fqtest
@@ -113,7 +113,7 @@ mp3> .headers[0].flags.a = 1
   "footers": [],
   "frames": [
     {
-      "audio_data": "<5>AAAAAAA=",
+      "audio_data": "\u0000\u0000\u0000\u0000\u0000",
       "crc_calculated": "827a",
       "header": {
         "bitrate": 56000,
@@ -307,7 +307,7 @@ mp3> .headers[0].flags.a = 1
       }
     },
     {
-      "audio_data": "<187>B6rDjjOF02TxocEIHFgfXh8YHEYEHonlsy5aD6g7E2vw+GBQFAQDAoJEDE5o0aNsH3iAEAQxOD/BB050+c5fznL+7p93Lg+D4Ph8EAxKAMH9IAH///555554T7EPKQdc5TdRYNYihmqWGn6jVTNuL+Em0eAKJCYbPQRwVHtKrRk2Hogmi3/vFJwLDWJ//++4IUY5R/oJnyoaCgV9HgUESINnfuTyoCETQkEv/+OQSYPWtQkEQMCZSqCIEQ==",
+      "audio_data": "\u0007\ufffdÎ3\ufffd\ufffdd\ufffd\ufffd\ufffd\b\u001cX\u001f^\u001f\u0018\u001cF\u0004\u001e\ufffd\ufffd\ufffd.Z\u000f\ufffd;\u0013k\ufffd\ufffd`P\u0014\u0004\u0003\u0002\ufffdD\fNhѣl\u001fx\ufffd\u0010\u000418?\ufffd\u0007Nt\ufffd\ufffd_\ufffdr\ufffd\ufffd\ufffdw.\u000f\ufffd\ufffd\ufffd|\u0010\fJ\u0000\ufffd\ufffd \u0001\ufffd\ufffd\ufffdy\ufffd\ufffdxO\ufffd\u000f)\u0007\\\ufffd7Q`\ufffd\"\ufffdj\ufffd\u001a~\ufffdU3n/\ufffd&\ufffd\ufffd\n$&\u001b=\u0004pT{J\ufffd\u00196\u001e\ufffd&\ufffd\u007f\ufffd\u0014\ufffd\u000b\rb\u007f\ufffd\ufffd\ufffd!F9G\ufffd\t\ufffd*\u001a\n\u0005}\u001e\u0005\u0004H\ufffdg~\ufffd\ufffd\ufffd!\u0013BA/\ufffd\ufffd\ufffdI\ufffdֵ\t\u0004@\ufffd\ufffdJ\ufffd\ufffd\u0011",
       "crc_calculated": "e5b0",
       "header": {
         "bitrate": 64000,
@@ -372,7 +372,7 @@ mp3> .headers[0].flags.a = 1
       }
     },
     {
-      "audio_data": "<188>EUs2SgiDWMkg1ClSmMjI+ROAQCS8kSNCUFYNGBEDQd6wVWCsRHiwdgr6P4lOlXKBqDUqdWdiL/BXlj3Ev//xEkxBTUUzLjEwMKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo=",
+      "audio_data": "\u0011K6J\b\ufffdX\ufffd \ufffd)R\ufffd\ufffd\ufffd\ufffd\u0013\ufffd@$\ufffd\ufffd#BPV\r\u0018\u0011\u0003AްU`\ufffdDx\ufffdv\n\ufffd?\ufffdN\ufffdr\ufffd\ufffd5*ugb/\ufffdW\ufffd=Ŀ\ufffd\ufffd\u0012LAME3.100\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
       "crc_calculated": "61fd",
       "header": {
         "bitrate": 64000,
@@ -466,7 +466,7 @@ mp3> .headers[0].flags.a = 1
         }
       ],
       "magic": "ID3",
-      "padding": "<10>AAAAAAAAAAAAAA==",
+      "padding": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "revision": 0,
       "size": 35,
       "version": 4
@@ -480,7 +480,7 @@ mp3> .headers[0].flags.a |= empty
   "footers": [],
   "frames": [
     {
-      "audio_data": "<5>AAAAAAA=",
+      "audio_data": "\u0000\u0000\u0000\u0000\u0000",
       "crc_calculated": "827a",
       "header": {
         "bitrate": 56000,
@@ -674,7 +674,7 @@ mp3> .headers[0].flags.a |= empty
       }
     },
     {
-      "audio_data": "<187>B6rDjjOF02TxocEIHFgfXh8YHEYEHonlsy5aD6g7E2vw+GBQFAQDAoJEDE5o0aNsH3iAEAQxOD/BB050+c5fznL+7p93Lg+D4Ph8EAxKAMH9IAH///555554T7EPKQdc5TdRYNYihmqWGn6jVTNuL+Em0eAKJCYbPQRwVHtKrRk2Hogmi3/vFJwLDWJ//++4IUY5R/oJnyoaCgV9HgUESINnfuTyoCETQkEv/+OQSYPWtQkEQMCZSqCIEQ==",
+      "audio_data": "\u0007\ufffdÎ3\ufffd\ufffdd\ufffd\ufffd\ufffd\b\u001cX\u001f^\u001f\u0018\u001cF\u0004\u001e\ufffd\ufffd\ufffd.Z\u000f\ufffd;\u0013k\ufffd\ufffd`P\u0014\u0004\u0003\u0002\ufffdD\fNhѣl\u001fx\ufffd\u0010\u000418?\ufffd\u0007Nt\ufffd\ufffd_\ufffdr\ufffd\ufffd\ufffdw.\u000f\ufffd\ufffd\ufffd|\u0010\fJ\u0000\ufffd\ufffd \u0001\ufffd\ufffd\ufffdy\ufffd\ufffdxO\ufffd\u000f)\u0007\\\ufffd7Q`\ufffd\"\ufffdj\ufffd\u001a~\ufffdU3n/\ufffd&\ufffd\ufffd\n$&\u001b=\u0004pT{J\ufffd\u00196\u001e\ufffd&\ufffd\u007f\ufffd\u0014\ufffd\u000b\rb\u007f\ufffd\ufffd\ufffd!F9G\ufffd\t\ufffd*\u001a\n\u0005}\u001e\u0005\u0004H\ufffdg~\ufffd\ufffd\ufffd!\u0013BA/\ufffd\ufffd\ufffdI\ufffdֵ\t\u0004@\ufffd\ufffdJ\ufffd\ufffd\u0011",
       "crc_calculated": "e5b0",
       "header": {
         "bitrate": 64000,
@@ -739,7 +739,7 @@ mp3> .headers[0].flags.a |= empty
       }
     },
     {
-      "audio_data": "<188>EUs2SgiDWMkg1ClSmMjI+ROAQCS8kSNCUFYNGBEDQd6wVWCsRHiwdgr6P4lOlXKBqDUqdWdiL/BXlj3Ev//xEkxBTUUzLjEwMKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo=",
+      "audio_data": "\u0011K6J\b\ufffdX\ufffd \ufffd)R\ufffd\ufffd\ufffd\ufffd\u0013\ufffd@$\ufffd\ufffd#BPV\r\u0018\u0011\u0003AްU`\ufffdDx\ufffdv\n\ufffd?\ufffdN\ufffdr\ufffd\ufffd5*ugb/\ufffdW\ufffd=Ŀ\ufffd\ufffd\u0012LAME3.100\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
       "crc_calculated": "61fd",
       "header": {
         "bitrate": 64000,
@@ -832,7 +832,7 @@ mp3> .headers[0].flags.a |= empty
         }
       ],
       "magic": "ID3",
-      "padding": "<10>AAAAAAAAAAAAAA==",
+      "padding": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "revision": 0,
       "size": 35,
       "version": 4


### PR DESCRIPTION
I think this is more intuitive but might in some case cause very large JSON output but maybe that less common or expected. In does cases i think you either want to use some other bits_format (md5, truncate, etc) or you delete/transform the jq value before turn it into JSON.

Strings in gojq are binary safe so you can use to hold raw bytes. But note that convert the binary into JSON is lossy, same as the JSON standard.

Add bits_format option documentation.