### PR TITLE
gojq: Update rebased fq fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	// fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-	github.com/wader/gojq v0.12.1-0.20221119094510-72d27cb69e7b
+	github.com/wader/gojq v0.12.1-0.20221207144518-b419002080b5
 	// fork of github.com/chzyer/readline, see github.com/wader/readline fq branch
 	github.com/wader/readline v0.0.0-20220928125628-732951d41240
 )
@@ -74,7 +74,7 @@ require (
 )
 
 require (
-	github.com/itchyny/timefmt-go v0.1.4 // indirect
+	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	golang.org/x/sys v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/gomarkdown/markdown v0.0.0-20221013030248-663e2500819c h1:iyaGYbCmcYK
 github.com/gomarkdown/markdown v0.0.0-20221013030248-663e2500819c/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/gopacket/gopacket v0.1.0 h1:Gtjoa9MKRR/uBFHXDB8VxPkfk1fHOKhZcWLhUqb1lrg=
 github.com/gopacket/gopacket v0.1.0/go.mod h1:DlRRfaM/QjAu2ADqraIure1Eif0HpNL8hmyVQ+qci5Y=
-github.com/itchyny/timefmt-go v0.1.4 h1:hFEfWVdwsEi+CY8xY2FtgWHGQaBaC3JeHd+cve0ynVM=
-github.com/itchyny/timefmt-go v0.1.4/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
+github.com/itchyny/timefmt-go v0.1.5 h1:G0INE2la8S6ru/ZI5JecgyzbbJNs5lG1RcBqa7Jm6GE=
+github.com/itchyny/timefmt-go v0.1.5/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -23,8 +23,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/wader/gojq v0.12.1-0.20221119094510-72d27cb69e7b h1:+imkppSNy1IXch1Vd1iJBXSh1jdLS6gr8GHby8mLnLE=
-github.com/wader/gojq v0.12.1-0.20221119094510-72d27cb69e7b/go.mod h1:/+WKHSfP8sgyJDXeD9VjxlGjExGfjPUy0zm/Zy3Ind0=
+github.com/wader/gojq v0.12.1-0.20221207144518-b419002080b5 h1:5HluhYgupTaLHX14/hYvyoQ3iFgCrjL/4jbPhV8oEew=
+github.com/wader/gojq v0.12.1-0.20221207144518-b419002080b5/go.mod h1:jBlZvrM1MW7GZNy4VfEvMXo+If1HTuBp7W21XKe+ShQ=
 github.com/wader/readline v0.0.0-20220928125628-732951d41240 h1:fqNaldd6kVsMNGXLXH4TtB1kJtaPQOzGwqNYgswIM94=
 github.com/wader/readline v0.0.0-20220928125628-732951d41240/go.mod h1:Zgz8IJWvJoe7NK23CCPpC109XMCqJCpUhpHcnnA4XaM=
 golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=

--- a/pkg/interp/testdata/gojq.fqtest
+++ b/pkg/interp/testdata/gojq.fqtest
@@ -308,3 +308,6 @@ null> 0xf_0000_0000_0000_0000_0000_0000_0000_0000
 null> 0x012_3456789abcdefx
                          ^ unexpected token "x"
 null> ^D
+# test JQValue in assign/update path
+$ fq -c -d mp3 '.headers[0].version as $i | [] | .[$i] = 1 | .[$i] += 2' test.mp3
+[null,null,null,null,3]


### PR DESCRIPTION
Fix issue with JQValue:s in assig/update paths.

Rebase on upstream master, commits since last rebase:
```
c1a3ebd (tag: v0.12.10, origin/main) bump up version to 0.12.10
5294c9e update CHANGELOG.md for v0.12.10
319a797 update dependencies
20ca575 add notes on precedence of unary operators against variable binding
62ffdf7 fix break in try catch syntax
35c123b improve the order of test cases
fe0e20a improve performance of ascii_downcase, ascii_upcase functions
76648c7 improve match/2 to reduce syntax tree nodes just like splits/2
6a683bb improve the install targets in Makefile
6631dd3 escape the null character in csv, tsv, sh formats (close #200)
5253817 fix path value validation on getpath function (fix #198)
```