### PR TITLE
mp4: sgpd,sbgp: Change grouping_type to a string

### DIFF
--- a/format/mp4/boxes.go
+++ b/format/mp4/boxes.go
@@ -1317,7 +1317,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 	case "sgpd":
 		version := d.FieldU8("version")
 		d.FieldU24("flags")
-		d.FieldU32("grouping_type")
+		d.FieldUTF8("grouping_type", 4)
 		var defaultLength uint64
 		if version == 1 {
 			defaultLength = d.FieldU32("default_length")
@@ -1345,7 +1345,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 		version := d.FieldU8("version")
 		d.FieldU24("flags")
 
-		d.FieldU32("grouping_type")
+		d.FieldUTF8("grouping_type", 4)
 		if version == 1 {
 			d.FieldU32("grouping_type_parameter")
 		}

--- a/format/mp4/testdata/aac.fqtest
+++ b/format/mp4/testdata/aac.fqtest
@@ -299,7 +299,7 @@ $ fq -d mp4 dv aac.mp4
 0x500|                                       01      |             .  |                          version: 1 0x50d-0x50d.7 (1)
 0x500|                                          00 00|              ..|                          flags: 0 0x50e-0x510.7 (3)
 0x510|00                                             |.               |
-0x510|   72 6f 6c 6c                                 | roll           |                          grouping_type: 1919904876 0x511-0x514.7 (4)
+0x510|   72 6f 6c 6c                                 | roll           |                          grouping_type: "roll" 0x511-0x514.7 (4)
 0x510|               00 00 00 02                     |     ....       |                          default_length: 2 0x515-0x518.7 (4)
 0x510|                           00 00 00 01         |         ....   |                          entry_count: 1 0x519-0x51c.7 (4)
      |                                               |                |                          entries[0:1]: 0x51d-0x51e.7 (2)
@@ -310,7 +310,7 @@ $ fq -d mp4 dv aac.mp4
 0x520|         73 62 67 70                           |   sbgp         |                          type: "sbgp" (Sample to Group box) 0x523-0x526.7 (4)
 0x520|                     00                        |       .        |                          version: 0 0x527-0x527.7 (1)
 0x520|                        00 00 00               |        ...     |                          flags: 0 0x528-0x52a.7 (3)
-0x520|                                 72 6f 6c 6c   |           roll |                          grouping_type: 1919904876 0x52b-0x52e.7 (4)
+0x520|                                 72 6f 6c 6c   |           roll |                          grouping_type: "roll" 0x52b-0x52e.7 (4)
 0x520|                                             00|               .|                          entry_count: 1 0x52f-0x532.7 (4)
 0x530|00 00 01                                       |...             |
      |                                               |                |                          entries[0:1]: 0x533-0x53a.7 (8)

--- a/format/mp4/testdata/dash.fqtest
+++ b/format/mp4/testdata/dash.fqtest
@@ -290,7 +290,7 @@ $ fq -d mp4 dv dash_audio_init.mp4
 0x2b0|70 64                                          |pd              |
 0x2b0|      01                                       |  .             |                          version: 1 0x2b2-0x2b2.7 (1)
 0x2b0|         00 00 00                              |   ...          |                          flags: 0 0x2b3-0x2b5.7 (3)
-0x2b0|                  72 6f 6c 6c                  |      roll      |                          grouping_type: 1919904876 0x2b6-0x2b9.7 (4)
+0x2b0|                  72 6f 6c 6c                  |      roll      |                          grouping_type: "roll" 0x2b6-0x2b9.7 (4)
 0x2b0|                              00 00 00 02      |          ....  |                          default_length: 2 0x2ba-0x2bd.7 (4)
 0x2b0|                                          00 00|              ..|                          entry_count: 1 0x2be-0x2c1.7 (4)
 0x2c0|00 01                                          |..              |
@@ -468,7 +468,7 @@ $ fq -d mp4 dv dash_audio_1.m4s
 0x0d0|                                    73 62 67 70|            sbgp|              type: "sbgp" (Sample to Group box) 0xdc-0xdf.7 (4)
 0x0e0|00                                             |.               |              version: 0 0xe0-0xe0.7 (1)
 0x0e0|   00 00 00                                    | ...            |              flags: 0 0xe1-0xe3.7 (3)
-0x0e0|            72 6f 6c 6c                        |    roll        |              grouping_type: 1919904876 0xe4-0xe7.7 (4)
+0x0e0|            72 6f 6c 6c                        |    roll        |              grouping_type: "roll" 0xe4-0xe7.7 (4)
 0x0e0|                        00 00 00 01            |        ....    |              entry_count: 1 0xe8-0xeb.7 (4)
      |                                               |                |              entries[0:1]: 0xec-0xf3.7 (8)
      |                                               |                |                [0]{}: entry 0xec-0xf3.7 (8)


### PR DESCRIPTION
Is defined as int32 but is a string in practive it seems