### PR TITLE
decode: Support multiple format args and some rename and refactor

### DIFF
--- a/doc/presentations/bts2022/mp3.go
+++ b/doc/presentations/bts2022/mp3.go
@@ -1,4 +1,4 @@
-func decode(d *decode.D, _ any) any {
+func decode(d *decode.D) any {
 	d.FieldArray("headers", func(d *decode.D) {
 		for !d.End() {
 			d.TryFieldFormat("header", headerGroup)

--- a/format/ape/apev2.go
+++ b/format/ape/apev2.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func apev2Decode(d *decode.D, _ any) any {
+func apev2Decode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	headerFooterFn := func(d *decode.D, name string) uint64 {

--- a/format/apple/bookmark/apple_bookmark.go
+++ b/format/apple/bookmark/apple_bookmark.go
@@ -379,7 +379,7 @@ const headerEndBitPos = headerEnd * 8
 // all offsets are calculated relative to the end of the bookmark header
 func calcOffset(i uint64) int64 { return int64(8 * (i + headerEnd)) }
 
-func bookmarkDecode(d *decode.D, _ any) any {
+func bookmarkDecode(d *decode.D) any {
 	// all fields are little-endian with the exception of the Date datatype.
 	d.Endian = decode.LittleEndian
 

--- a/format/apple/bplist/bplist.go
+++ b/format/apple/bplist/bplist.go
@@ -227,7 +227,7 @@ type plist struct {
 	pld      apple.PosLoopDetector[uint64]
 }
 
-func bplistDecode(d *decode.D, _ any) any {
+func bplistDecode(d *decode.D) any {
 	d.FieldStruct("header", func(d *decode.D) {
 		d.FieldUTF8("magic", 6, d.StrAssert("bplist"))
 		d.FieldUTF8("version", 2, d.StrAssert("00"))

--- a/format/apple/macho/macho.go
+++ b/format/apple/macho/macho.go
@@ -364,7 +364,7 @@ var sectionTypes = scalar.UintMapSymStr{
 	0x15: "thread_local_init_function_pointers",
 }
 
-func machoDecode(d *decode.D, _ any) any {
+func machoDecode(d *decode.D) any {
 	var archBits int
 	var cpuType uint64
 	var ncmds uint64

--- a/format/apple/macho/macho_fat.go
+++ b/format/apple/macho/macho_fat.go
@@ -26,7 +26,7 @@ func init() {
 //nolint:revive
 const FAT_MAGIC = 0xcafe_babe
 
-func machoFatDecode(d *decode.D, _ any) any {
+func machoFatDecode(d *decode.D) any {
 	type ofile struct {
 		offset int64
 		size   int64

--- a/format/ar/ar.go
+++ b/format/ar/ar.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func decodeAr(d *decode.D, _ any) any {
+func decodeAr(d *decode.D) any {
 	d.FieldUTF8("signature", 8, d.StrAssert("!<arch>\n"))
 	d.FieldArray("files", func(d *decode.D) {
 		for !d.End() {

--- a/format/asn1/asn1_ber.go
+++ b/format/asn1/asn1_ber.go
@@ -413,7 +413,7 @@ func decodeASN1BERValue(d *decode.D, bib *bitio.Buffer, sb *strings.Builder, par
 	})
 }
 
-func decodeASN1BER(d *decode.D, _ any) any {
+func decodeASN1BER(d *decode.D) any {
 	decodeASN1BERValue(d, nil, nil, formConstructed, universalTypeSequence)
 	return nil
 }

--- a/format/av1/av1_ccr.go
+++ b/format/av1/av1_ccr.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func ccrDecode(d *decode.D, _ any) any {
+func ccrDecode(d *decode.D) any {
 	d.FieldU1("marker")
 	d.FieldU7("version")
 	d.FieldU3("seq_profile")

--- a/format/av1/av1_frame.go
+++ b/format/av1/av1_frame.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func frameDecode(d *decode.D, _ any) any {
+func frameDecode(d *decode.D) any {
 	for d.NotEnd() {
 		d.FieldFormat("obu", obuFormat, nil)
 	}

--- a/format/av1/av1_obu.go
+++ b/format/av1/av1_obu.go
@@ -40,7 +40,7 @@ var obuTypeNames = scalar.UintMapSymStr{
 	OBU_PADDING:                "OBU_PADDING",
 }
 
-func obuDecode(d *decode.D, _ any) any {
+func obuDecode(d *decode.D) any {
 	var obuType uint64
 	var obuSize int64
 	hasExtension := false

--- a/format/avro/avro_ocf.go
+++ b/format/avro/avro_ocf.go
@@ -128,7 +128,7 @@ func decodeBlockCodec(d *decode.D, dataSize int64, codec string) *bytes.Buffer {
 	return bb
 }
 
-func decodeAvroOCF(d *decode.D, _ any) any {
+func decodeAvroOCF(d *decode.D) any {
 	header := decodeHeader(d)
 
 	decodeFn, err := decoders.DecodeFnForSchema(header.Schema)

--- a/format/bencode/bencode.go
+++ b/format/bencode/bencode.go
@@ -91,7 +91,7 @@ func decodeBencodeValue(d *decode.D) {
 	}
 }
 
-func decodeBencode(d *decode.D, _ any) any {
+func decodeBencode(d *decode.D) any {
 	decodeBencodeValue(d)
 	return nil
 }

--- a/format/bitcoin/bitcoin_blkdat.go
+++ b/format/bitcoin/bitcoin_blkdat.go
@@ -22,7 +22,7 @@ func init() {
 	})
 }
 
-func decodeBlkDat(d *decode.D, in any) any {
+func decodeBlkDat(d *decode.D) any {
 	validBlocks := 0
 	for !d.End() {
 		d.FieldFormat("block", bitcoinBlockFormat, format.BitCoinBlockIn{HasHeader: true})

--- a/format/bitcoin/bitcoin_block.go
+++ b/format/bitcoin/bitcoin_block.go
@@ -22,7 +22,7 @@ func init() {
 			{Names: []string{format.BITCOIN_TRANSACTION}, Group: &bitcoinTranscationFormat},
 		},
 		DecodeFn: decodeBitcoinBlock,
-		DecodeInArg: format.BitCoinBlockIn{
+		DefaultInArg: format.BitCoinBlockIn{
 			HasHeader: false,
 		},
 	})
@@ -35,8 +35,10 @@ var rawHexReverse = scalar.BitBufFn(func(s scalar.BitBuf) (scalar.BitBuf, error)
 	})
 })
 
-func decodeBitcoinBlock(d *decode.D, in any) any {
-	bbi, _ := in.(format.BitCoinBlockIn)
+func decodeBitcoinBlock(d *decode.D) any {
+	var bbi format.BitCoinBlockIn
+	d.ArgAs(&bbi)
+
 	size := d.BitsLeft()
 
 	if bbi.HasHeader {

--- a/format/bitcoin/bitcoin_script.go
+++ b/format/bitcoin/bitcoin_script.go
@@ -43,7 +43,7 @@ func init() {
 	})
 }
 
-func decodeBitcoinScript(d *decode.D, in any) any {
+func decodeBitcoinScript(d *decode.D) any {
 	// based on https://en.bitcoin.it/wiki/Script
 	opcodeEntries := opcodeEntries{
 		{r: [2]byte{0x00, 0x00}, s: scalar.Uint{Sym: "false"}},

--- a/format/bitcoin/bitcoin_transaction.go
+++ b/format/bitcoin/bitcoin_transaction.go
@@ -44,7 +44,7 @@ func decodeVarInt(d *decode.D) uint64 {
 // all zero
 var txIDCoinbaseBytes = [32]byte{}
 
-func decodeBitcoinTranscation(d *decode.D, in any) any {
+func decodeBitcoinTranscation(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldU32("version")

--- a/format/bits/bits.go
+++ b/format/bits/bits.go
@@ -13,8 +13,8 @@ import (
 //go:embed bytes.md
 var bitsFS embed.FS
 
-func decodeBits(unit int) func(d *decode.D, _ any) any {
-	return func(d *decode.D, _ any) any {
+func decodeBits(unit int) func(d *decode.D) any {
+	return func(d *decode.D) any {
 		var s scalar.Any
 		b, _ := interp.NewBinaryFromBitReader(d.BitBufRange(0, d.Len()), unit, 0)
 		s.Actual = b

--- a/format/bson/bson.go
+++ b/format/bson/bson.go
@@ -111,7 +111,7 @@ func decodeBSONDocument(d *decode.D) {
 	})
 }
 
-func decodeBSON(d *decode.D, _ any) any {
+func decodeBSON(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	decodeBSONDocument(d)

--- a/format/bzip2/bzip2.go
+++ b/format/bzip2/bzip2.go
@@ -48,7 +48,7 @@ func (bfr bitFlipReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func bzip2Decode(d *decode.D, _ any) any {
+func bzip2Decode(d *decode.D) any {
 	// moreStreams := true
 
 	// d.FieldArray("streams", func(d *decode.D) {

--- a/format/cbor/cbor.go
+++ b/format/cbor/cbor.go
@@ -263,7 +263,7 @@ func decodeCBORValue(d *decode.D) any {
 	panic("unreachable")
 }
 
-func decodeCBOR(d *decode.D, _ any) any {
+func decodeCBOR(d *decode.D) any {
 	decodeCBORValue(d)
 	return nil
 }

--- a/format/csv/csv.go
+++ b/format/csv/csv.go
@@ -26,7 +26,7 @@ func init() {
 		Description: "Comma separated values",
 		ProbeOrder:  format.ProbeOrderTextFuzzy,
 		DecodeFn:    decodeCSV,
-		DecodeInArg: format.CSVLIn{
+		DefaultInArg: format.CSVLIn{
 			Comma:   ",",
 			Comment: "#",
 		},
@@ -36,8 +36,9 @@ func init() {
 	interp.RegisterFunc1("_to_csv", toCSV)
 }
 
-func decodeCSV(d *decode.D, in any) any {
-	ci, _ := in.(format.CSVLIn)
+func decodeCSV(d *decode.D) any {
+	var ci format.CSVLIn
+	d.ArgAs(&ci)
 
 	var rvs []any
 	br := d.RawLen(d.Len())

--- a/format/dns/dns.go
+++ b/format/dns/dns.go
@@ -261,9 +261,11 @@ func dnsDecode(d *decode.D, hasLengthHeader bool) any {
 	return nil
 }
 
-func dnsUDPDecode(d *decode.D, in any) any {
-	if upi, ok := in.(format.UDPPayloadIn); ok {
+func dnsUDPDecode(d *decode.D) any {
+	var upi format.UDPPayloadIn
+	if d.ArgAs(&upi) {
 		upi.MustIsPort(d.Fatalf, format.UDPPortDomain, format.UDPPortMDNS)
 	}
+
 	return dnsDecode(d, false)
 }

--- a/format/dns/dns_tcp.go
+++ b/format/dns/dns_tcp.go
@@ -15,8 +15,9 @@ func init() {
 	})
 }
 
-func dnsTCPDecode(d *decode.D, in any) any {
-	if tsi, ok := in.(format.TCPStreamIn); ok {
+func dnsTCPDecode(d *decode.D) any {
+	var tsi format.TCPStreamIn
+	if d.ArgAs(&tsi) {
 		tsi.MustIsPort(d.Fatalf, format.TCPPortDomain)
 	}
 	return dnsDecode(d, true)

--- a/format/elf/elf.go
+++ b/format/elf/elf.go
@@ -1100,7 +1100,7 @@ func elfDecodeSectionHeaders(d *decode.D, ec elfContext) {
 	}
 }
 
-func elfDecode(d *decode.D, _ any) any {
+func elfDecode(d *decode.D) any {
 	var ec elfContext
 
 	d.FieldStruct("header", func(d *decode.D) { elfDecodeHeader(d, &ec) })

--- a/format/fairplay/fairplay.go
+++ b/format/fairplay/fairplay.go
@@ -16,7 +16,7 @@ func init() {
 	})
 }
 
-func fairPlaySPCDecode(d *decode.D, _ any) any {
+func fairPlaySPCDecode(d *decode.D) any {
 	d.FieldU32("version")
 	d.FieldRawLen("reserved", 32)
 	d.FieldRawLen("iv", 16*8)

--- a/format/flac/flac.go
+++ b/format/flac/flac.go
@@ -32,7 +32,7 @@ func init() {
 	})
 }
 
-func flacDecode(d *decode.D, _ any) any {
+func flacDecode(d *decode.D) any {
 	d.FieldUTF8("magic", 4, d.StrAssert("fLaC"))
 
 	var streamInfo format.FlacStreamInfo

--- a/format/flac/flac_frame.go
+++ b/format/flac/flac_frame.go
@@ -17,7 +17,7 @@ func init() {
 		Name:        format.FLAC_FRAME,
 		Description: "FLAC frame",
 		DecodeFn:    frameDecode,
-		DecodeInArg: format.FlacFrameIn{
+		DefaultInArg: format.FlacFrameIn{
 			BitsPerSample: 16, // TODO: maybe should not have a default value?
 		},
 	})
@@ -100,7 +100,7 @@ func utf8Uint(d *decode.D) uint64 {
 }
 
 // in argument is an optional FlacFrameIn struct with stream info
-func frameDecode(d *decode.D, in any) any {
+func frameDecode(d *decode.D) any {
 	frameStart := d.Pos()
 	blockSize := 0
 	channelAssignment := uint64(0)
@@ -108,8 +108,8 @@ func frameDecode(d *decode.D, in any) any {
 	sampleSize := 0
 	sideChannelIndex := -1
 
-	ffi, ok := in.(format.FlacFrameIn)
-	if ok {
+	var ffi format.FlacFrameIn
+	if d.ArgAs(&ffi) {
 		sampleSize = ffi.BitsPerSample
 	}
 

--- a/format/flac/flac_metadatablock.go
+++ b/format/flac/flac_metadatablock.go
@@ -49,7 +49,7 @@ var metadataBlockNames = scalar.UintMapSymStr{
 	MetadataBlockPicture:       "picture",
 }
 
-func metadatablockDecode(d *decode.D, _ any) any {
+func metadatablockDecode(d *decode.D) any {
 	var hasStreamInfo bool
 	var streamInfo format.FlacStreamInfo
 

--- a/format/flac/flac_metadatablocks.go
+++ b/format/flac/flac_metadatablocks.go
@@ -23,7 +23,7 @@ func init() {
 	})
 }
 
-func metadatablocksDecode(d *decode.D, _ any) any {
+func metadatablocksDecode(d *decode.D) any {
 	flacMetadatablocksOut := format.FlacMetadatablocksOut{}
 
 	isLastBlock := false

--- a/format/flac/flac_picture.go
+++ b/format/flac/flac_picture.go
@@ -44,7 +44,7 @@ func init() {
 	})
 }
 
-func pictureDecode(d *decode.D, _ any) any {
+func pictureDecode(d *decode.D) any {
 	lenStr := func(name string) {
 		l := d.FieldU32(name + "_length")
 		d.FieldUTF8(name, int(l))

--- a/format/flac/flac_streaminfo.go
+++ b/format/flac/flac_streaminfo.go
@@ -15,7 +15,7 @@ func init() {
 	})
 }
 
-func streaminfoDecode(d *decode.D, _ any) any {
+func streaminfoDecode(d *decode.D) any {
 	d.FieldU16("minimum_block_size")
 	d.FieldU16("maximum_block_size")
 	d.FieldU24("minimum_frame_size")

--- a/format/flv/flv.go
+++ b/format/flv/flv.go
@@ -65,7 +65,7 @@ var typeNames = scalar.UintMapSymStr{
 	typeLongString:  "LongString",
 }
 
-func flvDecode(d *decode.D, _ any) any {
+func flvDecode(d *decode.D) any {
 	var fieldScriptDataObject func()
 	var fieldScriptDataVariable func(d *decode.D, name string)
 

--- a/format/gif/gif.go
+++ b/format/gif/gif.go
@@ -51,7 +51,7 @@ func fieldColorMap(d *decode.D, name string, bitDepth int) {
 	})
 }
 
-func gifDecode(d *decode.D, _ any) any {
+func gifDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldUTF8("header", 6, d.StrAssert("GIF87a", "GIF89a"))

--- a/format/gzip/gzip.go
+++ b/format/gzip/gzip.go
@@ -58,7 +58,7 @@ var deflateExtraFlagsNames = scalar.UintMapSymStr{
 	4: "fast",
 }
 
-func gzDecode(d *decode.D, _ any) any {
+func gzDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldRawLen("identification", 2*8, d.AssertBitBuf([]byte("\x1f\x8b")))

--- a/format/icc/icc_profile.go
+++ b/format/icc/icc_profile.go
@@ -81,7 +81,7 @@ func decodeBCDU8(d *decode.D) uint64 {
 	return (n>>4)*10 + n&0xf
 }
 
-func iccProfileDecode(d *decode.D, _ any) any {
+func iccProfileDecode(d *decode.D) any {
 	/*
 	   0..3 Profile size uInt32Number
 	   4..7 CMM Type signature see below

--- a/format/id3/id3v1.go
+++ b/format/id3/id3v1.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 // Decode ID3v1 tag
-func id3v1Decode(d *decode.D, _ any) any {
+func id3v1Decode(d *decode.D) any {
 	d.AssertAtLeastBitsLeft(128 * 8)
 	d.FieldUTF8("magic", 3, d.StrAssert("TAG"))
 	if d.PeekBits(8) == uint64('+') {

--- a/format/id3/id3v11.go
+++ b/format/id3/id3v11.go
@@ -15,7 +15,7 @@ func init() {
 	})
 }
 
-func id3v11Decode(d *decode.D, _ any) any {
+func id3v11Decode(d *decode.D) any {
 	d.AssertAtLeastBitsLeft(128 * 8)
 	d.FieldUTF8("magic", 4, d.StrAssert("TAG+"))
 	d.FieldUTF8("title", 60)

--- a/format/id3/id3v2.go
+++ b/format/id3/id3v2.go
@@ -565,7 +565,7 @@ func decodeFrame(d *decode.D, version int) uint64 {
 		// TODO: DecodeFn
 		// TODO: unknown after frame decode
 		unsyncedBR := d.NewBitBufFromReader(unsyncReader{Reader: bitio.NewIOReader(d.BitBufRange(d.Pos(), int64(dataSize)*8))})
-		d.FieldFormatBitBuf("unsync", unsyncedBR, decode.FormatFn(func(d *decode.D, _ any) any {
+		d.FieldFormatBitBuf("unsync", unsyncedBR, decode.FormatFn(func(d *decode.D) any {
 			if fn, ok := frames[idNormalized]; ok {
 				fn(d)
 			} else {
@@ -606,7 +606,7 @@ func decodeFrames(d *decode.D, version int, size uint64) {
 	}
 }
 
-func id3v2Decode(d *decode.D, _ any) any {
+func id3v2Decode(d *decode.D) any {
 	d.AssertAtLeastBitsLeft(4 * 8)
 	d.FieldUTF8("magic", 3, d.StrAssert("ID3"))
 	version := int(d.FieldU8("version"))

--- a/format/inet/bsd_loopback_frame.go
+++ b/format/inet/bsd_loopback_frame.go
@@ -38,8 +38,9 @@ var bsdLookbackNetworkLayerMap = scalar.UintMap{
 	bsdLoopbackNetworkLayerIPv6: {Sym: "ipv6", Description: `Internet protocol v6`},
 }
 
-func decodeLoopbackFrame(d *decode.D, in any) any {
-	if lfi, ok := in.(format.LinkFrameIn); ok {
+func decodeLoopbackFrame(d *decode.D) any {
+	var lfi format.LinkFrameIn
+	if d.ArgAs(&lfi) {
 		if lfi.Type != format.LinkTypeNULL {
 			d.Fatalf("wrong link type %d", lfi.Type)
 		}

--- a/format/inet/ether8023_frame.go
+++ b/format/inet/ether8023_frame.go
@@ -34,8 +34,9 @@ var mapUToEtherSym = scalar.UintFn(func(s scalar.Uint) (scalar.Uint, error) {
 	return s, nil
 })
 
-func decodeEthernetFrame(d *decode.D, in any) any {
-	if lfi, ok := in.(format.LinkFrameIn); ok {
+func decodeEthernetFrame(d *decode.D) any {
+	var lfi format.LinkFrameIn
+	if d.ArgAs(&lfi) {
 		if lfi.Type != format.LinkTypeETHERNET {
 			d.Fatalf("wrong link type %d", lfi.Type)
 		}

--- a/format/inet/icmp.go
+++ b/format/inet/icmp.go
@@ -92,8 +92,9 @@ var icmpCodeMapMap = map[uint64]scalar.UintMapDescription{
 	},
 }
 
-func decodeICMP(d *decode.D, in any) any {
-	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolICMP {
+func decodeICMP(d *decode.D) any {
+	var ipi format.IPPacketIn
+	if d.ArgAs(&ipi) && ipi.Protocol != format.IPv4ProtocolICMP {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}
 

--- a/format/inet/icmpv6.go
+++ b/format/inet/icmpv6.go
@@ -77,8 +77,9 @@ var icmpv6CodeMapMap = map[uint64]scalar.UintMapDescription{
 	},
 }
 
-func decodeICMPv6(d *decode.D, in any) any {
-	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolICMPv6 {
+func decodeICMPv6(d *decode.D) any {
+	var ipi format.IPPacketIn
+	if d.ArgAs(&ipi) && ipi.Protocol != format.IPv4ProtocolICMPv6 {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}
 

--- a/format/inet/ipv4_packet.go
+++ b/format/inet/ipv4_packet.go
@@ -49,8 +49,9 @@ var mapUToIPv4Sym = scalar.UintFn(func(s scalar.Uint) (scalar.Uint, error) {
 	return s, nil
 })
 
-func decodeIPv4(d *decode.D, in any) any {
-	if ipi, ok := in.(format.InetPacketIn); ok && ipi.EtherType != format.EtherTypeIPv4 {
+func decodeIPv4(d *decode.D) any {
+	var ipi format.InetPacketIn
+	if d.ArgAs(&ipi) && ipi.EtherType != format.EtherTypeIPv4 {
 		d.Fatalf("incorrect ethertype %d", ipi.EtherType)
 	}
 

--- a/format/inet/ipv6_packet.go
+++ b/format/inet/ipv6_packet.go
@@ -108,8 +108,9 @@ var mapUToIPv6Sym = scalar.BitBufFn(func(s scalar.BitBuf) (scalar.BitBuf, error)
 	return s, nil
 })
 
-func decodeIPv6(d *decode.D, in any) any {
-	if ipi, ok := in.(format.InetPacketIn); ok && ipi.EtherType != format.EtherTypeIPv6 {
+func decodeIPv6(d *decode.D) any {
+	var ipi format.InetPacketIn
+	if d.ArgAs(&ipi) && ipi.EtherType != format.EtherTypeIPv6 {
 		d.Fatalf("incorrect ethertype %d", ipi.EtherType)
 	}
 

--- a/format/inet/sll2_packet.go
+++ b/format/inet/sll2_packet.go
@@ -24,11 +24,10 @@ func init() {
 	})
 }
 
-func decodeSLL2(d *decode.D, in any) any {
-	if lfi, ok := in.(format.LinkFrameIn); ok {
-		if lfi.Type != format.LinkTypeLINUX_SLL2 {
-			d.Fatalf("wrong link type %d", lfi.Type)
-		}
+func decodeSLL2(d *decode.D) any {
+	var lfi format.LinkFrameIn
+	if d.ArgAs(&lfi) && lfi.Type != format.LinkTypeLINUX_SLL2 {
+		d.Fatalf("wrong link type %d", lfi.Type)
 	}
 
 	protcolType := d.FieldU16("protocol_type", format.EtherTypeMap, scalar.UintHex)

--- a/format/inet/sll_packet.go
+++ b/format/inet/sll_packet.go
@@ -108,11 +108,10 @@ var arpHdrTypeMAp = scalar.UintMap{
 	0xfffe:             {Sym: "none", Description: `zero header length`},
 }
 
-func decodeSLL(d *decode.D, in any) any {
-	if lfi, ok := in.(format.LinkFrameIn); ok {
-		if lfi.Type != format.LinkTypeLINUX_SLL {
-			d.Fatalf("wrong link type %d", lfi.Type)
-		}
+func decodeSLL(d *decode.D) any {
+	var lfi format.LinkFrameIn
+	if d.ArgAs(&lfi) && lfi.Type != format.LinkTypeLINUX_SLL {
+		d.Fatalf("wrong link type %d", lfi.Type)
 	}
 
 	d.FieldU16("packet_type", sllPacketTypeMap)

--- a/format/inet/tcp_segment.go
+++ b/format/inet/tcp_segment.go
@@ -38,8 +38,9 @@ var tcpOptionsMap = scalar.UintMap{
 	tcpOptionTimestamp:     {Sym: "timestamp", Description: "Timestamp and echo of previous timestamp"},
 }
 
-func decodeTCP(d *decode.D, in any) any {
-	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolTCP {
+func decodeTCP(d *decode.D) any {
+	var ipi format.IPPacketIn
+	if d.ArgAs(&ipi) && ipi.Protocol != format.IPv4ProtocolTCP {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}
 

--- a/format/inet/udp_datagram.go
+++ b/format/inet/udp_datagram.go
@@ -21,8 +21,9 @@ func init() {
 	})
 }
 
-func decodeUDP(d *decode.D, in any) any {
-	if ipi, ok := in.(format.IPPacketIn); ok && ipi.Protocol != format.IPv4ProtocolUDP {
+func decodeUDP(d *decode.D) any {
+	var ipi format.IPPacketIn
+	if d.ArgAs(&ipi) && ipi.Protocol != format.IPv4ProtocolUDP {
 		d.Fatalf("incorrect protocol %d", ipi.Protocol)
 	}
 

--- a/format/jpeg/jpeg.go
+++ b/format/jpeg/jpeg.go
@@ -164,7 +164,7 @@ var markers = scalar.UintMap{
 	TEM:   {Sym: "tem", Description: "For temporary private use in arithmetic coding"},
 }
 
-func jpegDecode(d *decode.D, _ any) any {
+func jpegDecode(d *decode.D) any {
 	d.AssertLeastBytesLeft(2)
 	if !bytes.Equal(d.PeekBytes(2), []byte{0xff, SOI}) {
 		d.Errorf("no SOI marker")

--- a/format/json/json.go
+++ b/format/json/json.go
@@ -79,7 +79,7 @@ func decodeJSONEx(d *decode.D, lines bool) any {
 	return nil
 }
 
-func decodeJSON(d *decode.D, _ any) any {
+func decodeJSON(d *decode.D) any {
 	return decodeJSONEx(d, false)
 }
 

--- a/format/json/jsonl.go
+++ b/format/json/jsonl.go
@@ -27,7 +27,7 @@ func init() {
 	interp.RegisterFunc0("to_jsonl", toJSONL)
 }
 
-func decodeJSONL(d *decode.D, _ any) any {
+func decodeJSONL(d *decode.D) any {
 	return decodeJSONEx(d, true)
 }
 

--- a/format/markdown/markdown.go
+++ b/format/markdown/markdown.go
@@ -28,7 +28,7 @@ func init() {
 	interp.RegisterFS(markdownFS)
 }
 
-func decodeMarkdown(d *decode.D, _ any) any {
+func decodeMarkdown(d *decode.D) any {
 	b, err := io.ReadAll(bitio.NewIOReader(d.RawLen(d.Len())))
 	if err != nil {
 		panic(err)

--- a/format/matroska/matroska.go
+++ b/format/matroska/matroska.go
@@ -56,7 +56,7 @@ func init() {
 		Description: "Matroska file",
 		Groups:      []string{format.PROBE},
 		DecodeFn:    matroskaDecode,
-		DecodeInArg: format.MatroskaIn{
+		DefaultInArg: format.MatroskaIn{
 			DecodeSamples: true,
 		},
 		Dependencies: []decode.Dependency{
@@ -440,8 +440,9 @@ func decodeMaster(d *decode.D, bitsLimit int64, elm *ebml.Master, unknownSize bo
 	})
 }
 
-func matroskaDecode(d *decode.D, in any) any {
-	mi, _ := in.(format.MatroskaIn)
+func matroskaDecode(d *decode.D) any {
+	var mi format.MatroskaIn
+	d.ArgAs(&mi)
 
 	ebmlHeaderID := uint64(0x1a45dfa3)
 	if d.PeekBits(32) != ebmlHeaderID {

--- a/format/mp3/mp3.go
+++ b/format/mp3/mp3.go
@@ -21,7 +21,7 @@ func init() {
 		Description: "MP3 file",
 		Groups:      []string{format.PROBE},
 		DecodeFn:    mp3Decode,
-		DecodeInArg: format.Mp3In{
+		DefaultInArg: format.Mp3In{
 			MaxUniqueHeaderConfigs: 5,
 			MaxUnknown:             50,
 			MaxSyncSeek:            4 * 1024 * 8,
@@ -41,8 +41,9 @@ func init() {
 	})
 }
 
-func mp3Decode(d *decode.D, in any) any {
-	mi, _ := in.(format.Mp3In)
+func mp3Decode(d *decode.D) any {
+	var mi format.Mp3In
+	d.ArgAs(&mi)
 
 	// things in a mp3 stream usually have few unique combinations of.
 	// does not include bitrate on purpose

--- a/format/mp3/mp3_tag_vbri.go
+++ b/format/mp3/mp3_tag_vbri.go
@@ -18,7 +18,7 @@ func init() {
 	})
 }
 
-func mp3FrameTagVBRIDecode(d *decode.D, _ any) any {
+func mp3FrameTagVBRIDecode(d *decode.D) any {
 	d.FieldUTF8("header", 4, d.StrAssert("VBRI"))
 	d.FieldU16("version_id")
 	d.FieldU16("delay")

--- a/format/mp3/mp3_tag_xing.go
+++ b/format/mp3/mp3_tag_xing.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func mp3FrameTagXingDecode(d *decode.D, _ any) any {
+func mp3FrameTagXingDecode(d *decode.D) any {
 	d.FieldUTF8("header", 4, d.StrAssert("Xing", "Info"))
 	qualityPresent := false
 	tocPresent := false

--- a/format/mp4/mp4.go
+++ b/format/mp4/mp4.go
@@ -63,7 +63,7 @@ func init() {
 			format.IMAGE, // avif
 		},
 		DecodeFn: mp4Decode,
-		DecodeInArg: format.Mp4In{
+		DefaultInArg: format.Mp4In{
 			DecodeSamples:  true,
 			AllowTruncated: false,
 		},
@@ -417,8 +417,9 @@ func mp4Tracks(d *decode.D, ctx *decodeContext) {
 	})
 }
 
-func mp4Decode(d *decode.D, in any) any {
-	mi, _ := in.(format.Mp4In)
+func mp4Decode(d *decode.D) any {
+	var mi format.Mp4In
+	d.ArgAs(&mi)
 
 	ctx := &decodeContext{
 		opts:   mi,

--- a/format/mp4/pssh_playready.go
+++ b/format/mp4/pssh_playready.go
@@ -25,7 +25,7 @@ var recordTypeNames = scalar.UintMapSymStr{
 	recordTypeLicenseStore:           "License store",
 }
 
-func playreadyPsshDecode(d *decode.D, _ any) any {
+func playreadyPsshDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldU32("size")

--- a/format/mpeg/aac_frame.go
+++ b/format/mpeg/aac_frame.go
@@ -18,7 +18,7 @@ func init() {
 		Name:        format.AAC_FRAME,
 		Description: "Advanced Audio Coding frame",
 		DecodeFn:    aacDecode,
-		DecodeInArg: format.AACFrameIn{
+		DefaultInArg: format.AACFrameIn{
 			ObjectType: format.MPEGAudioObjectTypeMain,
 		},
 		RootArray: true,
@@ -272,16 +272,14 @@ func aacFillElement(d *decode.D) {
 	})
 }
 
-func aacDecode(d *decode.D, in any) any {
-	var objectType int
-	if afi, ok := in.(format.AACFrameIn); ok {
-		objectType = afi.ObjectType
-	}
+func aacDecode(d *decode.D) any {
+	var ai format.AACFrameIn
+	d.ArgAs(&ai)
 
 	// TODO: seems tricky to know length of blocks
 	// TODO: currently break when length is unknown
 
-	switch objectType {
+	switch ai.ObjectType {
 	case format.MPEGAudioObjectTypeMain,
 		format.MPEGAudioObjectTypeLC,
 		format.MPEGAudioObjectTypeSSR,
@@ -299,7 +297,7 @@ func aacDecode(d *decode.D, in any) any {
 					aacFillElement(d)
 
 				case SCE:
-					aacSingleChannelElement(d, objectType)
+					aacSingleChannelElement(d, ai.ObjectType)
 					seenTerm = true
 
 				case PCE:

--- a/format/mpeg/adts.go
+++ b/format/mpeg/adts.go
@@ -22,7 +22,7 @@ func init() {
 	})
 }
 
-func adtsDecoder(d *decode.D, _ any) any {
+func adtsDecoder(d *decode.D) any {
 	validFrames := 0
 	for !d.End() {
 		if dv, _, _ := d.TryFieldFormat("frame", adtsFrame, nil); dv == nil {

--- a/format/mpeg/adts_frame.go
+++ b/format/mpeg/adts_frame.go
@@ -29,7 +29,7 @@ var protectionAbsentNames = scalar.BoolMapDescription{
 	false: "Has CRC",
 }
 
-func adtsFrameDecoder(d *decode.D, _ any) any {
+func adtsFrameDecoder(d *decode.D) any {
 
 	/*
 	   adts_frame() {

--- a/format/mpeg/annexb.go
+++ b/format/mpeg/annexb.go
@@ -22,7 +22,7 @@ func annexBDecodeStartCodeLen(v uint64) int64 {
 	}
 }
 
-func annexBDecode(d *decode.D, _ any, format decode.Group) any {
+func annexBDecode(d *decode.D, format decode.Group) any {
 	currentOffset, currentPrefixLen, err := annexBFindStartCode(d)
 	// TODO: really restrict to 0?
 	if err != nil || currentOffset != 0 {

--- a/format/mpeg/avc_annexb.go
+++ b/format/mpeg/avc_annexb.go
@@ -12,8 +12,8 @@ func init() {
 	interp.RegisterFormat(decode.Format{
 		Name:        format.AVC_ANNEXB,
 		Description: "H.264/AVC Annex B",
-		DecodeFn: func(d *decode.D, in any) any {
-			return annexBDecode(d, in, annexBAVCNALUFormat)
+		DecodeFn: func(d *decode.D) any {
+			return annexBDecode(d, annexBAVCNALUFormat)
 		},
 		RootArray: true,
 		RootName:  "stream",

--- a/format/mpeg/avc_au.go
+++ b/format/mpeg/avc_au.go
@@ -15,7 +15,7 @@ func init() {
 		Name:        format.AVC_AU,
 		Description: "H.264/AVC Access Unit",
 		DecodeFn:    avcAUDecode,
-		DecodeInArg: format.AvcAuIn{
+		DefaultInArg: format.AvcAuIn{
 			LengthSize: 0,
 		},
 		RootArray: true,
@@ -26,18 +26,19 @@ func init() {
 	})
 }
 
-func avcAUDecode(d *decode.D, in any) any {
-	avcIn, _ := in.(format.AvcAuIn)
+func avcAUDecode(d *decode.D) any {
+	var ai format.AvcAuIn
+	d.ArgAs(&ai)
 
-	if avcIn.LengthSize == 0 {
+	if ai.LengthSize == 0 {
 		// TODO: is annexb the correct name?
-		annexBDecode(d, nil, avcNALUFormat)
+		annexBDecode(d, avcNALUFormat)
 		return nil
 	}
 
 	for d.NotEnd() {
 		d.FieldStruct("nalu", func(d *decode.D) {
-			l := int64(d.FieldU("length", int(avcIn.LengthSize)*8)) * 8
+			l := int64(d.FieldU("length", int(ai.LengthSize)*8)) * 8
 			d.FieldFormatLen("nalu", l, avcNALUFormat, nil)
 		})
 	}

--- a/format/mpeg/avc_dcr.go
+++ b/format/mpeg/avc_dcr.go
@@ -116,7 +116,7 @@ func avcDcrParameterSet(d *decode.D, numParamSets uint64) {
 	}
 }
 
-func avcDcrDecode(d *decode.D, _ any) any {
+func avcDcrDecode(d *decode.D) any {
 	d.FieldU8("configuration_version")
 	d.FieldU8("profile_indication", avcProfileNames)
 	d.FieldU8("profile_compatibility")

--- a/format/mpeg/avc_nalu.go
+++ b/format/mpeg/avc_nalu.go
@@ -98,7 +98,7 @@ var sliceNames = scalar.UintMapSymStr{
 	9: "si",
 }
 
-func avcNALUDecode(d *decode.D, _ any) any {
+func avcNALUDecode(d *decode.D) any {
 	d.FieldBool("forbidden_zero_bit")
 	d.FieldU2("nal_ref_idc")
 	nalType := d.FieldU5("nal_unit_type", avcNALNames)

--- a/format/mpeg/avc_pps.go
+++ b/format/mpeg/avc_pps.go
@@ -20,7 +20,7 @@ func moreRBSPData(d *decode.D) bool {
 	return l >= 8 && d.PeekBits(8) != 0b1000_0000
 }
 
-func avcPPSDecode(d *decode.D, _ any) any {
+func avcPPSDecode(d *decode.D) any {
 	d.FieldUintFn("pic_parameter_set_id", uEV)
 	d.FieldUintFn("seq_parameter_set_id", uEV)
 	d.FieldBool("entropy_coding_mode_flag")

--- a/format/mpeg/avc_sei.go
+++ b/format/mpeg/avc_sei.go
@@ -101,7 +101,7 @@ func ffSum(d *decode.D) uint64 {
 	return s
 }
 
-func avcSEIDecode(d *decode.D, _ any) any {
+func avcSEIDecode(d *decode.D) any {
 	payloadType := d.FieldUintFn("payload_type", func(d *decode.D) uint64 { return ffSum(d) }, seiNames)
 	payloadSize := d.FieldUintFn("payload_size", func(d *decode.D) uint64 { return ffSum(d) })
 

--- a/format/mpeg/avc_sps.go
+++ b/format/mpeg/avc_sps.go
@@ -134,7 +134,7 @@ func avcHdrParameters(d *decode.D) {
 	d.FieldU5("time_offset_length")
 }
 
-func avcSPSDecode(d *decode.D, _ any) any {
+func avcSPSDecode(d *decode.D) any {
 	profileIdc := d.FieldU8("profile_idc", avcProfileNames)
 	d.FieldBool("constraint_set0_flag")
 	d.FieldBool("constraint_set1_flag")

--- a/format/mpeg/hevc_annexb.go
+++ b/format/mpeg/hevc_annexb.go
@@ -12,8 +12,8 @@ func init() {
 	interp.RegisterFormat(decode.Format{
 		Name:        format.HEVC_ANNEXB,
 		Description: "H.265/HEVC Annex B",
-		DecodeFn: func(d *decode.D, in any) any {
-			return annexBDecode(d, in, annexBHEVCNALUFormat)
+		DecodeFn: func(d *decode.D) any {
+			return annexBDecode(d, annexBHEVCNALUFormat)
 		},
 		RootArray: true,
 		RootName:  "stream",

--- a/format/mpeg/hevc_au.go
+++ b/format/mpeg/hevc_au.go
@@ -13,7 +13,7 @@ func init() {
 		Name:        format.HEVC_AU,
 		Description: "H.265/HEVC Access Unit",
 		DecodeFn:    hevcAUDecode,
-		DecodeInArg: format.HevcAuIn{
+		DefaultInArg: format.HevcAuIn{
 			LengthSize: 4,
 		},
 		RootArray: true,
@@ -25,18 +25,19 @@ func init() {
 }
 
 // TODO: share/refactor with avcAUDecode?
-func hevcAUDecode(d *decode.D, in any) any {
-	hevcIn, _ := in.(format.HevcAuIn)
+func hevcAUDecode(d *decode.D) any {
+	var hi format.HevcAuIn
+	d.ArgAs(&hi)
 
-	if hevcIn.LengthSize == 0 {
+	if hi.LengthSize == 0 {
 		// TODO: is annexb the correct name?
-		annexBDecode(d, nil, hevcAUNALFormat)
+		annexBDecode(d, hevcAUNALFormat)
 		return nil
 	}
 
 	for d.NotEnd() {
 		d.FieldStruct("nalu", func(d *decode.D) {
-			l := int64(d.FieldU("length", int(hevcIn.LengthSize)*8)) * 8
+			l := int64(d.FieldU("length", int(hi.LengthSize)*8)) * 8
 			d.FieldFormatLen("nalu", l, hevcAUNALFormat, nil)
 		})
 	}

--- a/format/mpeg/hevc_dcr.go
+++ b/format/mpeg/hevc_dcr.go
@@ -20,7 +20,7 @@ func init() {
 	})
 }
 
-func hevcDcrDecode(d *decode.D, _ any) any {
+func hevcDcrDecode(d *decode.D) any {
 	d.FieldU8("configuration_version")
 	d.FieldU2("general_profile_space")
 	d.FieldU1("general_tier_flag")

--- a/format/mpeg/hevc_nalu.go
+++ b/format/mpeg/hevc_nalu.go
@@ -82,7 +82,7 @@ var hevcNALNames = scalar.UintMapSymStr{
 	47:            "RSV_NVCL47",
 }
 
-func hevcNALUDecode(d *decode.D, _ any) any {
+func hevcNALUDecode(d *decode.D) any {
 	d.FieldBool("forbidden_zero_bit")
 	nalType := d.FieldU6("nal_unit_type", hevcNALNames)
 	d.FieldU6("nuh_layer_id")

--- a/format/mpeg/hevc_pps.go
+++ b/format/mpeg/hevc_pps.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 // H.265 page 36
-func hevcPPSDecode(d *decode.D, _ any) any {
+func hevcPPSDecode(d *decode.D) any {
 	d.FieldUintFn("pps_pic_parameter_set_id", uEV)
 	d.FieldUintFn("pps_seq_parameter_set_id", uEV)
 	d.FieldBool("dependent_slice_segments_enabled_flag")

--- a/format/mpeg/hevc_sps.go
+++ b/format/mpeg/hevc_sps.go
@@ -241,7 +241,7 @@ func hevcVuiParameters(d *decode.D, spsMaxSubLayersMinus1 uint64) {
 }
 
 // H.265 page 34
-func hevcSPSDecode(d *decode.D, _ any) any {
+func hevcSPSDecode(d *decode.D) any {
 	d.FieldU4("sps_video_parameter_set_id")
 	spsMaxSubLayersMinus1 := d.FieldU3("sps_max_sub_layers_minus1")
 	d.FieldBool("sps_temporal_id_nesting_flag")

--- a/format/mpeg/hevc_vps.go
+++ b/format/mpeg/hevc_vps.go
@@ -19,7 +19,7 @@ func init() {
 const maxVpsLayers = 1000
 
 // H.265 page 33
-func hevcVPSDecode(d *decode.D, _ any) any {
+func hevcVPSDecode(d *decode.D) any {
 	d.FieldU4("vps_video_parameter_set_id")
 	d.FieldBool("vps_base_layer_internal_flag")
 	d.FieldBool("vps_base_layer_available_flag")

--- a/format/mpeg/mp3_frame.go
+++ b/format/mpeg/mp3_frame.go
@@ -141,7 +141,7 @@ var protectionNames = scalar.BoolMapDescription{
 	false: "Has CRC",
 }
 
-func frameDecode(d *decode.D, _ any) any {
+func frameDecode(d *decode.D) any {
 	const headerBytes = 4
 	var sideInfoBytes int
 	var isStereo bool

--- a/format/mpeg/mpeg_asc.go
+++ b/format/mpeg/mpeg_asc.go
@@ -44,7 +44,7 @@ var channelConfigurationNames = scalar.UintMapDescription{
 	7: "front-center, front-left, front-right, side-left, side-right, back-left, back-right, LFE-channel",
 }
 
-func ascDecoder(d *decode.D, _ any) any {
+func ascDecoder(d *decode.D) any {
 	objectType := d.FieldUintFn("object_type", decodeEscapeValueCarryFn(5, 6, 0), format.MPEGAudioObjectTypeNames)
 	d.FieldUintFn("sampling_frequency", decodeEscapeValueAbsFn(4, 24, 0), frequencyIndexHzMap)
 	d.FieldU4("channel_configuration", channelConfigurationNames)

--- a/format/mpeg/mpeg_es.go
+++ b/format/mpeg/mpeg_es.go
@@ -277,7 +277,7 @@ func odDecodeTag(d *decode.D, edc *esDecodeContext, _ int, fn func(d *decode.D))
 	}
 }
 
-func esDecode(d *decode.D, _ any) any {
+func esDecode(d *decode.D) any {
 	var edc esDecodeContext
 	odDecodeTag(d, &edc, -1, nil)
 	return format.MpegEsOut{DecoderConfigs: edc.decoderConfigs}

--- a/format/mpeg/mpeg_pes.go
+++ b/format/mpeg/mpeg_pes.go
@@ -33,7 +33,7 @@ type subStream struct {
 	l int
 }
 
-func pesDecode(d *decode.D, _ any) any {
+func pesDecode(d *decode.D) any {
 	substreams := map[int]*subStream{}
 
 	prefix := d.PeekBits(24)

--- a/format/mpeg/mpeg_pes_packet.go
+++ b/format/mpeg/mpeg_pes_packet.go
@@ -69,7 +69,7 @@ var mpegVersion = scalar.UintMapDescription{
 	0b10: "MPEG1",
 }
 
-func pesPacketDecode(d *decode.D, _ any) any {
+func pesPacketDecode(d *decode.D) any {
 	var v any
 
 	d.FieldU24("prefix", d.UintAssert(0b0000_0000_0000_0000_0000_0001), scalar.UintBin)

--- a/format/mpeg/mpeg_spu.go
+++ b/format/mpeg/mpeg_spu.go
@@ -100,7 +100,7 @@ func decodeLines(d *decode.D, lines int, width int) []string {
 	return ls
 }
 
-func spuDecode(d *decode.D, _ any) any {
+func spuDecode(d *decode.D) any {
 	d.FieldU16("size")
 	dcsqtOffset := d.FieldU16("dcsqt_offset")
 

--- a/format/mpeg/mpeg_ts.go
+++ b/format/mpeg/mpeg_ts.go
@@ -19,7 +19,7 @@ func init() {
 
 // TODO: ts_packet
 
-func tsDecode(d *decode.D, _ any) any {
+func tsDecode(d *decode.D) any {
 	d.FieldU8("sync", d.UintAssert(0x47), scalar.UintHex)
 	d.FieldBool("transport_error_indicator")
 	d.FieldBool("payload_unit_start")

--- a/format/msgpack/msgpack.go
+++ b/format/msgpack/msgpack.go
@@ -154,7 +154,7 @@ func decodeMsgPackValue(d *decode.D) {
 	}
 }
 
-func decodeMsgPack(d *decode.D, _ any) any {
+func decodeMsgPack(d *decode.D) any {
 	decodeMsgPackValue(d)
 	return nil
 }

--- a/format/ogg/ogg.go
+++ b/format/ogg/ogg.go
@@ -57,7 +57,7 @@ type stream struct {
 	flacStreamInfo format.FlacStreamInfo
 }
 
-func decodeOgg(d *decode.D, _ any) any {
+func decodeOgg(d *decode.D) any {
 	validPages := 0
 	streams := map[uint32]*stream{}
 	streamsD := d.FieldArrayValue("streams")

--- a/format/ogg/ogg_page.go
+++ b/format/ogg/ogg_page.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func pageDecode(d *decode.D, _ any) any {
+func pageDecode(d *decode.D) any {
 	p := format.OggPageOut{}
 	startPos := d.Pos()
 

--- a/format/opus/opus_packet.go
+++ b/format/opus/opus_packet.go
@@ -23,7 +23,7 @@ func init() {
 	})
 }
 
-func opusDecode(d *decode.D, _ any) any {
+func opusDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	var prefix []byte

--- a/format/pcap/pcap.go
+++ b/format/pcap/pcap.go
@@ -53,7 +53,7 @@ func init() {
 	interp.RegisterFS(pcapFS)
 }
 
-func decodePcap(d *decode.D, _ any) any {
+func decodePcap(d *decode.D) any {
 	var endian decode.Endian
 	linkType := 0
 	timestampUNSStr := "ts_usec"

--- a/format/pcap/pcapng.go
+++ b/format/pcap/pcapng.go
@@ -361,7 +361,7 @@ type decodeContext struct {
 	flowDecoder        *flowsdecoder.Decoder
 }
 
-func decodePcapng(d *decode.D, _ any) any {
+func decodePcapng(d *decode.D) any {
 	sectionHeaders := 0
 	for !d.End() {
 		fd := flowsdecoder.New(flowsdecoder.DecoderOptions{CheckTCPOptions: false})

--- a/format/png/png.go
+++ b/format/png/png.go
@@ -77,7 +77,7 @@ var colorTypeMap = scalar.UintMapSymStr{
 	colorTypeRGBA:               "rgba",
 }
 
-func pngDecode(d *decode.D, _ any) any {
+func pngDecode(d *decode.D) any {
 	iEndFound := false
 	var colorType uint64
 
@@ -127,7 +127,7 @@ func pngDecode(d *decode.D, _ any) any {
 
 				switch compressionMethod {
 				case compressionDeflate:
-					d.FieldFormatReaderLen("uncompressed", dataLen, zlib.NewReader, decode.FormatFn(func(d *decode.D, _ any) any {
+					d.FieldFormatReaderLen("uncompressed", dataLen, zlib.NewReader, decode.FormatFn(func(d *decode.D) any {
 						d.FieldUTF8("text", int(d.BitsLeft()/8))
 						return nil
 					}))

--- a/format/prores/prores_frame.go
+++ b/format/prores/prores_frame.go
@@ -17,7 +17,7 @@ func init() {
 	})
 }
 
-func decodeProResFrame(d *decode.D, _ any) any {
+func decodeProResFrame(d *decode.D) any {
 	var size int64
 	d.FieldStruct("container", func(d *decode.D) {
 		size = int64(d.FieldU32("size"))

--- a/format/protobuf/protobuf.go
+++ b/format/protobuf/protobuf.go
@@ -128,14 +128,11 @@ func protobufDecodeFields(d *decode.D, pbm *format.ProtoBufMessage) {
 	})
 }
 
-func protobufDecode(d *decode.D, in any) any {
-	var pbm *format.ProtoBufMessage
-	pbi, ok := in.(format.ProtoBufIn)
-	if ok {
-		pbm = &pbi.Message
-	}
+func protobufDecode(d *decode.D) any {
+	var pbi format.ProtoBufIn
+	d.ArgAs(&pbi)
 
-	protobufDecodeFields(d, pbm)
+	protobufDecodeFields(d, &pbi.Message)
 
 	return nil
 }

--- a/format/protobuf/protobuf_widevine.go
+++ b/format/protobuf/protobuf_widevine.go
@@ -22,7 +22,7 @@ func init() {
 	})
 }
 
-func widevineDecode(d *decode.D, _ any) any {
+func widevineDecode(d *decode.D) any {
 	widewinePb := format.ProtoBufMessage{
 		1: {Type: format.ProtoBufTypeEnum, Name: "algorithm", Enums: scalar.UintMapSymStr{
 			0: "unencrypted",

--- a/format/riff/avi.go
+++ b/format/riff/avi.go
@@ -40,7 +40,7 @@ func init() {
 		Name:        format.AVI,
 		Description: "Audio Video Interleaved",
 		DecodeFn:    aviDecode,
-		DecodeInArg: format.AviIn{
+		DefaultInArg: format.AviIn{
 			DecodeSamples: true,
 		},
 		Dependencies: []decode.Dependency{
@@ -213,8 +213,9 @@ func aviDecodeChunkIndex(d *decode.D) []ranges.Range {
 	return rs
 }
 
-func aviDecode(d *decode.D, in any) any {
-	ai, _ := in.(format.AviIn)
+func aviDecode(d *decode.D) any {
+	var ai format.AviIn
+	d.ArgAs(&ai)
 
 	d.Endian = decode.LittleEndian
 

--- a/format/riff/wav.go
+++ b/format/riff/wav.go
@@ -47,7 +47,7 @@ var subFormatNames = scalar.RawBytesMap{
 	{Bytes: subFormatIEEEFloat[:], Scalar: scalar.BitBuf{Sym: "ieee_float"}},
 }
 
-func wavDecode(d *decode.D, _ any) any {
+func wavDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	// there are wav files in the wild with id3v2 header id3v1 footer

--- a/format/rtmp/amf0.go
+++ b/format/rtmp/amf0.go
@@ -144,7 +144,7 @@ func amf0DecodeValue(d *decode.D) {
 	}
 }
 
-func amf0Decode(d *decode.D, _ any) any {
+func amf0Decode(d *decode.D) any {
 	amf0DecodeValue(d)
 	return nil
 }

--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -307,9 +307,11 @@ func rtmpDecodeMessageType(d *decode.D, typ int, chunkSize *int) {
 	}
 }
 
-func rtmpDecode(d *decode.D, in any) any {
+func rtmpDecode(d *decode.D) any {
 	var isClient bool
-	if tsi, ok := in.(format.TCPStreamIn); ok {
+
+	var tsi format.TCPStreamIn
+	if d.ArgAs(&tsi) {
 		tsi.MustIsPort(d.Fatalf, format.TCPPortRTMP)
 		isClient = tsi.IsClient
 	}

--- a/format/tar/tar.go
+++ b/format/tar/tar.go
@@ -29,7 +29,7 @@ func init() {
 
 var unixTimeEpochDate = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-func tarDecode(d *decode.D, _ any) any {
+func tarDecode(d *decode.D) any {
 	const blockBytes = 512
 	const blockBits = blockBytes * 8
 

--- a/format/tiff/tiff.go
+++ b/format/tiff/tiff.go
@@ -201,7 +201,7 @@ func decodeIfd(d *decode.D, s *strips, tagNames scalar.UintMapSymStr) int64 {
 	return nextIfdOffset
 }
 
-func tiffDecode(d *decode.D, _ any) any {
+func tiffDecode(d *decode.D) any {
 	endian := d.FieldU32("endian", endianNames, scalar.UintHex)
 
 	switch endian {

--- a/format/toml/toml.go
+++ b/format/toml/toml.go
@@ -29,7 +29,7 @@ func init() {
 	interp.RegisterFunc0("to_toml", toTOML)
 }
 
-func decodeTOML(d *decode.D, _ any) any {
+func decodeTOML(d *decode.D) any {
 	br := d.RawLen(d.Len())
 	var r any
 

--- a/format/tzif/tzif.go
+++ b/format/tzif/tzif.go
@@ -23,7 +23,7 @@ func init() {
 	interp.RegisterFS(tzifFS)
 }
 
-func decodeTZIF(d *decode.D, _ any) any {
+func decodeTZIF(d *decode.D) any {
 	d.Endian = decode.BigEndian
 
 	v1h := decodeTZifHeader(d, "v1header")

--- a/format/vorbis/vorbis_comment.go
+++ b/format/vorbis/vorbis_comment.go
@@ -23,7 +23,7 @@ func init() {
 	})
 }
 
-func commentDecode(d *decode.D, _ any) any {
+func commentDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	vendorLen := d.FieldU32("vendor_length")

--- a/format/vorbis/vorbis_packet.go
+++ b/format/vorbis/vorbis_packet.go
@@ -38,7 +38,7 @@ var packetTypeNames = map[uint]string{
 	packetTypeSetup:          "Setup",
 }
 
-func vorbisDecode(d *decode.D, _ any) any {
+func vorbisDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	packetType := d.FieldScalarUintFn("packet_type", func(d *decode.D) scalar.Uint {

--- a/format/vpx/vp8_frame.go
+++ b/format/vpx/vp8_frame.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func vp8Decode(d *decode.D, _ any) any {
+func vp8Decode(d *decode.D) any {
 	var isKeyFrame bool
 
 	versions := map[uint64]struct {

--- a/format/vpx/vp9_cfm.go
+++ b/format/vpx/vp9_cfm.go
@@ -18,7 +18,7 @@ func init() {
 	})
 }
 
-func vp9CFMDecode(d *decode.D, _ any) any {
+func vp9CFMDecode(d *decode.D) any {
 	for d.NotEnd() {
 		d.FieldStruct("feature", func(d *decode.D) {
 			id := d.FieldU8("id", vp9FeatureIDNames)

--- a/format/vpx/vp9_frame.go
+++ b/format/vpx/vp9_frame.go
@@ -107,7 +107,7 @@ func vp9DecodeFrameSize(d *decode.D) {
 	d.FieldUintFn("frame_height", func(d *decode.D) uint64 { return d.U16() + 1 })
 }
 
-func vp9Decode(d *decode.D, _ any) any {
+func vp9Decode(d *decode.D) any {
 
 	// TODO: header_size at end? even for show_existing_frame?
 

--- a/format/vpx/vpx_ccr.go
+++ b/format/vpx/vpx_ccr.go
@@ -16,7 +16,7 @@ func init() {
 	})
 }
 
-func vpxCCRDecode(d *decode.D, _ any) any {
+func vpxCCRDecode(d *decode.D) any {
 	d.FieldU8("profile")
 	d.FieldU8("level", vpxLevelNames)
 	d.FieldU4("bit_depth")

--- a/format/wasm/wasm.go
+++ b/format/wasm/wasm.go
@@ -593,7 +593,7 @@ const (
 	opcodeIf    Opcode = 0x04
 )
 
-func decodeWASM(d *decode.D, _ any) any {
+func decodeWASM(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	// delayed initialization to break initialization reference cycle

--- a/format/webp/webp.go
+++ b/format/webp/webp.go
@@ -39,7 +39,7 @@ func decodeChunk(d *decode.D, expectedChunkID string, fn func(d *decode.D)) {
 	}
 }
 
-func webpDecode(d *decode.D, _ any) any {
+func webpDecode(d *decode.D) any {
 	d.Endian = decode.LittleEndian
 
 	d.FieldUTF8("riff_id", 4, d.StrAssert("RIFF"))

--- a/format/xml/html.go
+++ b/format/xml/html.go
@@ -21,7 +21,7 @@ func init() {
 		Name:        format.HTML,
 		Description: "HyperText Markup Language",
 		DecodeFn:    decodeHTML,
-		DecodeInArg: format.HTMLIn{
+		DefaultInArg: format.HTMLIn{
 			Seq:             false,
 			Array:           false,
 			AttributePrefix: "@",
@@ -192,8 +192,9 @@ func fromHTMLToArray(n *html.Node) any {
 	return f(n)
 }
 
-func decodeHTML(d *decode.D, in any) any {
-	hi, _ := in.(format.HTMLIn)
+func decodeHTML(d *decode.D) any {
+	var hi format.HTMLIn
+	d.ArgAs(&hi)
 
 	br := d.RawLen(d.Len())
 	var r any

--- a/format/xml/xml.go
+++ b/format/xml/xml.go
@@ -39,7 +39,7 @@ func init() {
 		ProbeOrder:  format.ProbeOrderTextFuzzy,
 		Groups:      []string{format.PROBE},
 		DecodeFn:    decodeXML,
-		DecodeInArg: format.XMLIn{
+		DefaultInArg: format.XMLIn{
 			Seq:             false,
 			Array:           false,
 			AttributePrefix: "@",
@@ -247,8 +247,9 @@ func fromXMLToArray(n xmlNode) any {
 	return f(n, nil)
 }
 
-func decodeXML(d *decode.D, in any) any {
-	xi, _ := in.(format.XMLIn)
+func decodeXML(d *decode.D) any {
+	var xi format.XMLIn
+	d.ArgAs(&xi)
 
 	br := d.RawLen(d.Len())
 	var r any

--- a/format/yaml/yaml.go
+++ b/format/yaml/yaml.go
@@ -32,7 +32,7 @@ func init() {
 	interp.RegisterFunc0("to_yaml", toYAML)
 }
 
-func decodeYAML(d *decode.D, _ any) any {
+func decodeYAML(d *decode.D) any {
 	br := d.RawLen(d.Len())
 	var r any
 

--- a/format/zip/zip.go
+++ b/format/zip/zip.go
@@ -26,7 +26,7 @@ func init() {
 		Description: "ZIP archive",
 		Groups:      []string{format.PROBE},
 		DecodeFn:    zipDecode,
-		DecodeInArg: format.ZipIn{
+		DefaultInArg: format.ZipIn{
 			Uncompress: true,
 		},
 		Dependencies: []decode.Dependency{
@@ -142,8 +142,9 @@ func fieldMSDOSDate(d *decode.D) {
 	d.FieldU5("day")
 }
 
-func zipDecode(d *decode.D, in any) any {
-	zi, _ := in.(format.ZipIn)
+func zipDecode(d *decode.D) any {
+	var zi format.ZipIn
+	d.ArgAs(&zi)
 
 	d.Endian = decode.LittleEndian
 

--- a/pkg/decode/format.go
+++ b/pkg/decode/format.go
@@ -12,9 +12,8 @@ type Format struct {
 	ProbeOrder         int // probe order is from low to hi value then by name
 	Description        string
 	Groups             []string
-	DecodeFn           func(d *D, _ any) any
-	DecodeInArg        any
-	DecodeOutType      any
+	DecodeFn           func(d *D) any
+	DefaultInArg       any
 	RootArray          bool
 	RootName           string
 	Dependencies       []Dependency
@@ -44,7 +43,7 @@ type FormatHelp struct {
 	References []HelpReference
 }
 
-func FormatFn(d func(d *D, _ any) any) Group {
+func FormatFn(d func(d *D) any) Group {
 	return Group{{
 		DecodeFn: d,
 	}}


### PR DESCRIPTION
This will allow passing both cli options and format options to sub decoder. Ex: pass keylog option to a tls decoder when decoding a pcap. Ex: pass decode options to a format inside a http body inside a pcap.

Add ArgAs method to lookup argument based on type. This also makes the format decode function have same signature as sub decoders in the decode API.

This change decode.Format a bit:
DecodeFn is now just func(d *D) any
DecodeInArg renamed to DefaultInArg