### PR TITLE
toml,xml: Fail fast on invalid content

### DIFF
--- a/format/toml/testdata/toml.fqtest
+++ b/format/toml/testdata/toml.fqtest
@@ -63,9 +63,9 @@ true = true
 toml: top-level values must be Go maps or structs
 ----
 
-error at position 0x0: root object has no values
+error at position 0x0: EOF
 ----
-$ fq -n '"" | from_toml'
+$ fq -n '" " | from_toml'
 exitcode: 5
 stderr:
-error: error at position 0x0: root object has no values
+error: error at position 0x1: root object has no values


### PR DESCRIPTION
encoding/xml and github.com/BurntSushi/toml both reads a lot before detecting that it can't decode. Now we instead read one UTF-8 and make sure it's valid xml or toml 

Should speed up probing

Relatd to #586 bigzero-zip.zip