### PR TITLE
interp: Fix input completion regression in sub-REPLs

### DIFF
--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -150,9 +150,11 @@ type Platform struct {
 	Arch string
 }
 
+type CompleteFn func(line string, pos int) (newLine []string, shared int)
+
 type ReadlineOpts struct {
 	Prompt     string
-	CompleteFn func(line string, pos int) (newLine []string, shared int)
+	CompleteFn CompleteFn
 }
 
 type OS interface {

--- a/pkg/interp/testdata/completion.fqtest
+++ b/pkg/interp/testdata/completion.fqtest
@@ -68,4 +68,8 @@ color
 colors
 compact
 completion_timeout
+mp3> .frames[0] | repl
+> .frames[0] mp3_frame> .he\t
+header
+> .frames[0] mp3_frame> ^D
 mp3> ^D


### PR DESCRIPTION
readline Config was used to pass completer function per readline call, was changed in #612 and caused regression. Now use our own member in stdOS to pass it instead.

Add a test but test script completer is implemented differently.