### PR TITLE
interp: Allow and convert JQValues:s (ex decode value) in function ar…

### DIFF
--- a/internal/gojqex/types.go
+++ b/internal/gojqex/types.go
@@ -124,22 +124,11 @@ func CastFn[T any](v any, structFn func(input any, result any) error) (T, bool) 
 	default:
 		ft := reflect.TypeOf(&t)
 		if ft.Elem().Kind() == reflect.Struct {
-			m := map[string]any{}
-			switch v := v.(type) {
-			case map[string]any:
-				m = v
-			case nil:
-				// nop use instantiated map
-			case gojq.JQValue:
-				if jm, ok := Cast[map[string]any](v.JQValueToGoJQ()); ok {
-					m = jm
-				} else {
-					return t, false
-				}
-			default:
+			// TODO: some way to allow decode value passthru?
+			m, ok := ToGoJQValue(v)
+			if !ok {
 				return t, false
 			}
-
 			if structFn == nil {
 				panic("structFn nil")
 			}

--- a/pkg/interp/testdata/value.fqtest
+++ b/pkg/interp/testdata/value.fqtest
@@ -262,4 +262,8 @@ mp3> .headers._index
 error: expected a extkey but got: _index
 mp3> ._index
 error: expected a extkey but got: _index
+mp3> .headers[0].header.version as $r | {a:12} | tojson({indent: $r}) | println
+{
+    "a": 12
+}
 mp3> ^D


### PR DESCRIPTION
…g objects

Before it failed when passing a decode value, like an integer, string etc, as a object value to an internal function (written in go), ex some_function({name: <decode value>}).

A future improvement could be to allow an internal function to say that it wants a "raw" decode value etc and not one converted to primitive type.