### PR TITLE
interp: Make tovalue output behave as jq value

### DIFF
--- a/pkg/interp/interp.jq
+++ b/pkg/interp/interp.jq
@@ -16,7 +16,8 @@ def display($opts):
   ( . as $c
   | options($opts) as $opts
   | try _todisplay catch $c
-  | if ($opts.value_output | not) and _can_display then _display($opts)
+  | if $opts.value_output then tovalue end
+  | if _can_display then _display($opts)
     else
       ( if _is_string and $opts.raw_string then print
         else _print_color_json($opts)

--- a/pkg/interp/testdata/tovalue.fqtest
+++ b/pkg/interp/testdata/tovalue.fqtest
@@ -1,4 +1,8 @@
 # TODO: use test format
+$ fq -i . test.mp3
+mp3> .headers[0] | tovalue.header.magic
+"ID3"
+mp3> ^D
 $ fq -i
 null> "aaa" | mp3_frame | .gap0 | tovalue, tovalue({sizebase: 2})
 "aaa"

--- a/pkg/interp/testdata/value_output.fqtest
+++ b/pkg/interp/testdata/value_output.fqtest
@@ -20,3 +20,7 @@ ID3
   "unused": 0
 }
 35
+$ fq -o bits_format=base64 -V '.frames[0].audio_data' test.mp3
+"AAAAAAA="
+$ fq -o bits_format=base64 -Vr '.frames[0].audio_data' test.mp3
+AAAAAAA=


### PR DESCRIPTION
Now ex "tovalue | .some.thing" on a decode value will make some.thing be jq value instead of a decode value which woud be displayed as a decode treee, seems confusing.

I think this is more intuetive and make more sense.