### PR TITLE
decode,interp: Refactor format groups into a proper struct

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,12 +10,7 @@
             "program": ".",
             "cwd": "${workspaceFolder}",
             "env": {},
-            "args": [
-                "-d",
-                "mp4",
-                ".",
-                "file"
-            ],
+            "args": [".", "doc/file.mp3"]
         }
     ]
 }

--- a/format/ape/apev2.go
+++ b/format/ape/apev2.go
@@ -8,17 +8,18 @@ import (
 	"github.com/wader/fq/pkg/interp"
 )
 
-var imageFormat decode.Group
+var imageGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.APEV2,
-		Description: "APEv2 metadata tag",
-		DecodeFn:    apev2Decode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.IMAGE}, Group: &imageFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Apev2,
+		&decode.Format{
+			Description: "APEv2 metadata tag",
+			DecodeFn:    apev2Decode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Image}, Out: &imageGroup},
+			},
+		})
 }
 
 func apev2Decode(d *decode.D) any {
@@ -59,7 +60,7 @@ func apev2Decode(d *decode.D) any {
 					d.FramedFn(int64(itemSize)*8, func(d *decode.D) {
 						d.FieldUTF8Null("filename")
 						// assume image if binary
-						d.FieldFormatOrRaw("value", imageFormat, nil)
+						d.FieldFormatOrRaw("value", &imageGroup, nil)
 					})
 				} else {
 					d.FieldUTF8("value", int(itemSize))

--- a/format/apple/bookmark/apple_bookmark.go
+++ b/format/apple/bookmark/apple_bookmark.go
@@ -15,14 +15,14 @@ import (
 var bookmarkFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.APPLE_BOOKMARK,
-		ProbeOrder:  format.ProbeOrderBinUnique,
-		Description: "Apple BookmarkData",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    bookmarkDecode,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(format.AppleBookmark,
+		&decode.Format{
+			ProbeOrder:  format.ProbeOrderBinUnique,
+			Description: "Apple BookmarkData",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    bookmarkDecode,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(bookmarkFS)
 }
 

--- a/format/apple/bplist/bplist.go
+++ b/format/apple/bplist/bplist.go
@@ -17,14 +17,15 @@ import (
 var bplistFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BPLIST,
-		ProbeOrder:  format.ProbeOrderBinUnique,
-		Description: "Apple Binary Property List",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    bplistDecode,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(
+		format.Bplist,
+		&decode.Format{
+			ProbeOrder:  format.ProbeOrderBinUnique,
+			Description: "Apple Binary Property List",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    bplistDecode,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(bplistFS)
 }
 

--- a/format/apple/macho/macho.go
+++ b/format/apple/macho/macho.go
@@ -18,12 +18,13 @@ import (
 var machoFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MACHO,
-		Description: "Mach-O macOS executable",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    machoDecode,
-	})
+	interp.RegisterFormat(
+		format.Macho,
+		&decode.Format{
+			Description: "Mach-O macOS executable",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    machoDecode,
+		})
 	interp.RegisterFS(machoFS)
 }
 

--- a/format/apple/macho/macho_fat.go
+++ b/format/apple/macho/macho_fat.go
@@ -12,15 +12,16 @@ import (
 var machoFormat decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MACHO_FAT,
-		Description: "Fat Mach-O macOS executable (multi-architecture)",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    machoFatDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.MACHO}, Group: &machoFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.MachoFat,
+		&decode.Format{
+			Description: "Fat Mach-O macOS executable (multi-architecture)",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    machoFatDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Macho}, Out: &machoFormat},
+			},
+		})
 }
 
 const FAT_MAGIC = 0xcafe_babe
@@ -55,7 +56,7 @@ func machoFatDecode(d *decode.D) any {
 	d.FieldArray("files", func(d *decode.D) {
 		for _, o := range ofiles {
 			d.RangeFn(o.offset*8, o.size*8, func(d *decode.D) {
-				d.FieldFormat("file", machoFormat, nil)
+				d.FieldFormat("file", &machoFormat, nil)
 			})
 		}
 	})

--- a/format/ar/ar.go
+++ b/format/ar/ar.go
@@ -7,18 +7,19 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var probeFormat decode.Group
+var probeGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AR,
-		Description: "Unix archive",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeAr,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.PROBE}, Group: &probeFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Ar,
+		&decode.Format{
+			Description: "Unix archive",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeAr,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Probe}, Out: &probeGroup},
+			},
+		})
 }
 
 func decodeAr(d *decode.D) any {
@@ -37,7 +38,7 @@ func decodeAr(d *decode.D) any {
 				}
 				size := int64(sizeStr.SymUint()) * 8
 				d.FieldUTF8("ending_characters", 2)
-				d.FieldFormatOrRawLen("data", size, probeFormat, nil)
+				d.FieldFormatOrRawLen("data", size, &probeGroup, nil)
 				padding := d.AlignBits(16)
 				if padding > 0 {
 					d.FieldRawLen("padding", int64(padding))

--- a/format/asn1/asn1_ber.go
+++ b/format/asn1/asn1_ber.go
@@ -33,12 +33,13 @@ import (
 var asn1FS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ASN1_BER,
-		Description: "ASN1 BER (basic encoding rules, also CER and DER)",
-		DecodeFn:    decodeASN1BER,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(
+		format.Asn1Ber,
+		&decode.Format{
+			Description: "ASN1 BER (basic encoding rules, also CER and DER)",
+			DecodeFn:    decodeASN1BER,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(asn1FS)
 }
 

--- a/format/av1/av1_ccr.go
+++ b/format/av1/av1_ccr.go
@@ -12,11 +12,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AV1_CCR,
-		Description: "AV1 Codec Configuration Record",
-		DecodeFn:    ccrDecode,
-	})
+	interp.RegisterFormat(
+		format.Av1Ccr,
+		&decode.Format{
+			Description: "AV1 Codec Configuration Record",
+			DecodeFn:    ccrDecode,
+		})
 }
 
 func ccrDecode(d *decode.D) any {

--- a/format/av1/av1_frame.go
+++ b/format/av1/av1_frame.go
@@ -10,24 +10,25 @@ import (
 	"github.com/wader/fq/pkg/interp"
 )
 
-var obuFormat decode.Group
+var av1FrameObuGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AV1_FRAME,
-		Description: "AV1 frame",
-		DecodeFn:    frameDecode,
-		RootArray:   true,
-		RootName:    "frame",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AV1_OBU}, Group: &obuFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Av1Frame,
+		&decode.Format{
+			Description: "AV1 frame",
+			DecodeFn:    frameDecode,
+			RootArray:   true,
+			RootName:    "frame",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Av1Obu}, Out: &av1FrameObuGroup},
+			},
+		})
 }
 
 func frameDecode(d *decode.D) any {
 	for d.NotEnd() {
-		d.FieldFormat("obu", obuFormat, nil)
+		d.FieldFormat("obu", &av1FrameObuGroup, nil)
 	}
 
 	return nil

--- a/format/av1/av1_obu.go
+++ b/format/av1/av1_obu.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AV1_OBU,
-		Description: "AV1 Open Bitstream Unit",
-		DecodeFn:    obuDecode,
-	})
+	interp.RegisterFormat(
+		format.Av1Obu,
+		&decode.Format{
+			Description: "AV1 Open Bitstream Unit",
+			DecodeFn:    obuDecode,
+		})
 }
 
 const (

--- a/format/avro/avro_ocf.go
+++ b/format/avro/avro_ocf.go
@@ -20,12 +20,13 @@ import (
 var avroOcfFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVRO_OCF,
-		Description: "Avro object container file",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeAvroOCF,
-	})
+	interp.RegisterFormat(
+		format.AvroOcf,
+		&decode.Format{
+			Description: "Avro object container file",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeAvroOCF,
+		})
 	interp.RegisterFS(avroOcfFS)
 }
 

--- a/format/bencode/bencode.go
+++ b/format/bencode/bencode.go
@@ -17,12 +17,13 @@ import (
 var bencodeFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BENCODE,
-		Description: "BitTorrent bencoding",
-		DecodeFn:    decodeBencode,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(
+		format.Bencode,
+		&decode.Format{
+			Description: "BitTorrent bencoding",
+			DecodeFn:    decodeBencode,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(bencodeFS)
 }
 

--- a/format/bitcoin/bitcoin_blkdat.go
+++ b/format/bitcoin/bitcoin_blkdat.go
@@ -6,26 +6,27 @@ import (
 	"github.com/wader/fq/pkg/interp"
 )
 
-var bitcoinBlockFormat decode.Group
+var bitcoinBlockGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BITCOIN_BLKDAT,
-		Description: "Bitcoin blk.dat",
-		Groups:      []string{format.PROBE},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.BITCOIN_BLOCK}, Group: &bitcoinBlockFormat},
-		},
-		DecodeFn:  decodeBlkDat,
-		RootArray: true,
-		RootName:  "blocks",
-	})
+	interp.RegisterFormat(
+		format.BitcoinBlkdat,
+		&decode.Format{
+			Description: "Bitcoin blk.dat",
+			Groups:      []*decode.Group{format.Probe},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.BitcoinBlock}, Out: &bitcoinBlockGroup},
+			},
+			DecodeFn:  decodeBlkDat,
+			RootArray: true,
+			RootName:  "blocks",
+		})
 }
 
 func decodeBlkDat(d *decode.D) any {
 	validBlocks := 0
 	for !d.End() {
-		d.FieldFormat("block", bitcoinBlockFormat, format.BitCoinBlockIn{HasHeader: true})
+		d.FieldFormat("block", &bitcoinBlockGroup, format.BitCoinBlockIn{HasHeader: true})
 		validBlocks++
 	}
 

--- a/format/bitcoin/bitcoin_block.go
+++ b/format/bitcoin/bitcoin_block.go
@@ -12,20 +12,21 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var bitcoinTranscationFormat decode.Group
+var bitcoinTranscationGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BITCOIN_BLOCK,
-		Description: "Bitcoin block",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.BITCOIN_TRANSACTION}, Group: &bitcoinTranscationFormat},
-		},
-		DecodeFn: decodeBitcoinBlock,
-		DefaultInArg: format.BitCoinBlockIn{
-			HasHeader: false,
-		},
-	})
+	interp.RegisterFormat(
+		format.BitcoinBlock,
+		&decode.Format{
+			Description: "Bitcoin block",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.BitcoinTransaction}, Out: &bitcoinTranscationGroup},
+			},
+			DecodeFn: decodeBitcoinBlock,
+			DefaultInArg: format.BitCoinBlockIn{
+				HasHeader: false,
+			},
+		})
 }
 
 var rawHexReverse = scalar.BitBufFn(func(s scalar.BitBuf) (scalar.BitBuf, error) {
@@ -78,7 +79,7 @@ func decodeBitcoinBlock(d *decode.D) any {
 		txCount := d.FieldUintFn("tx_count", decodeVarInt)
 		d.FieldArray("transactions", func(d *decode.D) {
 			for i := uint64(0); i < txCount; i++ {
-				d.FieldFormat("transaction", bitcoinTranscationFormat, nil)
+				d.FieldFormat("transaction", &bitcoinTranscationGroup, nil)
 			}
 		})
 	})

--- a/format/bitcoin/bitcoin_script.go
+++ b/format/bitcoin/bitcoin_script.go
@@ -34,13 +34,14 @@ func (ops opcodeEntries) MapUint(s scalar.Uint) (scalar.Uint, error) {
 }
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BITCOIN_SCRIPT,
-		Description: "Bitcoin script",
-		DecodeFn:    decodeBitcoinScript,
-		RootArray:   true,
-		RootName:    "opcodes",
-	})
+	interp.RegisterFormat(
+		format.BitcoinScript,
+		&decode.Format{
+			Description: "Bitcoin script",
+			DecodeFn:    decodeBitcoinScript,
+			RootArray:   true,
+			RootName:    "opcodes",
+		})
 }
 
 func decodeBitcoinScript(d *decode.D) any {

--- a/format/bitcoin/bitcoin_transaction.go
+++ b/format/bitcoin/bitcoin_transaction.go
@@ -11,17 +11,18 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var bitcoinScriptFormat decode.Group
+var bitcoinScriptGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BITCOIN_TRANSACTION,
-		Description: "Bitcoin transaction",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.BITCOIN_SCRIPT}, Group: &bitcoinScriptFormat},
-		},
-		DecodeFn: decodeBitcoinTranscation,
-	})
+	interp.RegisterFormat(
+		format.BitcoinTransaction,
+		&decode.Format{
+			Description: "Bitcoin transaction",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.BitcoinScript}, Out: &bitcoinScriptGroup},
+			},
+			DecodeFn: decodeBitcoinTranscation,
+		})
 }
 
 // Prefix with fd, and the next 2 bytes is the VarInt (in little-endian).
@@ -63,7 +64,7 @@ func decodeBitcoinTranscation(d *decode.D) any {
 				}, rawHexReverse)
 				d.FieldU32("vout")
 				scriptSigSize := d.FieldUintFn("scriptsig_size", decodeVarInt)
-				d.FieldFormatOrRawLen("scriptsig", int64(scriptSigSize)*8, bitcoinScriptFormat, nil)
+				d.FieldFormatOrRawLen("scriptsig", int64(scriptSigSize)*8, &bitcoinScriptGroup, nil)
 				// TODO: better way to know if there should be a valid script
 				d.FieldU32("sequence", scalar.UintHex)
 			})
@@ -76,7 +77,7 @@ func decodeBitcoinTranscation(d *decode.D) any {
 				d.FieldU64("value")
 				scriptSigSize := d.FieldUintFn("scriptpub_size", decodeVarInt)
 				// TODO: better way to know if there should be a valid script
-				d.FieldFormatOrRawLen("scriptpub", int64(scriptSigSize)*8, bitcoinScriptFormat, nil)
+				d.FieldFormatOrRawLen("scriptpub", int64(scriptSigSize)*8, &bitcoinScriptGroup, nil)
 			})
 		}
 	})

--- a/format/bits/bits.go
+++ b/format/bits/bits.go
@@ -25,17 +25,19 @@ func decodeBits(unit int) func(d *decode.D) any {
 }
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:               format.BITS,
-		Description:        "Raw bits",
-		DecodeFn:           decodeBits(1),
-		SkipDecodeFunction: true, // skip add bits and frombits function
-	})
-	interp.RegisterFormat(decode.Format{
-		Name:               format.BYTES,
-		Description:        "Raw bytes",
-		DecodeFn:           decodeBits(8),
-		SkipDecodeFunction: true, // skip add bytes and frombytes function
-	})
+	interp.RegisterFormat(
+		format.Bits,
+		&decode.Format{
+			Description:        "Raw bits",
+			DecodeFn:           decodeBits(1),
+			SkipDecodeFunction: true, // skip add bits and frombits function
+		})
+	interp.RegisterFormat(
+		format.Bytes,
+		&decode.Format{
+			Description:        "Raw bytes",
+			DecodeFn:           decodeBits(8),
+			SkipDecodeFunction: true, // skip add bytes and frombytes function
+		})
 	interp.RegisterFS(bitsFS)
 }

--- a/format/bson/bson.go
+++ b/format/bson/bson.go
@@ -17,12 +17,13 @@ import (
 var bsonFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BSON,
-		Description: "Binary JSON",
-		DecodeFn:    decodeBSON,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(
+		format.Bson,
+		&decode.Format{
+			Description: "Binary JSON",
+			DecodeFn:    decodeBSON,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(bsonFS)
 }
 

--- a/format/bzip2/bzip2.go
+++ b/format/bzip2/bzip2.go
@@ -22,15 +22,16 @@ import (
 var probeGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BZIP2,
-		Description: "bzip2 compression",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    bzip2Decode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.PROBE}, Group: &probeGroup},
-		},
-	})
+	interp.RegisterFormat(
+		format.Bzip2,
+		&decode.Format{
+			Description: "bzip2 compression",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    bzip2Decode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Probe}, Out: &probeGroup},
+			},
+		})
 }
 
 const blockMagic = 0x31_41_59_26_53_59
@@ -109,7 +110,8 @@ func bzip2Decode(d *decode.D) any {
 
 	compressedStart := d.Pos()
 
-	readCompressedSize, uncompressedBR, dv, _, _ := d.TryFieldReaderRangeFormat("uncompressed", 0, d.Len(), bzip2.NewReader, probeGroup, nil)
+	readCompressedSize, uncompressedBR, dv, _, _ :=
+		d.TryFieldReaderRangeFormat("uncompressed", 0, d.Len(), bzip2.NewReader, &probeGroup, nil)
 	if uncompressedBR != nil {
 		if dv == nil {
 			d.FieldRootBitBuf("uncompressed", uncompressedBR)

--- a/format/cbor/cbor.go
+++ b/format/cbor/cbor.go
@@ -25,12 +25,13 @@ import (
 var cborFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.CBOR,
-		Description: "Concise Binary Object Representation",
-		DecodeFn:    decodeCBOR,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(
+		format.Cbor,
+		&decode.Format{
+			Description: "Concise Binary Object Representation",
+			DecodeFn:    decodeCBOR,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(cborFS)
 }
 

--- a/format/csv/csv.go
+++ b/format/csv/csv.go
@@ -21,17 +21,18 @@ import (
 var csvFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.CSV,
-		Description: "Comma separated values",
-		ProbeOrder:  format.ProbeOrderTextFuzzy,
-		DecodeFn:    decodeCSV,
-		DefaultInArg: format.CSVLIn{
-			Comma:   ",",
-			Comment: "#",
-		},
-		Functions: []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Csv,
+		&decode.Format{
+			Description: "Comma separated values",
+			ProbeOrder:  format.ProbeOrderTextFuzzy,
+			DecodeFn:    decodeCSV,
+			DefaultInArg: format.CSVLIn{
+				Comma:   ",",
+				Comment: "#",
+			},
+			Functions: []string{"_todisplay"},
+		})
 	interp.RegisterFS(csvFS)
 	interp.RegisterFunc1("_to_csv", toCSV)
 }

--- a/format/dns/dns.go
+++ b/format/dns/dns.go
@@ -14,12 +14,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.DNS,
-		Description: "DNS packet",
-		Groups:      []string{format.UDP_PAYLOAD},
-		DecodeFn:    dnsUDPDecode,
-	})
+	interp.RegisterFormat(
+		format.Dns,
+		&decode.Format{
+			Description: "DNS packet",
+			Groups:      []*decode.Group{format.UdpPayload},
+			DecodeFn:    dnsUDPDecode,
+		})
 }
 
 const (

--- a/format/dns/dns_tcp.go
+++ b/format/dns/dns_tcp.go
@@ -7,12 +7,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.DNS_TCP,
-		Description: "DNS packet (TCP)",
-		Groups:      []string{format.TCP_STREAM},
-		DecodeFn:    dnsTCPDecode,
-	})
+	interp.RegisterFormat(
+		format.DnsTcp,
+		&decode.Format{
+			Description: "DNS packet (TCP)",
+			Groups:      []*decode.Group{format.TcpStream},
+			DecodeFn:    dnsTCPDecode,
+		})
 }
 
 func dnsTCPDecode(d *decode.D) any {

--- a/format/elf/elf.go
+++ b/format/elf/elf.go
@@ -17,12 +17,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ELF,
-		Description: "Executable and Linkable Format",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    elfDecode,
-	})
+	interp.RegisterFormat(
+		format.Elf,
+		&decode.Format{
+			Description: "Executable and Linkable Format",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    elfDecode,
+		})
 }
 
 const (

--- a/format/fairplay/fairplay.go
+++ b/format/fairplay/fairplay.go
@@ -9,11 +9,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.FAIRPLAY_SPC,
-		Description: "FairPlay Server Playback Context",
-		DecodeFn:    fairPlaySPCDecode,
-	})
+	interp.RegisterFormat(
+		format.FairplaySpc,
+		&decode.Format{
+			Description: "FairPlay Server Playback Context",
+			DecodeFn:    fairPlaySPCDecode,
+		})
 }
 
 func fairPlaySPCDecode(d *decode.D) any {

--- a/format/flac/flac_frame.go
+++ b/format/flac/flac_frame.go
@@ -13,14 +13,15 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.FLAC_FRAME,
-		Description: "FLAC frame",
-		DecodeFn:    frameDecode,
-		DefaultInArg: format.FlacFrameIn{
-			BitsPerSample: 16, // TODO: maybe should not have a default value?
-		},
-	})
+	interp.RegisterFormat(
+		format.FlacFrame,
+		&decode.Format{
+			Description: "FLAC frame",
+			DecodeFn:    frameDecode,
+			DefaultInArg: format.FlacFrameIn{
+				BitsPerSample: 16, // TODO: maybe should not have a default value?
+			},
+		})
 }
 
 const (

--- a/format/flac/flac_metadatablocks.go
+++ b/format/flac/flac_metadatablocks.go
@@ -8,19 +8,20 @@ import (
 	"github.com/wader/fq/pkg/interp"
 )
 
-var flacMetadatablockFormat decode.Group
+var flacMetadatablockGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.FLAC_METADATABLOCKS,
-		Description: "FLAC metadatablocks",
-		DecodeFn:    metadatablocksDecode,
-		RootArray:   true,
-		RootName:    "metadatablocks",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.FLAC_METADATABLOCK}, Group: &flacMetadatablockFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.FlacMetadatablocks,
+		&decode.Format{
+			Description: "FLAC metadatablocks",
+			DecodeFn:    metadatablocksDecode,
+			RootArray:   true,
+			RootName:    "metadatablocks",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.FlacMetadatablock}, Out: &flacMetadatablockGroup},
+			},
+		})
 }
 
 func metadatablocksDecode(d *decode.D) any {
@@ -28,7 +29,7 @@ func metadatablocksDecode(d *decode.D) any {
 
 	isLastBlock := false
 	for !isLastBlock {
-		_, v := d.FieldFormat("metadatablock", flacMetadatablockFormat, nil)
+		_, v := d.FieldFormat("metadatablock", &flacMetadatablockGroup, nil)
 		flacMetadatablockOut, ok := v.(format.FlacMetadatablockOut)
 		if !ok {
 			panic(fmt.Sprintf("expected FlacMetadatablocksOut, got %#+v", flacMetadatablockOut))

--- a/format/flac/flac_picture.go
+++ b/format/flac/flac_picture.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var images decode.Group
+var imageGroup decode.Group
 
 var pictureTypeNames = scalar.UintMapSymStr{
 	0:  "Other",
@@ -34,14 +34,15 @@ var pictureTypeNames = scalar.UintMapSymStr{
 }
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.FLAC_PICTURE,
-		Description: "FLAC metadatablock picture",
-		DecodeFn:    pictureDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.IMAGE}, Group: &images},
-		},
-	})
+	interp.RegisterFormat(
+		format.FlacPicture,
+		&decode.Format{
+			Description: "FLAC metadatablock picture",
+			DecodeFn:    pictureDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Image}, Out: &imageGroup},
+			},
+		})
 }
 
 func pictureDecode(d *decode.D) any {
@@ -57,7 +58,7 @@ func pictureDecode(d *decode.D) any {
 	d.FieldU32("color_depth")
 	d.FieldU32("number_of_index_colors")
 	pictureLen := d.FieldU32("picture_length")
-	d.FieldFormatOrRawLen("picture_data", int64(pictureLen)*8, images, nil)
+	d.FieldFormatOrRawLen("picture_data", int64(pictureLen)*8, &imageGroup, nil)
 
 	return nil
 }

--- a/format/flac/flac_streaminfo.go
+++ b/format/flac/flac_streaminfo.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.FLAC_STREAMINFO,
-		Description: "FLAC streaminfo",
-		DecodeFn:    streaminfoDecode,
-	})
+	interp.RegisterFormat(
+		format.FlacStreaminfo,
+		&decode.Format{
+			Description: "FLAC streaminfo",
+			DecodeFn:    streaminfoDecode,
+		})
 }
 
 func streaminfoDecode(d *decode.D) any {

--- a/format/flv/flv.go
+++ b/format/flv/flv.go
@@ -13,10 +13,10 @@ import (
 )
 
 func init() {
-	registry.MustRegister(decode.Format{
+	registry.MustRegister(&decode.Format{
 		Name:        format.FLV,
 		Description: "Flash video",
-		Groups:      []string{format.PROBE},
+		Groups:      []*decode.Group{format.Probe},
 		DecodeFn:    flvDecode,
 	})
 }

--- a/format/format.go
+++ b/format/format.go
@@ -1,5 +1,7 @@
 package format
 
+import "github.com/wader/fq/pkg/decode"
+
 // TODO: do before-format somehow and topology sort?
 const (
 	ProbeOrderBinUnique = 0   // binary with unlikely overlap
@@ -8,140 +10,162 @@ const (
 	ProbeOrderTextFuzzy = 300 // text with possible overlap
 )
 
-// TODO: change to CamelCase?
-const (
-	ALL = "all"
+// TODO: move to group package somehow?
 
-	IMAGE          = "image"
-	PROBE          = "probe"
-	LINK_FRAME     = "link_frame"  // ex: ethernet
-	INET_PACKET    = "inet_packet" // ex: ipv4
-	IP_PACKET      = "ip_packet"   // ex: tcp
-	TCP_STREAM     = "tcp_stream"  // ex: http
-	UDP_PAYLOAD    = "udp_payload" // ex: dns
-	MP3_FRAME_TAGS = "mp3_frame_tags"
+var (
+	All = &decode.Group{Name: "all"}
 
-	BYTES = "bytes"
-	BITS  = "bits"
+	Image        = &decode.Group{Name: "image"}
+	Probe        = &decode.Group{Name: "probe"}
+	LinkFrame    = &decode.Group{Name: "link_frame", DefaultInArg: LinkFrameIn{}}   // ex: ethernet
+	InetPacket   = &decode.Group{Name: "inet_packet", DefaultInArg: InetPacketIn{}} // ex: ipv4
+	IpPacket     = &decode.Group{Name: "ip_packet", DefaultInArg: InetPacketIn{}}   // ex: tcp
+	TcpStream    = &decode.Group{Name: "tcp_stream", DefaultInArg: TCPStreamIn{}}   // ex: http
+	UdpPayload   = &decode.Group{Name: "udp_payload", DefaultInArg: UDPPayloadIn{}} // ex: dns
+	Mp3FrameTags = &decode.Group{Name: "mp3_frame_tags"}
 
-	AAC_FRAME           = "aac_frame"
-	ADTS                = "adts"
-	ADTS_FRAME          = "adts_frame"
-	AIFF                = "aiff"
-	AMF0                = "amf0"
-	APEV2               = "apev2"
-	APPLE_BOOKMARK      = "apple_bookmark"
-	AR                  = "ar"
-	ASN1_BER            = "asn1_ber"
-	AV1_CCR             = "av1_ccr"
-	AV1_FRAME           = "av1_frame"
-	AV1_OBU             = "av1_obu"
-	AVC_ANNEXB          = "avc_annexb"
-	AVC_AU              = "avc_au"
-	AVC_DCR             = "avc_dcr"
-	AVC_NALU            = "avc_nalu"
-	AVC_PPS             = "avc_pps"
-	AVC_SEI             = "avc_sei"
-	AVC_SPS             = "avc_sps"
-	AVI                 = "avi"
-	AVRO_OCF            = "avro_ocf"
-	BENCODE             = "bencode"
-	BITCOIN_BLKDAT      = "bitcoin_blkdat"
-	BITCOIN_BLOCK       = "bitcoin_block"
-	BITCOIN_SCRIPT      = "bitcoin_script"
-	BITCOIN_TRANSACTION = "bitcoin_transaction"
-	BPLIST              = "bplist"
-	BSD_LOOPBACK_FRAME  = "bsd_loopback_frame"
-	BSON                = "bson"
-	BZIP2               = "bzip2"
-	CBOR                = "cbor"
-	CSV                 = "csv"
-	DNS                 = "dns"
-	DNS_TCP             = "dns_tcp"
-	ELF                 = "elf"
-	ETHER8023_FRAME     = "ether8023_frame"
-	EXIF                = "exif"
-	FAIRPLAY_SPC        = "fairplay_spc"
-	FLAC                = "flac"
-	FLAC_FRAME          = "flac_frame"
-	FLAC_METADATABLOCK  = "flac_metadatablock"
-	FLAC_METADATABLOCKS = "flac_metadatablocks"
-	FLAC_PICTURE        = "flac_picture"
-	FLAC_STREAMINFO     = "flac_streaminfo"
-	FLV                 = "flv" // TODO:
-	GIF                 = "gif"
-	GZIP                = "gzip"
-	HEVC_ANNEXB         = "hevc_annexb"
-	HEVC_AU             = "hevc_au"
-	HEVC_DCR            = "hevc_dcr"
-	HEVC_NALU           = "hevc_nalu"
-	HEVC_PPS            = "hevc_pps"
-	HEVC_SPS            = "hevc_sps"
-	HEVC_VPS            = "hevc_vps"
-	HTML                = "html"
-	ICC_PROFILE         = "icc_profile"
-	ICMP                = "icmp"
-	ICMPV6              = "icmpv6"
-	ID3V1               = "id3v1"
-	ID3V11              = "id3v11"
-	ID3V2               = "id3v2"
-	IPV4_PACKET         = "ipv4_packet"
-	IPV6_PACKET         = "ipv6_packet"
-	JPEG                = "jpeg"
-	JSON                = "json"
-	JSONL               = "jsonl"
-	MACHO               = "macho"
-	MACHO_FAT           = "macho_fat"
-	MARKDOWN            = "markdown"
-	MATROSKA            = "matroska"
-	MP3                 = "mp3"
-	MP3_FRAME           = "mp3_frame"
-	MP3_FRAME_VBRI      = "mp3_frame_vbri"
-	MP3_FRAME_XING      = "mp3_frame_xing"
-	MP4                 = "mp4"
-	MPEG_ASC            = "mpeg_asc"
-	MPEG_ES             = "mpeg_es"
-	MPEG_PES            = "mpeg_pes"
-	MPEG_PES_PACKET     = "mpeg_pes_packet"
-	MPEG_SPU            = "mpeg_spu"
-	MPEG_TS             = "mpeg_ts"
-	MSGPACK             = "msgpack"
-	OGG                 = "ogg"
-	OGG_PAGE            = "ogg_page"
-	OPUS_PACKET         = "opus_packet"
-	PCAP                = "pcap"
-	PCAPNG              = "pcapng"
-	PNG                 = "png"
-	PRORES_FRAME        = "prores_frame"
-	PROTOBUF            = "protobuf"
-	PROTOBUF_WIDEVINE   = "protobuf_widevine"
-	PSSH_PLAYREADY      = "pssh_playready"
-	RTMP                = "rtmp"
-	SLL_PACKET          = "sll_packet"
-	SLL2_PACKET         = "sll2_packet"
-	TAR                 = "tar"
-	TCP_SEGMENT         = "tcp_segment"
-	TIFF                = "tiff"
-	TLS                 = "tls"
-	TOML                = "toml"
-	TZIF                = "tzif"
-	UDP_DATAGRAM        = "udp_datagram"
-	VORBIS_COMMENT      = "vorbis_comment"
-	VORBIS_PACKET       = "vorbis_packet"
-	VP8_FRAME           = "vp8_frame"
-	VP9_CFM             = "vp9_cfm"
-	VP9_FRAME           = "vp9_frame"
-	VPX_CCR             = "vpx_ccr"
-	WASM                = "wasm"
-	WAV                 = "wav"
-	WEBP                = "webp"
-	XML                 = "xml"
-	YAML                = "yaml"
-	ZIP                 = "zip"
+	Bytes = &decode.Group{Name: "bytes"}
+	Bits  = &decode.Group{Name: "bits"}
+
+	AacFrame           = &decode.Group{Name: "aac_frame"}
+	Adts               = &decode.Group{Name: "adts"}
+	AdtsFrame          = &decode.Group{Name: "adts_frame"}
+	Aiff               = &decode.Group{Name: "aiff"}
+	Amf0               = &decode.Group{Name: "amf0"}
+	Apev2              = &decode.Group{Name: "apev2"}
+	AppleBookmark      = &decode.Group{Name: "apple_bookmark"}
+	Ar                 = &decode.Group{Name: "ar"}
+	Asn1Ber            = &decode.Group{Name: "asn1_ber"}
+	Av1Ccr             = &decode.Group{Name: "av1_ccr"}
+	Av1Frame           = &decode.Group{Name: "av1_frame"}
+	Av1Obu             = &decode.Group{Name: "av1_obu"}
+	AvcAnnexb          = &decode.Group{Name: "avc_annexb"}
+	AvcAu              = &decode.Group{Name: "avc_au"}
+	AvcDcr             = &decode.Group{Name: "avc_dcr"}
+	AvcNalu            = &decode.Group{Name: "avc_nalu"}
+	AvcPps             = &decode.Group{Name: "avc_pps"}
+	AvcSei             = &decode.Group{Name: "avc_sei"}
+	AvcSps             = &decode.Group{Name: "avc_sps"}
+	Avi                = &decode.Group{Name: "avi"}
+	AvroOcf            = &decode.Group{Name: "avro_ocf"}
+	Bencode            = &decode.Group{Name: "bencode"}
+	BitcoinBlkdat      = &decode.Group{Name: "bitcoin_blkdat"}
+	BitcoinBlock       = &decode.Group{Name: "bitcoin_block"}
+	BitcoinScript      = &decode.Group{Name: "bitcoin_script"}
+	BitcoinTransaction = &decode.Group{Name: "bitcoin_transaction"}
+	Bplist             = &decode.Group{Name: "bplist"}
+	BsdLoopbackFrame   = &decode.Group{Name: "bsd_loopback_frame"}
+	Bson               = &decode.Group{Name: "bson"}
+	Bzip2              = &decode.Group{Name: "bzip2"}
+	Cbor               = &decode.Group{Name: "cbor"}
+	Csv                = &decode.Group{Name: "csv"}
+	Dns                = &decode.Group{Name: "dns"}
+	DnsTcp             = &decode.Group{Name: "dns_tcp"}
+	Elf                = &decode.Group{Name: "elf"}
+	Ether8023Frame     = &decode.Group{Name: "ether8023_frame"}
+	Exif               = &decode.Group{Name: "exif"}
+	FairplaySpc        = &decode.Group{Name: "fairplay_spc"}
+	Flac               = &decode.Group{Name: "flac"}
+	FlacFrame          = &decode.Group{Name: "flac_frame"}
+	FlacMetadatablock  = &decode.Group{Name: "flac_metadatablock"}
+	FlacMetadatablocks = &decode.Group{Name: "flac_metadatablocks"}
+	FlacPicture        = &decode.Group{Name: "flac_picture"}
+	FlacStreaminfo     = &decode.Group{Name: "flac_streaminfo"}
+	Flv                = &decode.Group{Name: "flv"}
+	Gif                = &decode.Group{Name: "gif"}
+	Gzip               = &decode.Group{Name: "gzip"}
+	HevcAnnexb         = &decode.Group{Name: "hevc_annexb"}
+	HevcAu             = &decode.Group{Name: "hevc_au"}
+	HevcDcr            = &decode.Group{Name: "hevc_dcr"}
+	HevcNalu           = &decode.Group{Name: "hevc_nalu"}
+	HevcPps            = &decode.Group{Name: "hevc_pps"}
+	HevcSps            = &decode.Group{Name: "hevc_sps"}
+	HevcVps            = &decode.Group{Name: "hevc_vps"}
+	Html               = &decode.Group{Name: "html"}
+	IccProfile         = &decode.Group{Name: "icc_profile"}
+	Icmp               = &decode.Group{Name: "icmp"}
+	Icmpv6             = &decode.Group{Name: "icmpv6"}
+	Id3v1              = &decode.Group{Name: "id3v1"}
+	Id3v11             = &decode.Group{Name: "id3v11"}
+	Id3v2              = &decode.Group{Name: "id3v2"}
+	Ipv4Packet         = &decode.Group{Name: "ipv4_packet"}
+	Ipv6Packet         = &decode.Group{Name: "ipv6_packet"}
+	Jpeg               = &decode.Group{Name: "jpeg"}
+	Json               = &decode.Group{Name: "json"}
+	Jsonl              = &decode.Group{Name: "jsonl"}
+	Macho              = &decode.Group{Name: "macho"}
+	MachoFat           = &decode.Group{Name: "macho_fat"}
+	Markdown           = &decode.Group{Name: "markdown"}
+	Matroska           = &decode.Group{Name: "matroska"}
+	Mp3                = &decode.Group{Name: "mp3"}
+	Mp3Frame           = &decode.Group{Name: "mp3_frame"}
+	Mp3FrameVbri       = &decode.Group{Name: "mp3_frame_vbri"}
+	Mp3FrameXing       = &decode.Group{Name: "mp3_frame_xing"}
+	Mp4                = &decode.Group{Name: "mp4"}
+	MpegAsc            = &decode.Group{Name: "mpeg_asc"}
+	MpegEs             = &decode.Group{Name: "mpeg_es"}
+	MpegPes            = &decode.Group{Name: "mpeg_pes"}
+	MpegPesPacket      = &decode.Group{Name: "mpeg_pes_packet"}
+	MpegSpu            = &decode.Group{Name: "mpeg_spu"}
+	MpegTs             = &decode.Group{Name: "mpeg_ts"}
+	Msgpack            = &decode.Group{Name: "msgpack"}
+	Ogg                = &decode.Group{Name: "ogg"}
+	OggPage            = &decode.Group{Name: "ogg_page"}
+	OpusPacket         = &decode.Group{Name: "opus_packet"}
+	Pcap               = &decode.Group{Name: "pcap"}
+	Pcapng             = &decode.Group{Name: "pcapng"}
+	Png                = &decode.Group{Name: "png"}
+	ProresFrame        = &decode.Group{Name: "prores_frame"}
+	Protobuf           = &decode.Group{Name: "protobuf"}
+	ProtobufWidevine   = &decode.Group{Name: "protobuf_widevine"}
+	PsshPlayready      = &decode.Group{Name: "pssh_playready"}
+	Rtmp               = &decode.Group{Name: "rtmp"}
+	SllPacket          = &decode.Group{Name: "sll_packet"}
+	Sll2Packet         = &decode.Group{Name: "sll2_packet"}
+	Tar                = &decode.Group{Name: "tar"}
+	TcpSegment         = &decode.Group{Name: "tcp_segment"}
+	Tiff               = &decode.Group{Name: "tiff"}
+	Tls                = &decode.Group{Name: "tls"}
+	Toml               = &decode.Group{Name: "toml"}
+	Tzif               = &decode.Group{Name: "tzif"}
+	UdpDatagram        = &decode.Group{Name: "udp_datagram"}
+	VorbisComment      = &decode.Group{Name: "vorbis_comment"}
+	VorbisPacket       = &decode.Group{Name: "vorbis_packet"}
+	Vp8Frame           = &decode.Group{Name: "vp8_frame"}
+	Vp9Cfm             = &decode.Group{Name: "vp9_cfm"}
+	Vp9Frame           = &decode.Group{Name: "vp9_frame"}
+	VpxCcr             = &decode.Group{Name: "vpx_ccr"}
+	Wasm               = &decode.Group{Name: "wasm"}
+	Wav                = &decode.Group{Name: "wav"}
+	Webp               = &decode.Group{Name: "webp"}
+	Xml                = &decode.Group{Name: "xml"}
+	Yaml               = &decode.Group{Name: "yaml"}
+	Zip                = &decode.Group{Name: "zip"}
 )
 
 // below are data types used to communicate between formats <FormatName>In/Out
 
+type AACFrameIn struct {
+	ObjectType int `doc:"Audio object type"`
+}
+type AvcAuIn struct {
+	LengthSize uint64 `doc:"Length value size"`
+}
+
+type AvcDcrOut struct {
+	LengthSize uint64
+}
+type FlacFrameIn struct {
+	SamplesBuf    []byte
+	BitsPerSample int `doc:"Bits per sample"`
+}
+
+type FlacFrameOut struct {
+	SamplesBuf    []byte
+	Samples       uint64
+	Channels      int
+	BitsPerSample int
+}
 type FlacStreamInfo struct {
 	SampleRate           uint64
 	BitsPerSample        uint64
@@ -164,16 +188,12 @@ type FlacMetadatablocksOut struct {
 	StreamInfo    FlacStreamInfo
 }
 
-type FlacFrameIn struct {
-	SamplesBuf    []byte
-	BitsPerSample int `doc:"Bits per sample"`
+type HevcAuIn struct {
+	LengthSize uint64 `doc:"Length value size"`
 }
 
-type FlacFrameOut struct {
-	SamplesBuf    []byte
-	Samples       uint64
-	Channels      int
-	BitsPerSample int
+type HevcDcrOut struct {
+	LengthSize uint64
 }
 
 type OggPageOut struct {
@@ -185,45 +205,12 @@ type OggPageOut struct {
 	Segments           [][]byte
 }
 
-type AvcAuIn struct {
-	LengthSize uint64 `doc:"Length value size"`
-}
-
-type AvcDcrOut struct {
-	LengthSize uint64
-}
-
-type HevcAuIn struct {
-	LengthSize uint64 `doc:"Length value size"`
-}
-
-type HevcDcrOut struct {
-	LengthSize uint64
-}
-
 type ProtoBufIn struct {
 	Message ProtoBufMessage
 }
 
 type MatroskaIn struct {
 	DecodeSamples bool `doc:"Decode samples"`
-}
-
-type MpegDecoderConfig struct {
-	ObjectType    int
-	ASCObjectType int
-}
-
-type MpegEsOut struct {
-	DecoderConfigs []MpegDecoderConfig
-}
-
-type MPEGASCOut struct {
-	ObjectType int
-}
-
-type AACFrameIn struct {
-	ObjectType int `doc:"Audio object type"`
 }
 
 type Mp3In struct {
@@ -239,6 +226,19 @@ type MP3FrameOut struct {
 	SampleRate       int
 	ChannelsIndex    int
 	ChannelModeIndex int
+}
+
+type MpegDecoderConfig struct {
+	ObjectType    int
+	ASCObjectType int
+}
+
+type MpegEsOut struct {
+	DecoderConfigs []MpegDecoderConfig
+}
+
+type MPEGASCOut struct {
+	ObjectType int
 }
 
 type LinkFrameIn struct {

--- a/format/fuzz_test.go
+++ b/format/fuzz_test.go
@@ -23,7 +23,7 @@ func (fuzzFS) Open(name string) (fs.File, error) {
 
 type fuzzTest struct {
 	b []byte
-	f decode.Format
+	f *decode.Format
 }
 
 type fuzzTestInput struct {
@@ -102,12 +102,12 @@ func FuzzFormats(f *testing.F) {
 		f.Fatal(f)
 	}
 
-	gi := 0
-	var g decode.Group
+	fi := 0
+	var g *decode.Group
 
 	if n := os.Getenv("GROUP"); n != "" {
 		var err error
-		g, err = interp.DefaultRegistry.FormatGroup(n)
+		g, err = interp.DefaultRegistry.Group(n)
 		if err != nil {
 			f.Fatal(err)
 		}
@@ -117,18 +117,18 @@ func FuzzFormats(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, b []byte) {
-		fz := &fuzzTest{b: b, f: g[gi]}
+		fz := &fuzzTest{b: b, f: g.Formats[fi]}
 		q, err := interp.New(fz, interp.DefaultRegistry)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_ = q.Main(context.Background(), fz.Stdout(), "dev")
+		_ = q.Main(context.Background(), fz.Stdout(), "fuzz")
 		// if err != nil {
 		// 	// TODO: expect error
 		// 	t.Fatal(err)
 		// }
 
-		gi = (gi + 1) % len(g)
+		fi = (fi + 1) % len(g.Formats)
 	})
 }

--- a/format/gif/gif.go
+++ b/format/gif/gif.go
@@ -17,12 +17,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.GIF,
-		Description: "Graphics Interchange Format",
-		Groups:      []string{format.PROBE, format.IMAGE},
-		DecodeFn:    gifDecode,
-	})
+	interp.RegisterFormat(
+		format.Gif,
+		&decode.Format{
+			Description: "Graphics Interchange Format",
+			Groups:      []*decode.Group{format.Probe, format.Image},
+			DecodeFn:    gifDecode,
+		})
 }
 
 const (

--- a/format/gzip/gzip.go
+++ b/format/gzip/gzip.go
@@ -16,18 +16,19 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var probeFormat decode.Group
+var probeGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.GZIP,
-		Description: "gzip compression",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    gzDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.PROBE}, Group: &probeFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Gzip,
+		&decode.Format{
+			Description: "gzip compression",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    gzDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Probe}, Out: &probeGroup},
+			},
+		})
 }
 
 const deflateMethod = 8
@@ -108,7 +109,8 @@ func gzDecode(d *decode.D) any {
 	}
 
 	if rFn != nil {
-		readCompressedSize, uncompressedBR, dv, _, _ := d.TryFieldReaderRangeFormat("uncompressed", d.Pos(), d.BitsLeft(), rFn, probeFormat, nil)
+		readCompressedSize, uncompressedBR, dv, _, _ :=
+			d.TryFieldReaderRangeFormat("uncompressed", d.Pos(), d.BitsLeft(), rFn, &probeGroup, nil)
 		if uncompressedBR != nil {
 			if dv == nil {
 				d.FieldRootBitBuf("uncompressed", uncompressedBR)

--- a/format/icc/icc_profile.go
+++ b/format/icc/icc_profile.go
@@ -11,11 +11,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ICC_PROFILE,
-		Description: "International Color Consortium profile",
-		DecodeFn:    iccProfileDecode,
-	})
+	interp.RegisterFormat(
+		format.IccProfile,
+		&decode.Format{
+			Description: "International Color Consortium profile",
+			DecodeFn:    iccProfileDecode,
+		})
 }
 
 func xyzType(_ int64, d *decode.D) {

--- a/format/id3/id3v1.go
+++ b/format/id3/id3v1.go
@@ -10,11 +10,12 @@ import (
 // TODO: comment 28 long, zero byte, track number
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ID3V1,
-		Description: "ID3v1 metadata",
-		DecodeFn:    id3v1Decode,
-	})
+	interp.RegisterFormat(
+		format.Id3v1,
+		&decode.Format{
+			Description: "ID3v1 metadata",
+			DecodeFn:    id3v1Decode,
+		})
 }
 
 // Decode ID3v1 tag

--- a/format/id3/id3v11.go
+++ b/format/id3/id3v11.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ID3V11,
-		Description: "ID3v1.1 metadata",
-		DecodeFn:    id3v11Decode,
-	})
+	interp.RegisterFormat(
+		format.Id3v11,
+		&decode.Format{
+			Description: "ID3v1.1 metadata",
+			DecodeFn:    id3v11Decode,
+		})
 }
 
 func id3v11Decode(d *decode.D) any {

--- a/format/id3/id3v2.go
+++ b/format/id3/id3v2.go
@@ -19,17 +19,18 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
-var imageFormat decode.Group
+var imageGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ID3V2,
-		Description: "ID3v2 metadata",
-		DecodeFn:    id3v2Decode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.IMAGE}, Group: &imageFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Id3v2,
+		&decode.Format{
+			Description: "ID3v2 metadata",
+			DecodeFn:    id3v2Decode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Image}, Out: &imageGroup},
+			},
+		})
 }
 
 var idDescriptions = scalar.StrMapDescription{
@@ -449,7 +450,7 @@ func decodeFrame(d *decode.D, version int) uint64 {
 			d.FieldUTF8("image_format", 3)
 			d.FieldU8("picture_type") // TODO: table
 			d.FieldStrFn("description", textNullFn(int(encoding)))
-			d.FieldFormatOrRawLen("picture", d.BitsLeft(), imageFormat, nil)
+			d.FieldFormatOrRawLen("picture", d.BitsLeft(), &imageGroup, nil)
 		},
 
 		// <Header for 'Attached picture', ID: "APIC">
@@ -463,7 +464,7 @@ func decodeFrame(d *decode.D, version int) uint64 {
 			d.FieldStrFn("mime_type", textNullFn(encodingUTF8))
 			d.FieldU8("picture_type") // TODO: table
 			d.FieldStrFn("description", textNullFn(int(encoding)))
-			d.FieldFormatOrRawLen("picture", d.BitsLeft(), imageFormat, nil)
+			d.FieldFormatOrRawLen("picture", d.BitsLeft(), &imageGroup, nil)
 		},
 
 		// <Header for 'General encapsulated object', ID: "GEOB">
@@ -477,7 +478,7 @@ func decodeFrame(d *decode.D, version int) uint64 {
 			d.FieldStrFn("mime_type", textNullFn(encodingUTF8))
 			d.FieldStrFn("filename", textNullFn(int(encoding)))
 			d.FieldStrFn("description", textNullFn(int(encoding)))
-			d.FieldFormatOrRawLen("data", d.BitsLeft(), imageFormat, nil)
+			d.FieldFormatOrRawLen("data", d.BitsLeft(), &imageGroup, nil)
 		},
 
 		// Unsynced lyrics/text "ULT"

--- a/format/inet/bsd_loopback_frame.go
+++ b/format/inet/bsd_loopback_frame.go
@@ -12,15 +12,15 @@ import (
 var bsdLoopbackFrameInetPacketGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.BSD_LOOPBACK_FRAME,
-		Description: "BSD loopback frame",
-		Groups:      []string{format.LINK_FRAME},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.INET_PACKET}, Group: &bsdLoopbackFrameInetPacketGroup},
-		},
-		DecodeFn: decodeLoopbackFrame,
-	})
+	interp.RegisterFormat(
+		format.BsdLoopbackFrame, &decode.Format{
+			Description: "BSD loopback frame",
+			Groups:      []*decode.Group{format.LinkFrame},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.InetPacket}, Out: &bsdLoopbackFrameInetPacketGroup},
+			},
+			DecodeFn: decodeLoopbackFrame,
+		})
 }
 
 const (
@@ -56,7 +56,7 @@ func decodeLoopbackFrame(d *decode.D) any {
 	d.FieldFormatOrRawLen(
 		"payload",
 		d.BitsLeft(),
-		bsdLoopbackFrameInetPacketGroup,
+		&bsdLoopbackFrameInetPacketGroup,
 		// TODO: unknown mapped to ether type 0 is ok?
 		format.InetPacketIn{EtherType: bsdLoopbackFrameNetworkLayerEtherType[networkLayer]},
 	)

--- a/format/inet/ether8023_frame.go
+++ b/format/inet/ether8023_frame.go
@@ -15,15 +15,16 @@ import (
 var ether8023FrameInetPacketGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ETHER8023_FRAME,
-		Description: "Ethernet 802.3 frame",
-		Groups:      []string{format.LINK_FRAME},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.INET_PACKET}, Group: &ether8023FrameInetPacketGroup},
-		},
-		DecodeFn: decodeEthernetFrame,
-	})
+	interp.RegisterFormat(
+		format.Ether8023Frame,
+		&decode.Format{
+			Description: "Ethernet 802.3 frame",
+			Groups:      []*decode.Group{format.LinkFrame},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.InetPacket}, Out: &ether8023FrameInetPacketGroup},
+			},
+			DecodeFn: decodeEthernetFrame,
+		})
 }
 
 // TODO: move to shared?
@@ -49,7 +50,7 @@ func decodeEthernetFrame(d *decode.D) any {
 	d.FieldFormatOrRawLen(
 		"payload",
 		d.BitsLeft(),
-		ether8023FrameInetPacketGroup,
+		&ether8023FrameInetPacketGroup,
 		format.InetPacketIn{EtherType: int(etherType)},
 	)
 

--- a/format/inet/icmp.go
+++ b/format/inet/icmp.go
@@ -8,12 +8,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ICMP,
-		Description: "Internet Control Message Protocol",
-		Groups:      []string{format.IP_PACKET},
-		DecodeFn:    decodeICMP,
-	})
+	interp.RegisterFormat(
+		format.Icmp,
+		&decode.Format{
+			Description: "Internet Control Message Protocol",
+			Groups:      []*decode.Group{format.IpPacket},
+			DecodeFn:    decodeICMP,
+		})
 }
 
 // based on https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol

--- a/format/inet/icmpv6.go
+++ b/format/inet/icmpv6.go
@@ -8,12 +8,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ICMPV6,
-		Description: "Internet Control Message Protocol v6",
-		Groups:      []string{format.IP_PACKET},
-		DecodeFn:    decodeICMPv6,
-	})
+	interp.RegisterFormat(
+		format.Icmpv6,
+		&decode.Format{
+			Description: "Internet Control Message Protocol v6",
+			Groups:      []*decode.Group{format.IpPacket},
+			DecodeFn:    decodeICMPv6,
+		})
 }
 
 // based on https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol_for_IPv6

--- a/format/inet/ipv4_packet.go
+++ b/format/inet/ipv4_packet.go
@@ -15,18 +15,19 @@ import (
 var ipv4IpPacketGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.IPV4_PACKET,
-		Description: "Internet protocol v4 packet",
-		Groups: []string{
-			format.INET_PACKET,
-			format.LINK_FRAME,
-		},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.IP_PACKET}, Group: &ipv4IpPacketGroup},
-		},
-		DecodeFn: decodeIPv4,
-	})
+	interp.RegisterFormat(
+		format.Ipv4Packet,
+		&decode.Format{
+			Description: "Internet protocol v4 packet",
+			Groups: []*decode.Group{
+				format.InetPacket,
+				format.LinkFrame,
+			},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.IpPacket}, Out: &ipv4IpPacketGroup},
+			},
+			DecodeFn: decodeIPv4,
+		})
 }
 
 const (
@@ -113,7 +114,7 @@ func decodeIPv4(d *decode.D) any {
 		d.FieldFormatOrRawLen(
 			"payload",
 			dataLen,
-			ipv4IpPacketGroup,
+			&ipv4IpPacketGroup,
 			format.IPPacketIn{Protocol: int(protocol)},
 		)
 	}

--- a/format/inet/ipv6_packet.go
+++ b/format/inet/ipv6_packet.go
@@ -14,18 +14,19 @@ import (
 var ipv6IpPacketGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.IPV6_PACKET,
-		Description: "Internet protocol v6 packet",
-		Groups: []string{
-			format.INET_PACKET,
-			format.LINK_FRAME,
-		},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.IP_PACKET}, Group: &ipv6IpPacketGroup},
-		},
-		DecodeFn: decodeIPv6,
-	})
+	interp.RegisterFormat(
+		format.Ipv6Packet,
+		&decode.Format{
+			Description: "Internet protocol v6 packet",
+			Groups: []*decode.Group{
+				format.InetPacket,
+				format.LinkFrame,
+			},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.IpPacket}, Out: &ipv6IpPacketGroup},
+			},
+			DecodeFn: decodeIPv6,
+		})
 }
 
 const (
@@ -172,7 +173,7 @@ func decodeIPv6(d *decode.D) any {
 	d.FieldFormatOrRawLen(
 		"payload",
 		payloadLen,
-		ipv4IpPacketGroup,
+		&ipv4IpPacketGroup,
 		format.IPPacketIn{Protocol: int(nextHeader)},
 	)
 

--- a/format/inet/sll2_packet.go
+++ b/format/inet/sll2_packet.go
@@ -13,15 +13,16 @@ import (
 var sllPacket2InetPacketGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.SLL2_PACKET,
-		Description: "Linux cooked capture encapsulation v2",
-		Groups:      []string{format.LINK_FRAME},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.INET_PACKET}, Group: &sllPacket2InetPacketGroup},
-		},
-		DecodeFn: decodeSLL2,
-	})
+	interp.RegisterFormat(
+		format.Sll2Packet,
+		&decode.Format{
+			Description: "Linux cooked capture encapsulation v2",
+			Groups:      []*decode.Group{format.LinkFrame},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.InetPacket}, Out: &sllPacket2InetPacketGroup},
+			},
+			DecodeFn: decodeSLL2,
+		})
 }
 
 func decodeSLL2(d *decode.D) any {
@@ -54,7 +55,7 @@ func decodeSLL2(d *decode.D) any {
 		d.FieldFormatOrRawLen(
 			"payload",
 			d.BitsLeft(),
-			sllPacket2InetPacketGroup,
+			&sllPacket2InetPacketGroup,
 			format.InetPacketIn{EtherType: int(protcolType)},
 		)
 	default:

--- a/format/inet/sll_packet.go
+++ b/format/inet/sll_packet.go
@@ -13,15 +13,16 @@ import (
 var sllPacketInetPacketGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.SLL_PACKET,
-		Description: "Linux cooked capture encapsulation",
-		Groups:      []string{format.LINK_FRAME},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.INET_PACKET}, Group: &sllPacketInetPacketGroup},
-		},
-		DecodeFn: decodeSLL,
-	})
+	interp.RegisterFormat(
+		format.SllPacket,
+		&decode.Format{
+			Description: "Linux cooked capture encapsulation",
+			Groups:      []*decode.Group{format.LinkFrame},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.InetPacket}, Out: &sllPacketInetPacketGroup},
+			},
+			DecodeFn: decodeSLL,
+		})
 }
 
 var sllPacketTypeMap = scalar.UintMap{
@@ -131,7 +132,7 @@ func decodeSLL(d *decode.D) any {
 		d.FieldFormatOrRawLen(
 			"payload",
 			d.BitsLeft(),
-			sllPacketInetPacketGroup,
+			&sllPacketInetPacketGroup,
 			format.InetPacketIn{EtherType: int(protcolType)},
 		)
 	default:

--- a/format/inet/tcp_segment.go
+++ b/format/inet/tcp_segment.go
@@ -10,12 +10,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.TCP_SEGMENT,
-		Description: "Transmission control protocol segment",
-		Groups:      []string{format.IP_PACKET},
-		DecodeFn:    decodeTCP,
-	})
+	interp.RegisterFormat(
+		format.TcpSegment,
+		&decode.Format{
+			Description: "Transmission control protocol segment",
+			Groups:      []*decode.Group{format.IpPacket},
+			DecodeFn:    decodeTCP,
+		})
 }
 
 const (

--- a/format/inet/udp_datagram.go
+++ b/format/inet/udp_datagram.go
@@ -10,15 +10,16 @@ import (
 var udpPayloadGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.UDP_DATAGRAM,
-		Description: "User datagram protocol",
-		Groups:      []string{format.IP_PACKET},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.UDP_PAYLOAD}, Group: &udpPayloadGroup},
-		},
-		DecodeFn: decodeUDP,
-	})
+	interp.RegisterFormat(
+		format.UdpDatagram,
+		&decode.Format{
+			Description: "User datagram protocol",
+			Groups:      []*decode.Group{format.IpPacket},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.UdpPayload}, Out: &udpPayloadGroup},
+			},
+			DecodeFn: decodeUDP,
+		})
 }
 
 func decodeUDP(d *decode.D) any {
@@ -36,7 +37,7 @@ func decodeUDP(d *decode.D) any {
 	d.FieldFormatOrRawLen(
 		"payload",
 		payloadLen,
-		udpPayloadGroup,
+		&udpPayloadGroup,
 		format.UDPPayloadIn{
 			SourcePort:      int(sourcePort),
 			DestinationPort: int(destPort),

--- a/format/json/json.go
+++ b/format/json/json.go
@@ -20,14 +20,15 @@ import (
 var jsonFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.JSON,
-		Description: "JavaScript Object Notation",
-		ProbeOrder:  format.ProbeOrderTextJSON,
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeJSON,
-		Functions:   []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Json,
+		&decode.Format{
+			Description: "JavaScript Object Notation",
+			ProbeOrder:  format.ProbeOrderTextJSON,
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeJSON,
+			Functions:   []string{"_todisplay"},
+		})
 	interp.RegisterFS(jsonFS)
 	interp.RegisterFunc1("_to_json", toJSON)
 }

--- a/format/json/jsonl.go
+++ b/format/json/jsonl.go
@@ -15,14 +15,15 @@ var jsonlFS embed.FS
 // TODO: not strictly JSONL, allows any whitespace between
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.JSONL,
-		Description: "JavaScript Object Notation Lines",
-		ProbeOrder:  format.ProbeOrderTextFuzzy,
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeJSONL,
-		Functions:   []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Jsonl,
+		&decode.Format{
+			Description: "JavaScript Object Notation Lines",
+			ProbeOrder:  format.ProbeOrderTextFuzzy,
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeJSONL,
+			Functions:   []string{"_todisplay"},
+		})
 	interp.RegisterFS(jsonlFS)
 	interp.RegisterFunc0("to_jsonl", toJSONL)
 }

--- a/format/markdown/markdown.go
+++ b/format/markdown/markdown.go
@@ -19,12 +19,13 @@ import (
 var markdownFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MARKDOWN,
-		Description: "Markdown",
-		DecodeFn:    decodeMarkdown,
-		Functions:   []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Markdown,
+		&decode.Format{
+			Description: "Markdown",
+			DecodeFn:    decodeMarkdown,
+			Functions:   []string{"_todisplay"},
+		})
 	interp.RegisterFS(markdownFS)
 }
 

--- a/format/matroska/matroska.go
+++ b/format/matroska/matroska.go
@@ -28,75 +28,76 @@ import (
 //go:embed matroska.md
 var matroskaFS embed.FS
 
-var aacFrameFormat decode.Group
-var av1CCRFormat decode.Group
-var av1FrameFormat decode.Group
-var flacFrameFormat decode.Group
-var flacMetadatablocksFormat decode.Group
-var imageFormat decode.Group
-var mp3FrameFormat decode.Group
-var mpegASCFrameFormat decode.Group
-var mpegAVCAUFormat decode.Group
-var mpegAVCDCRFormat decode.Group
-var mpegHEVCDCRFormat decode.Group
-var mpegHEVCSampleFormat decode.Group
-var mpegPESPacketSampleFormat decode.Group
-var mpegSPUFrameFormat decode.Group
-var opusPacketFrameFormat decode.Group
-var vorbisPacketFormat decode.Group
-var vp8FrameFormat decode.Group
-var vp9CFMFormat decode.Group
-var vp9FrameFormat decode.Group
+var aacFrameGroup decode.Group
+var av1CCRGroup decode.Group
+var av1FrameGroup decode.Group
+var flacFrameGroup decode.Group
+var flacMetadatablocksGroup decode.Group
+var imageGroup decode.Group
+var mp3FrameGroup decode.Group
+var mpegASCFrameGroup decode.Group
+var mpegAVCAUGroup decode.Group
+var mpegAVCDCRGroup decode.Group
+var mpegHEVCDCRGroup decode.Group
+var mpegHEVCSampleGroup decode.Group
+var mpegPESPacketSampleGroup decode.Group
+var mpegSPUFrameGroup decode.Group
+var opusPacketFrameGroup decode.Group
+var vorbisPacketGroup decode.Group
+var vp8FrameGroup decode.Group
+var vp9CFMGroup decode.Group
+var vp9FrameGroup decode.Group
 
-var codecToFormat map[string]*decode.Group
+var codecToGroup map[string]*decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MATROSKA,
-		Description: "Matroska file",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    matroskaDecode,
-		DefaultInArg: format.MatroskaIn{
-			DecodeSamples: true,
-		},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AAC_FRAME}, Group: &aacFrameFormat},
-			{Names: []string{format.AV1_CCR}, Group: &av1CCRFormat},
-			{Names: []string{format.AV1_FRAME}, Group: &av1FrameFormat},
-			{Names: []string{format.AVC_AU}, Group: &mpegAVCAUFormat},
-			{Names: []string{format.AVC_DCR}, Group: &mpegAVCDCRFormat},
-			{Names: []string{format.FLAC_FRAME}, Group: &flacFrameFormat},
-			{Names: []string{format.FLAC_METADATABLOCKS}, Group: &flacMetadatablocksFormat},
-			{Names: []string{format.HEVC_AU}, Group: &mpegHEVCSampleFormat},
-			{Names: []string{format.HEVC_DCR}, Group: &mpegHEVCDCRFormat},
-			{Names: []string{format.IMAGE}, Group: &imageFormat},
-			{Names: []string{format.MP3_FRAME}, Group: &mp3FrameFormat},
-			{Names: []string{format.MPEG_ASC}, Group: &mpegASCFrameFormat},
-			{Names: []string{format.MPEG_PES_PACKET}, Group: &mpegPESPacketSampleFormat},
-			{Names: []string{format.MPEG_SPU}, Group: &mpegSPUFrameFormat},
-			{Names: []string{format.OPUS_PACKET}, Group: &opusPacketFrameFormat},
-			{Names: []string{format.VORBIS_PACKET}, Group: &vorbisPacketFormat},
-			{Names: []string{format.VP8_FRAME}, Group: &vp8FrameFormat},
-			{Names: []string{format.VP9_CFM}, Group: &vp9CFMFormat},
-			{Names: []string{format.VP9_FRAME}, Group: &vp9FrameFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Matroska,
+		&decode.Format{
+			Description: "Matroska file",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    matroskaDecode,
+			DefaultInArg: format.MatroskaIn{
+				DecodeSamples: true,
+			},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AacFrame}, Out: &aacFrameGroup},
+				{Groups: []*decode.Group{format.Av1Ccr}, Out: &av1CCRGroup},
+				{Groups: []*decode.Group{format.Av1Frame}, Out: &av1FrameGroup},
+				{Groups: []*decode.Group{format.AvcAu}, Out: &mpegAVCAUGroup},
+				{Groups: []*decode.Group{format.AvcDcr}, Out: &mpegAVCDCRGroup},
+				{Groups: []*decode.Group{format.FlacFrame}, Out: &flacFrameGroup},
+				{Groups: []*decode.Group{format.FlacMetadatablocks}, Out: &flacMetadatablocksGroup},
+				{Groups: []*decode.Group{format.HevcAu}, Out: &mpegHEVCSampleGroup},
+				{Groups: []*decode.Group{format.HevcDcr}, Out: &mpegHEVCDCRGroup},
+				{Groups: []*decode.Group{format.Image}, Out: &imageGroup},
+				{Groups: []*decode.Group{format.Mp3Frame}, Out: &mp3FrameGroup},
+				{Groups: []*decode.Group{format.MpegAsc}, Out: &mpegASCFrameGroup},
+				{Groups: []*decode.Group{format.MpegPesPacket}, Out: &mpegPESPacketSampleGroup},
+				{Groups: []*decode.Group{format.MpegSpu}, Out: &mpegSPUFrameGroup},
+				{Groups: []*decode.Group{format.OpusPacket}, Out: &opusPacketFrameGroup},
+				{Groups: []*decode.Group{format.VorbisPacket}, Out: &vorbisPacketGroup},
+				{Groups: []*decode.Group{format.Vp8Frame}, Out: &vp8FrameGroup},
+				{Groups: []*decode.Group{format.Vp9Cfm}, Out: &vp9CFMGroup},
+				{Groups: []*decode.Group{format.Vp9Frame}, Out: &vp9FrameGroup},
+			},
+		})
 	interp.RegisterFS(matroskaFS)
 
-	codecToFormat = map[string]*decode.Group{
-		"A_VORBIS":         &vorbisPacketFormat,
-		"A_MPEG/L3":        &mp3FrameFormat,
-		"A_FLAC":           &flacFrameFormat,
-		"A_AAC":            &aacFrameFormat,
-		"A_OPUS":           &opusPacketFrameFormat,
-		"V_VP8":            &vp8FrameFormat,
-		"V_VP9":            &vp9FrameFormat,
-		"V_AV1":            &av1FrameFormat,
-		"V_VOBSUB":         &mpegSPUFrameFormat,
-		"V_MPEG4/ISO/AVC":  &mpegAVCAUFormat,
-		"V_MPEGH/ISO/HEVC": &mpegHEVCSampleFormat,
-		"V_MPEG2":          &mpegPESPacketSampleFormat,
-		"S_VOBSUB":         &mpegSPUFrameFormat,
+	codecToGroup = map[string]*decode.Group{
+		"A_VORBIS":         &vorbisPacketGroup,
+		"A_MPEG/L3":        &mp3FrameGroup,
+		"A_FLAC":           &flacFrameGroup,
+		"A_AAC":            &aacFrameGroup,
+		"A_OPUS":           &opusPacketFrameGroup,
+		"V_VP8":            &vp8FrameGroup,
+		"V_VP9":            &vp9FrameGroup,
+		"V_AV1":            &av1FrameGroup,
+		"V_VOBSUB":         &mpegSPUFrameGroup,
+		"V_MPEG4/ISO/AVC":  &mpegAVCAUGroup,
+		"V_MPEGH/ISO/HEVC": &mpegHEVCSampleGroup,
+		"V_MPEG2":          &mpegPESPacketSampleGroup,
+		"S_VOBSUB":         &mpegSPUFrameGroup,
 	}
 }
 
@@ -427,7 +428,7 @@ func decodeMaster(d *decode.D, bitsLimit int64, elm *ebml.Master, unknownSize bo
 						}
 						d.SeekRel(int64(tagSize) * 8)
 					case ebml_matroska.FileDataID:
-						d.FieldFormatOrRawLen("value", int64(tagSize)*8, imageFormat, nil)
+						d.FieldFormatOrRawLen("value", int64(tagSize)*8, &imageGroup, nil)
 					default:
 						d.FieldRawLen("value", int64(tagSize)*8)
 					}
@@ -468,14 +469,14 @@ func matroskaDecode(d *decode.D) any {
 			t.parentD.RangeFn(t.codecPrivatePos, t.codecPrivateTagSize, func(d *decode.D) {
 				decodeLacingFn(d, lacingTypeXiph, func(d *decode.D) {
 					if mi.DecodeSamples {
-						d.FieldFormat("packet", vorbisPacketFormat, nil)
+						d.FieldFormat("packet", &vorbisPacketGroup, nil)
 					} else {
 						d.FieldRawLen("packet", d.BitsLeft())
 					}
 				})
 			})
 		case "A_AAC":
-			_, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, mpegASCFrameFormat, nil)
+			_, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, &mpegASCFrameGroup, nil)
 			mpegASCOut, ok := v.(format.MPEGASCOut)
 			if !ok {
 				panic(fmt.Sprintf("expected mpegASCOut got %#+v", v))
@@ -483,12 +484,12 @@ func matroskaDecode(d *decode.D) any {
 			//nolint:gosimple
 			t.formatInArg = format.AACFrameIn{ObjectType: mpegASCOut.ObjectType}
 		case "A_OPUS":
-			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, opusPacketFrameFormat, nil)
+			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, &opusPacketFrameGroup, nil)
 		case "A_FLAC":
 			t.parentD.RangeFn(t.codecPrivatePos, t.codecPrivateTagSize, func(d *decode.D) {
 				d.FieldStruct("value", func(d *decode.D) {
 					d.FieldUTF8("magic", 4, d.StrAssert("fLaC"))
-					_, v := d.FieldFormat("metadatablocks", flacMetadatablocksFormat, nil)
+					_, v := d.FieldFormat("metadatablocks", &flacMetadatablocksGroup, nil)
 					flacMetadatablockOut, ok := v.(format.FlacMetadatablocksOut)
 					if !ok {
 						panic(fmt.Sprintf("expected FlacMetadatablockOut got %#+v", v))
@@ -499,23 +500,23 @@ func matroskaDecode(d *decode.D) any {
 				})
 			})
 		case "V_MPEG4/ISO/AVC":
-			_, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, mpegAVCDCRFormat, nil)
+			_, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, &mpegAVCDCRGroup, nil)
 			avcDcrOut, ok := v.(format.AvcDcrOut)
 			if !ok {
 				panic(fmt.Sprintf("expected AvcDcrOut got %#+v", v))
 			}
 			t.formatInArg = format.AvcAuIn{LengthSize: avcDcrOut.LengthSize} //nolint:gosimple
 		case "V_MPEGH/ISO/HEVC":
-			_, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, mpegHEVCDCRFormat, nil)
+			_, v := t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, &mpegHEVCDCRGroup, nil)
 			hevcDcrOut, ok := v.(format.HevcDcrOut)
 			if !ok {
 				panic(fmt.Sprintf("expected HevcDcrOut got %#+v", v))
 			}
 			t.formatInArg = format.HevcAuIn{LengthSize: hevcDcrOut.LengthSize} //nolint:gosimple
 		case "V_AV1":
-			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, av1CCRFormat, nil)
+			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, &av1CCRGroup, nil)
 		case "V_VP9":
-			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, vp9CFMFormat, nil)
+			t.parentD.FieldFormatRange("value", t.codecPrivatePos, t.codecPrivateTagSize, &vp9CFMGroup, nil)
 		default:
 			t.parentD.RangeFn(t.codecPrivatePos, t.codecPrivateTagSize, func(d *decode.D) {
 				d.FieldRawLen("value", d.BitsLeft())
@@ -549,12 +550,12 @@ func matroskaDecode(d *decode.D) any {
 			var track *track
 			track, trackOk := trackNumberToTrack[int(trackNumber)]
 			if trackOk {
-				f = codecToFormat[track.codec]
+				f = codecToGroup[track.codec]
 			}
 
 			decodeLacingFn(d, int(lacing), func(d *decode.D) {
 				if mi.DecodeSamples && f != nil {
-					d.FieldFormat("packet", *f, track.formatInArg)
+					d.FieldFormat("packet", f, track.formatInArg)
 				} else {
 					d.FieldRawLen("packet", d.BitsLeft())
 				}

--- a/format/mp3/mp3_frame_vbri.go
+++ b/format/mp3/mp3_frame_vbri.go
@@ -10,12 +10,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MP3_FRAME_VBRI,
-		Description: "MP3 frame Fraunhofer encoder variable bitrate tag",
-		Groups:      []string{format.MP3_FRAME_TAGS},
-		DecodeFn:    mp3FrameTagVBRIDecode,
-	})
+	interp.RegisterFormat(
+		format.Mp3FrameVbri,
+		&decode.Format{
+			Description: "MP3 frame Fraunhofer encoder variable bitrate tag",
+			Groups:      []*decode.Group{format.Mp3FrameTags},
+			DecodeFn:    mp3FrameTagVBRIDecode,
+		})
 }
 
 func mp3FrameTagVBRIDecode(d *decode.D) any {

--- a/format/mp3/mp3_frame_xing.go
+++ b/format/mp3/mp3_frame_xing.go
@@ -11,12 +11,13 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MP3_FRAME_XING,
-		Description: "MP3 frame Xing/Info tag",
-		Groups:      []string{format.MP3_FRAME_TAGS},
-		DecodeFn:    mp3FrameTagXingDecode,
-	})
+	interp.RegisterFormat(
+		format.Mp3FrameXing,
+		&decode.Format{
+			Description: "MP3 frame Xing/Info tag",
+			Groups:      []*decode.Group{format.Mp3FrameTags},
+			DecodeFn:    mp3FrameTagXingDecode,
+		})
 }
 
 func mp3FrameTagXingDecode(d *decode.D) any {

--- a/format/mp4/boxes.go
+++ b/format/mp4/boxes.go
@@ -676,7 +676,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 			i++
 		})
 	case "avcC":
-		_, v := d.FieldFormat("descriptor", avcDCRFormat, nil)
+		_, v := d.FieldFormat("descriptor", &avcDCRGroup, nil)
 		avcDcrOut, ok := v.(format.AvcDcrOut)
 		if !ok {
 			panic(fmt.Sprintf("expected AvcDcrOut got %#+v", v))
@@ -685,7 +685,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 			t.formatInArg = format.AvcAuIn{LengthSize: avcDcrOut.LengthSize} //nolint:gosimple
 		}
 	case "hvcC":
-		_, v := d.FieldFormat("descriptor", hevcCDCRFormat, nil)
+		_, v := d.FieldFormat("descriptor", &hevcCDCRGroup, nil)
 		hevcDcrOut, ok := v.(format.HevcDcrOut)
 		if !ok {
 			panic(fmt.Sprintf("expected HevcDcrOut got %#+v", v))
@@ -696,7 +696,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 	case "dfLa":
 		d.FieldU8("version")
 		d.FieldU24("flags")
-		_, v := d.FieldFormat("descriptor", flacMetadatablocksFormat, nil)
+		_, v := d.FieldFormat("descriptor", &flacMetadatablocksGroup, nil)
 		flacMetadatablockOut, ok := v.(format.FlacMetadatablocksOut)
 		if !ok {
 			panic(fmt.Sprintf("expected FlacMetadatablockOut got %#+v", v))
@@ -707,16 +707,16 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 			}
 		}
 	case "dOps":
-		d.FieldFormat("descriptor", opusPacketFrameFormat, nil)
+		d.FieldFormat("descriptor", &opusPacketFrameGroup, nil)
 	case "av1C":
-		d.FieldFormat("descriptor", av1CCRFormat, nil)
+		d.FieldFormat("descriptor", &av1CCRGroup, nil)
 	case "vpcC":
 		d.FieldU8("version")
 		d.FieldU24("flags")
-		d.FieldFormat("descriptor", vpxCCRFormat, nil)
+		d.FieldFormat("descriptor", &vpxCCRGroup, nil)
 	case "esds":
 		d.FieldU32("version")
-		_, v := d.FieldFormat("descriptor", mpegESFormat, nil)
+		_, v := d.FieldFormat("descriptor", &mpegESGroup, nil)
 		mpegEsOut, ok := v.(format.MpegEsOut)
 		if !ok {
 			panic(fmt.Sprintf("expected mpegEsOut got %#+v", v))
@@ -936,7 +936,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 		d.FieldU24("flags")
 		d.FieldU32("reserved")
 		if ctx.isParent("covr") {
-			d.FieldFormatOrRawLen("data", d.BitsLeft(), imageFormat, nil)
+			d.FieldFormatOrRawLen("data", d.BitsLeft(), &imageGroup, nil)
 		} else {
 			d.FieldUTF8("data", int(d.BitsLeft()/8))
 		}
@@ -1239,7 +1239,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 			}
 			return s
 		})
-		d.FieldFormat("data", id3v2Format, nil)
+		d.FieldFormat("data", &id3v2Group, nil)
 	case "mehd":
 		version := d.FieldU8("version")
 		d.FieldU24("flags")
@@ -1282,9 +1282,9 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 
 		switch {
 		case bytes.Equal(systemID, systemIDWidevine[:]):
-			d.FieldFormatLen("data", int64(dataLen)*8, protoBufWidevineFormat, nil)
+			d.FieldFormatLen("data", int64(dataLen)*8, &protoBufWidevineGroup, nil)
 		case bytes.Equal(systemID, systemIDPlayReady[:]):
-			d.FieldFormatLen("data", int64(dataLen)*8, psshPlayreadyFormat, nil)
+			d.FieldFormatLen("data", int64(dataLen)*8, &psshPlayreadyGroup, nil)
 		case systemID == nil:
 			fallthrough
 		default:
@@ -1605,7 +1605,7 @@ func decodeBox(ctx *decodeContext, d *decode.D, typ string) {
 				d.FieldU8("color_range")
 			}
 		case "prof":
-			d.FieldFormat("profile", iccProfileFormat, nil)
+			d.FieldFormat("profile", &iccProfileGroup, nil)
 		default:
 			d.FieldRawLen("data", d.BitsLeft())
 		}

--- a/format/mp4/mp4.go
+++ b/format/mp4/mp4.go
@@ -29,71 +29,72 @@ import (
 //go:embed mp4.md
 var mp4FS embed.FS
 
-var aacFrameFormat decode.Group
-var av1CCRFormat decode.Group
-var av1FrameFormat decode.Group
-var avcAUFormat decode.Group
-var avcDCRFormat decode.Group
-var flacFrameFormat decode.Group
-var flacMetadatablocksFormat decode.Group
-var hevcAUFormat decode.Group
-var hevcCDCRFormat decode.Group
-var iccProfileFormat decode.Group
-var id3v2Format decode.Group
-var imageFormat decode.Group
-var jpegFormat decode.Group
-var mp3FrameFormat decode.Group
-var mpegESFormat decode.Group
-var mpegPESPacketSampleFormat decode.Group
-var opusPacketFrameFormat decode.Group
-var pngFormat decode.Group
-var proResFrameFormat decode.Group
-var protoBufWidevineFormat decode.Group
-var psshPlayreadyFormat decode.Group
-var vorbisPacketFormat decode.Group
-var vp9FrameFormat decode.Group
-var vpxCCRFormat decode.Group
+var aacFrameGroup decode.Group
+var av1CCRGroup decode.Group
+var av1FrameGroup decode.Group
+var avcAUGroup decode.Group
+var avcDCRGroup decode.Group
+var flacFrameGroup decode.Group
+var flacMetadatablocksGroup decode.Group
+var hevcAUGroup decode.Group
+var hevcCDCRGroup decode.Group
+var iccProfileGroup decode.Group
+var id3v2Group decode.Group
+var imageGroup decode.Group
+var jpegGroup decode.Group
+var mp3FrameGroup decode.Group
+var mpegESGroup decode.Group
+var mpegPESPacketSampleGroup decode.Group
+var opusPacketFrameGroup decode.Group
+var pngGroup decode.Group
+var proResFrameGroup decode.Group
+var protoBufWidevineGroup decode.Group
+var psshPlayreadyGroup decode.Group
+var vorbisPacketGroup decode.Group
+var vp9FrameGroup decode.Group
+var vpxCCRGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MP4,
-		Description: "ISOBMFF, QuickTime and similar",
-		Groups: []string{
-			format.PROBE,
-			format.IMAGE, // avif
-		},
-		DecodeFn: mp4Decode,
-		DefaultInArg: format.Mp4In{
-			DecodeSamples:  true,
-			AllowTruncated: false,
-		},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AAC_FRAME}, Group: &aacFrameFormat},
-			{Names: []string{format.AV1_CCR}, Group: &av1CCRFormat},
-			{Names: []string{format.AV1_FRAME}, Group: &av1FrameFormat},
-			{Names: []string{format.AVC_AU}, Group: &avcAUFormat},
-			{Names: []string{format.AVC_DCR}, Group: &avcDCRFormat},
-			{Names: []string{format.FLAC_FRAME}, Group: &flacFrameFormat},
-			{Names: []string{format.FLAC_METADATABLOCKS}, Group: &flacMetadatablocksFormat},
-			{Names: []string{format.HEVC_AU}, Group: &hevcAUFormat},
-			{Names: []string{format.HEVC_DCR}, Group: &hevcCDCRFormat},
-			{Names: []string{format.ICC_PROFILE}, Group: &iccProfileFormat},
-			{Names: []string{format.ID3V2}, Group: &id3v2Format},
-			{Names: []string{format.IMAGE}, Group: &imageFormat},
-			{Names: []string{format.JPEG}, Group: &jpegFormat},
-			{Names: []string{format.MP3_FRAME}, Group: &mp3FrameFormat},
-			{Names: []string{format.MPEG_ES}, Group: &mpegESFormat},
-			{Names: []string{format.MPEG_PES_PACKET}, Group: &mpegPESPacketSampleFormat},
-			{Names: []string{format.OPUS_PACKET}, Group: &opusPacketFrameFormat},
-			{Names: []string{format.PNG}, Group: &pngFormat},
-			{Names: []string{format.PRORES_FRAME}, Group: &proResFrameFormat},
-			{Names: []string{format.PROTOBUF_WIDEVINE}, Group: &protoBufWidevineFormat},
-			{Names: []string{format.PSSH_PLAYREADY}, Group: &psshPlayreadyFormat},
-			{Names: []string{format.VORBIS_PACKET}, Group: &vorbisPacketFormat},
-			{Names: []string{format.VP9_FRAME}, Group: &vp9FrameFormat},
-			{Names: []string{format.VPX_CCR}, Group: &vpxCCRFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Mp4,
+		&decode.Format{
+			Description: "ISOBMFF, QuickTime and similar",
+			Groups: []*decode.Group{
+				format.Probe,
+				format.Image, // avif
+			},
+			DecodeFn: mp4Decode,
+			DefaultInArg: format.Mp4In{
+				DecodeSamples:  true,
+				AllowTruncated: false,
+			},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AacFrame}, Out: &aacFrameGroup},
+				{Groups: []*decode.Group{format.Av1Ccr}, Out: &av1CCRGroup},
+				{Groups: []*decode.Group{format.Av1Frame}, Out: &av1FrameGroup},
+				{Groups: []*decode.Group{format.AvcAu}, Out: &avcAUGroup},
+				{Groups: []*decode.Group{format.AvcDcr}, Out: &avcDCRGroup},
+				{Groups: []*decode.Group{format.FlacFrame}, Out: &flacFrameGroup},
+				{Groups: []*decode.Group{format.FlacMetadatablocks}, Out: &flacMetadatablocksGroup},
+				{Groups: []*decode.Group{format.HevcAu}, Out: &hevcAUGroup},
+				{Groups: []*decode.Group{format.HevcDcr}, Out: &hevcCDCRGroup},
+				{Groups: []*decode.Group{format.IccProfile}, Out: &iccProfileGroup},
+				{Groups: []*decode.Group{format.Id3v2}, Out: &id3v2Group},
+				{Groups: []*decode.Group{format.Image}, Out: &imageGroup},
+				{Groups: []*decode.Group{format.Jpeg}, Out: &jpegGroup},
+				{Groups: []*decode.Group{format.Mp3Frame}, Out: &mp3FrameGroup},
+				{Groups: []*decode.Group{format.MpegEs}, Out: &mpegESGroup},
+				{Groups: []*decode.Group{format.MpegPesPacket}, Out: &mpegPESPacketSampleGroup},
+				{Groups: []*decode.Group{format.OpusPacket}, Out: &opusPacketFrameGroup},
+				{Groups: []*decode.Group{format.Png}, Out: &pngGroup},
+				{Groups: []*decode.Group{format.ProresFrame}, Out: &proResFrameGroup},
+				{Groups: []*decode.Group{format.ProtobufWidevine}, Out: &protoBufWidevineGroup},
+				{Groups: []*decode.Group{format.PsshPlayready}, Out: &psshPlayreadyGroup},
+				{Groups: []*decode.Group{format.VorbisPacket}, Out: &vorbisPacketGroup},
+				{Groups: []*decode.Group{format.Vp9Frame}, Out: &vp9FrameGroup},
+				{Groups: []*decode.Group{format.VpxCcr}, Out: &vpxCCRGroup},
+			},
+		})
 	interp.RegisterFS(mp4FS)
 }
 
@@ -231,38 +232,38 @@ func mp4Tracks(d *decode.D, ctx *decodeContext) {
 
 					switch {
 					case dataFormat == "fLaC":
-						d.FieldFormatLen(name, nBits, flacFrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &flacFrameGroup, inArg)
 					case dataFormat == "Opus":
-						d.FieldFormatLen(name, nBits, opusPacketFrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &opusPacketFrameGroup, inArg)
 					case dataFormat == "vp09":
-						d.FieldFormatLen(name, nBits, vp9FrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &vp9FrameGroup, inArg)
 					case dataFormat == "avc1":
-						d.FieldFormatLen(name, nBits, avcAUFormat, inArg)
+						d.FieldFormatLen(name, nBits, &avcAUGroup, inArg)
 					case dataFormat == "hev1",
 						dataFormat == "hvc1":
-						d.FieldFormatLen(name, nBits, hevcAUFormat, inArg)
+						d.FieldFormatLen(name, nBits, &hevcAUGroup, inArg)
 					case dataFormat == "av01":
-						d.FieldFormatLen(name, nBits, av1FrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &av1FrameGroup, inArg)
 					case dataFormat == "mp4a" && t.objectType == format.MPEGObjectTypeMP3:
-						d.FieldFormatLen(name, nBits, mp3FrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &mp3FrameGroup, inArg)
 					case dataFormat == "mp4a" && t.objectType == format.MPEGObjectTypeAAC:
-						d.FieldFormatLen(name, nBits, aacFrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &aacFrameGroup, inArg)
 					case dataFormat == "mp4a" && t.objectType == format.MPEGObjectTypeVORBIS:
-						d.FieldFormatLen(name, nBits, vorbisPacketFormat, inArg)
+						d.FieldFormatLen(name, nBits, &vorbisPacketGroup, inArg)
 					case dataFormat == "mp4v" && t.objectType == format.MPEGObjectTypeMPEG2VideoMain:
-						d.FieldFormatLen(name, nBits, mpegPESPacketSampleFormat, inArg)
+						d.FieldFormatLen(name, nBits, &mpegPESPacketSampleGroup, inArg)
 					case dataFormat == "mp4v" && t.objectType == format.MPEGObjectTypeMJPEG:
-						d.FieldFormatLen(name, nBits, jpegFormat, inArg)
+						d.FieldFormatLen(name, nBits, &jpegGroup, inArg)
 					case dataFormat == "mp4v" && t.objectType == format.MPEGObjectTypePNG:
-						d.FieldFormatLen(name, nBits, pngFormat, inArg)
+						d.FieldFormatLen(name, nBits, &pngGroup, inArg)
 					case dataFormat == "jpeg":
-						d.FieldFormatLen(name, nBits, jpegFormat, inArg)
+						d.FieldFormatLen(name, nBits, &jpegGroup, inArg)
 					case dataFormat == "apch",
 						dataFormat == "apcn",
 						dataFormat == "scpa",
 						dataFormat == "apco",
 						dataFormat == "ap4h":
-						d.FieldFormatLen(name, nBits, proResFrameFormat, inArg)
+						d.FieldFormatLen(name, nBits, &proResFrameGroup, inArg)
 					default:
 						d.FieldRawLen(name, d.BitsLeft())
 					}

--- a/format/mp4/pssh_playready.go
+++ b/format/mp4/pssh_playready.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.PSSH_PLAYREADY,
-		Description: "PlayReady PSSH",
-		DecodeFn:    playreadyPsshDecode,
-	})
+	interp.RegisterFormat(
+		format.PsshPlayready,
+		&decode.Format{
+			Description: "PlayReady PSSH",
+			DecodeFn:    playreadyPsshDecode,
+		})
 }
 
 const (

--- a/format/mpeg/aac_frame.go
+++ b/format/mpeg/aac_frame.go
@@ -14,16 +14,17 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AAC_FRAME,
-		Description: "Advanced Audio Coding frame",
-		DecodeFn:    aacDecode,
-		DefaultInArg: format.AACFrameIn{
-			ObjectType: format.MPEGAudioObjectTypeMain,
-		},
-		RootArray: true,
-		RootName:  "elements",
-	})
+	interp.RegisterFormat(
+		format.AacFrame,
+		&decode.Format{
+			Description: "Advanced Audio Coding frame",
+			DecodeFn:    aacDecode,
+			DefaultInArg: format.AACFrameIn{
+				ObjectType: format.MPEGAudioObjectTypeMain,
+			},
+			RootArray: true,
+			RootName:  "elements",
+		})
 }
 
 const (

--- a/format/mpeg/adts.go
+++ b/format/mpeg/adts.go
@@ -6,26 +6,27 @@ import (
 	"github.com/wader/fq/pkg/interp"
 )
 
-var adtsFrame decode.Group
+var adtsFrameGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ADTS,
-		Description: "Audio Data Transport Stream",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    adtsDecoder,
-		RootArray:   true,
-		RootName:    "frames",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.ADTS_FRAME}, Group: &adtsFrame},
-		},
-	})
+	interp.RegisterFormat(
+		format.Adts,
+		&decode.Format{
+			Description: "Audio Data Transport Stream",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    adtsDecoder,
+			RootArray:   true,
+			RootName:    "frames",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AdtsFrame}, Out: &adtsFrameGroup},
+			},
+		})
 }
 
 func adtsDecoder(d *decode.D) any {
 	validFrames := 0
 	for !d.End() {
-		if dv, _, _ := d.TryFieldFormat("frame", adtsFrame, nil); dv == nil {
+		if dv, _, _ := d.TryFieldFormat("frame", &adtsFrameGroup, nil); dv == nil {
 			break
 		}
 		validFrames++

--- a/format/mpeg/adts_frame.go
+++ b/format/mpeg/adts_frame.go
@@ -11,17 +11,18 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var aacFrameFormat decode.Group
+var aacFrameGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.ADTS_FRAME,
-		Description: "Audio Data Transport Stream frame",
-		DecodeFn:    adtsFrameDecoder,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AAC_FRAME}, Group: &aacFrameFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.AdtsFrame,
+		&decode.Format{
+			Description: "Audio Data Transport Stream frame",
+			DecodeFn:    adtsFrameDecoder,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AacFrame}, Out: &aacFrameGroup},
+			},
+		})
 }
 
 var protectionAbsentNames = scalar.BoolMapDescription{
@@ -97,7 +98,7 @@ func adtsFrameDecoder(d *decode.D) any {
 
 	d.FieldArray("raw_data_blocks", func(d *decode.D) {
 		for i := uint64(0); i < numberOfRDBs; i++ {
-			d.FieldFormatLen("raw_data_block", dataLength*8, aacFrameFormat, format.AACFrameIn{ObjectType: int(objectType)})
+			d.FieldFormatLen("raw_data_block", dataLength*8, &aacFrameGroup, format.AACFrameIn{ObjectType: int(objectType)})
 		}
 	})
 

--- a/format/mpeg/annexb.go
+++ b/format/mpeg/annexb.go
@@ -38,7 +38,7 @@ func annexBDecode(d *decode.D, format decode.Group) any {
 		}
 
 		naluLen := nextOffset
-		d.FieldFormatLen("nalu", naluLen, format, nil)
+		d.FieldFormatLen("nalu", naluLen, &format, nil)
 
 		currentPrefixLen = nextPrefixLen
 	}

--- a/format/mpeg/avc_annexb.go
+++ b/format/mpeg/avc_annexb.go
@@ -9,16 +9,17 @@ import (
 var annexBAVCNALUFormat decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_ANNEXB,
-		Description: "H.264/AVC Annex B",
-		DecodeFn: func(d *decode.D) any {
-			return annexBDecode(d, annexBAVCNALUFormat)
-		},
-		RootArray: true,
-		RootName:  "stream",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AVC_NALU}, Group: &annexBAVCNALUFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.AvcAnnexb,
+		&decode.Format{
+			Description: "H.264/AVC Annex B",
+			DecodeFn: func(d *decode.D) any {
+				return annexBDecode(d, annexBAVCNALUFormat)
+			},
+			RootArray: true,
+			RootName:  "stream",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AvcNalu}, Out: &annexBAVCNALUFormat},
+			},
+		})
 }

--- a/format/mpeg/avc_au.go
+++ b/format/mpeg/avc_au.go
@@ -11,19 +11,20 @@ import (
 var avcNALUFormat decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_AU,
-		Description: "H.264/AVC Access Unit",
-		DecodeFn:    avcAUDecode,
-		DefaultInArg: format.AvcAuIn{
-			LengthSize: 0,
-		},
-		RootArray: true,
-		RootName:  "access_unit",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AVC_NALU}, Group: &avcNALUFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.AvcAu,
+		&decode.Format{
+			Description: "H.264/AVC Access Unit",
+			DecodeFn:    avcAUDecode,
+			DefaultInArg: format.AvcAuIn{
+				LengthSize: 0,
+			},
+			RootArray: true,
+			RootName:  "access_unit",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AvcNalu}, Out: &avcNALUFormat},
+			},
+		})
 }
 
 func avcAUDecode(d *decode.D) any {
@@ -39,7 +40,7 @@ func avcAUDecode(d *decode.D) any {
 	for d.NotEnd() {
 		d.FieldStruct("nalu", func(d *decode.D) {
 			l := int64(d.FieldU("length", int(ai.LengthSize)*8)) * 8
-			d.FieldFormatLen("nalu", l, avcNALUFormat, nil)
+			d.FieldFormatLen("nalu", l, &avcNALUFormat, nil)
 		})
 	}
 

--- a/format/mpeg/avc_dcr.go
+++ b/format/mpeg/avc_dcr.go
@@ -15,14 +15,15 @@ import (
 var avcDCRNALFormat decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_DCR,
-		Description: "H.264/AVC Decoder Configuration Record",
-		DecodeFn:    avcDcrDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AVC_NALU}, Group: &avcDCRNALFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.AvcDcr,
+		&decode.Format{
+			Description: "H.264/AVC Decoder Configuration Record",
+			DecodeFn:    avcDcrDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AvcNalu}, Out: &avcDCRNALFormat},
+			},
+		})
 }
 
 var avcProfileNames = scalar.UintMapSymStr{
@@ -111,7 +112,7 @@ func avcDcrParameterSet(d *decode.D, numParamSets uint64) {
 	for i := uint64(0); i < numParamSets; i++ {
 		d.FieldStruct("set", func(d *decode.D) {
 			paramSetLen := d.FieldU16("length")
-			d.FieldFormatLen("nal", int64(paramSetLen)*8, avcDCRNALFormat, nil)
+			d.FieldFormatLen("nal", int64(paramSetLen)*8, &avcDCRNALFormat, nil)
 		})
 	}
 }

--- a/format/mpeg/avc_nalu.go
+++ b/format/mpeg/avc_nalu.go
@@ -16,16 +16,17 @@ var avcPPSFormat decode.Group
 var avcSEIFormat decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_NALU,
-		Description: "H.264/AVC Network Access Layer Unit",
-		DecodeFn:    avcNALUDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.AVC_SPS}, Group: &avcSPSFormat},
-			{Names: []string{format.AVC_PPS}, Group: &avcPPSFormat},
-			{Names: []string{format.AVC_SEI}, Group: &avcSEIFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.AvcNalu,
+		&decode.Format{
+			Description: "H.264/AVC Network Access Layer Unit",
+			DecodeFn:    avcNALUDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.AvcSps}, Out: &avcSPSFormat},
+				{Groups: []*decode.Group{format.AvcPps}, Out: &avcPPSFormat},
+				{Groups: []*decode.Group{format.AvcSei}, Out: &avcSEIFormat},
+			},
+		})
 }
 
 // 14496-10 9.1 Parsing process for Exp-Golomb codes
@@ -119,11 +120,11 @@ func avcNALUDecode(d *decode.D) any {
 			// TODO: if ( separate_colour_plane_flag from SPS ) colour_plane_id; frame_num
 		})
 	case avcNALSupplementalEnhancementInformation:
-		d.FieldFormatBitBuf("sei", unescapedBR, avcSEIFormat, nil)
+		d.FieldFormatBitBuf("sei", unescapedBR, &avcSEIFormat, nil)
 	case avcNALSequenceParameterSet:
-		d.FieldFormatBitBuf("sps", unescapedBR, avcSPSFormat, nil)
+		d.FieldFormatBitBuf("sps", unescapedBR, &avcSPSFormat, nil)
 	case avcNALPictureParameterSet:
-		d.FieldFormatBitBuf("pps", unescapedBR, avcPPSFormat, nil)
+		d.FieldFormatBitBuf("pps", unescapedBR, &avcPPSFormat, nil)
 	}
 	d.FieldRawLen("data", d.BitsLeft())
 

--- a/format/mpeg/avc_pps.go
+++ b/format/mpeg/avc_pps.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_PPS,
-		Description: "H.264/AVC Picture Parameter Set",
-		DecodeFn:    avcPPSDecode,
-	})
+	interp.RegisterFormat(
+		format.AvcPps,
+		&decode.Format{
+			Description: "H.264/AVC Picture Parameter Set",
+			DecodeFn:    avcPPSDecode,
+		})
 }
 
 func moreRBSPData(d *decode.D) bool {

--- a/format/mpeg/avc_sei.go
+++ b/format/mpeg/avc_sei.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_SEI,
-		Description: "H.264/AVC Supplemental Enhancement Information",
-		DecodeFn:    avcSEIDecode,
-	})
+	interp.RegisterFormat(
+		format.AvcSei,
+		&decode.Format{
+			Description: "H.264/AVC Supplemental Enhancement Information",
+			DecodeFn:    avcSEIDecode,
+		})
 }
 
 const (

--- a/format/mpeg/avc_sps.go
+++ b/format/mpeg/avc_sps.go
@@ -8,11 +8,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AVC_SPS,
-		Description: "H.264/AVC Sequence Parameter Set",
-		DecodeFn:    avcSPSDecode,
-	})
+	interp.RegisterFormat(
+		format.AvcSps,
+		&decode.Format{
+			Description: "H.264/AVC Sequence Parameter Set",
+			DecodeFn:    avcSPSDecode,
+		})
 }
 
 var avcVideoFormatMap = scalar.UintMapSymStr{

--- a/format/mpeg/hevc_annexb.go
+++ b/format/mpeg/hevc_annexb.go
@@ -9,16 +9,17 @@ import (
 var annexBHEVCNALUFormat decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HEVC_ANNEXB,
-		Description: "H.265/HEVC Annex B",
-		DecodeFn: func(d *decode.D) any {
-			return annexBDecode(d, annexBHEVCNALUFormat)
-		},
-		RootArray: true,
-		RootName:  "stream",
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.HEVC_NALU}, Group: &annexBHEVCNALUFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.HevcAnnexb,
+		&decode.Format{
+			Description: "H.265/HEVC Annex B",
+			DecodeFn: func(d *decode.D) any {
+				return annexBDecode(d, annexBHEVCNALUFormat)
+			},
+			RootArray: true,
+			RootName:  "stream",
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.HevcNalu}, Out: &annexBHEVCNALUFormat},
+			},
+		})
 }

--- a/format/mpeg/hevc_dcr.go
+++ b/format/mpeg/hevc_dcr.go
@@ -7,17 +7,18 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var hevcDCRNALFormat decode.Group
+var hevcDCRNALGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HEVC_DCR,
-		Description: "H.265/HEVC Decoder Configuration Record",
-		DecodeFn:    hevcDcrDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.HEVC_NALU}, Group: &hevcDCRNALFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.HevcDcr,
+		&decode.Format{
+			Description: "H.265/HEVC Decoder Configuration Record",
+			DecodeFn:    hevcDcrDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.HevcNalu}, Out: &hevcDCRNALGroup},
+			},
+		})
 }
 
 func hevcDcrDecode(d *decode.D) any {
@@ -55,7 +56,7 @@ func hevcDcrDecode(d *decode.D) any {
 					for i := uint64(0); i < numNals; i++ {
 						d.FieldStruct("nal", func(d *decode.D) {
 							nalUnitLength := int64(d.FieldU16("nal_unit_length"))
-							d.FieldFormatLen("nal", nalUnitLength*8, hevcDCRNALFormat, nil)
+							d.FieldFormatLen("nal", nalUnitLength*8, &hevcDCRNALGroup, nil)
 						})
 					}
 				})

--- a/format/mpeg/hevc_nalu.go
+++ b/format/mpeg/hevc_nalu.go
@@ -8,21 +8,22 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var hevcVPSFormat decode.Group
-var hevcPPSFormat decode.Group
-var hevcSPSFormat decode.Group
+var hevcVPSGroup decode.Group
+var hevcPPSGroup decode.Group
+var hevcSPSGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HEVC_NALU,
-		Description: "H.265/HEVC Network Access Layer Unit",
-		DecodeFn:    hevcNALUDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.HEVC_VPS}, Group: &hevcVPSFormat},
-			{Names: []string{format.HEVC_PPS}, Group: &hevcPPSFormat},
-			{Names: []string{format.HEVC_SPS}, Group: &hevcSPSFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.HevcNalu,
+		&decode.Format{
+			Description: "H.265/HEVC Network Access Layer Unit",
+			DecodeFn:    hevcNALUDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.HevcVps}, Out: &hevcVPSGroup},
+				{Groups: []*decode.Group{format.HevcPps}, Out: &hevcPPSGroup},
+				{Groups: []*decode.Group{format.HevcSps}, Out: &hevcSPSGroup},
+			},
+		})
 }
 
 const (
@@ -91,11 +92,11 @@ func hevcNALUDecode(d *decode.D) any {
 
 	switch nalType {
 	case hevcNALNUTVPS:
-		d.FieldFormatBitBuf("vps", unescapedBR, hevcVPSFormat, nil)
+		d.FieldFormatBitBuf("vps", unescapedBR, &hevcVPSGroup, nil)
 	case hevcNALNUTPPS:
-		d.FieldFormatBitBuf("pps", unescapedBR, hevcPPSFormat, nil)
+		d.FieldFormatBitBuf("pps", unescapedBR, &hevcPPSGroup, nil)
 	case hevcNALNUTSPS:
-		d.FieldFormatBitBuf("sps", unescapedBR, hevcSPSFormat, nil)
+		d.FieldFormatBitBuf("sps", unescapedBR, &hevcSPSGroup, nil)
 	}
 	d.FieldRawLen("data", d.BitsLeft())
 

--- a/format/mpeg/hevc_pps.go
+++ b/format/mpeg/hevc_pps.go
@@ -9,11 +9,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HEVC_PPS,
-		Description: "H.265/HEVC Picture Parameter Set",
-		DecodeFn:    hevcPPSDecode,
-	})
+	interp.RegisterFormat(
+		format.HevcPps,
+		&decode.Format{
+			Description: "H.265/HEVC Picture Parameter Set",
+			DecodeFn:    hevcPPSDecode,
+		})
 }
 
 // H.265 page 36

--- a/format/mpeg/hevc_sps.go
+++ b/format/mpeg/hevc_sps.go
@@ -9,11 +9,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HEVC_SPS,
-		Description: "H.265/HEVC Sequence Parameter Set",
-		DecodeFn:    hevcSPSDecode,
-	})
+	interp.RegisterFormat(
+		format.HevcSps,
+		&decode.Format{
+			Description: "H.265/HEVC Sequence Parameter Set",
+			DecodeFn:    hevcSPSDecode,
+		})
 }
 
 func profileLayerDecode(d *decode.D, prefix string, profilePresent bool, levelPresent bool, isSublayer bool) {

--- a/format/mpeg/hevc_vps.go
+++ b/format/mpeg/hevc_vps.go
@@ -9,11 +9,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HEVC_VPS,
-		Description: "H.265/HEVC Video Parameter Set",
-		DecodeFn:    hevcVPSDecode,
-	})
+	interp.RegisterFormat(
+		format.HevcVps,
+		&decode.Format{
+			Description: "H.265/HEVC Video Parameter Set",
+			DecodeFn:    hevcVPSDecode,
+		})
 }
 
 const maxVpsLayers = 1000

--- a/format/mpeg/mp3_frame.go
+++ b/format/mpeg/mp3_frame.go
@@ -21,17 +21,18 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var mp3FrameTagsHeader decode.Group
+var mp3FrameTagsGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MP3_FRAME,
-		Description: "MPEG audio layer 3 frame",
-		DecodeFn:    frameDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.MP3_FRAME_TAGS}, Group: &mp3FrameTagsHeader},
-		},
-	})
+	interp.RegisterFormat(
+		format.Mp3Frame,
+		&decode.Format{
+			Description: "MPEG audio layer 3 frame",
+			DecodeFn:    frameDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Mp3FrameTags}, Out: &mp3FrameTagsGroup},
+			},
+		})
 }
 
 // TODO: keep track of main data buffer and decode huffman tables
@@ -375,7 +376,7 @@ func frameDecode(d *decode.D) any {
 	// audio data size, may include audio data from other frames also if main_data_begin is used
 	restBytes := frameBytes - headerBytes - crcBytes - sideInfoBytes
 	d.FramedFn(int64(restBytes)*8, func(d *decode.D) {
-		_, _, _ = d.TryFieldFormat("tag", mp3FrameTagsHeader, nil)
+		_, _, _ = d.TryFieldFormat("tag", &mp3FrameTagsGroup, nil)
 		d.FieldRawLen("audio_data", d.BitsLeft())
 	})
 

--- a/format/mpeg/mpeg_asc.go
+++ b/format/mpeg/mpeg_asc.go
@@ -10,11 +10,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MPEG_ASC,
-		Description: "MPEG-4 Audio Specific Config",
-		DecodeFn:    ascDecoder,
-	})
+	interp.RegisterFormat(
+		format.MpegAsc,
+		&decode.Format{
+			Description: "MPEG-4 Audio Specific Config",
+			DecodeFn:    ascDecoder,
+		})
 }
 
 var frequencyIndexHzMap = scalar.UintMapSymUint{

--- a/format/mpeg/mpeg_pes_packet.go
+++ b/format/mpeg/mpeg_pes_packet.go
@@ -11,11 +11,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MPEG_PES_PACKET,
-		Description: "MPEG Packetized elementary stream packet",
-		DecodeFn:    pesPacketDecode,
-	})
+	interp.RegisterFormat(
+		format.MpegPesPacket,
+		&decode.Format{
+			Description: "MPEG Packetized elementary stream packet",
+			DecodeFn:    pesPacketDecode,
+		})
 }
 
 const (

--- a/format/mpeg/mpeg_spu.go
+++ b/format/mpeg/mpeg_spu.go
@@ -15,11 +15,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MPEG_SPU,
-		Description: "Sub Picture Unit (DVD subtitle)",
-		DecodeFn:    spuDecode,
-	})
+	interp.RegisterFormat(
+		format.MpegSpu,
+		&decode.Format{
+			Description: "Sub Picture Unit (DVD subtitle)",
+			DecodeFn:    spuDecode,
+		})
 }
 
 const (

--- a/format/mpeg/mpeg_ts.go
+++ b/format/mpeg/mpeg_ts.go
@@ -8,13 +8,14 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MPEG_TS,
-		ProbeOrder:  format.ProbeOrderBinFuzzy, // make sure to be after gif, both start with 0x47
-		Description: "MPEG Transport Stream",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    tsDecode,
-	})
+	interp.RegisterFormat(
+		format.MpegTs,
+		&decode.Format{
+			ProbeOrder:  format.ProbeOrderBinFuzzy, // make sure to be after gif, both start with 0x47
+			Description: "MPEG Transport Stream",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    tsDecode,
+		})
 }
 
 // TODO: ts_packet

--- a/format/msgpack/msgpack.go
+++ b/format/msgpack/msgpack.go
@@ -18,12 +18,13 @@ import (
 var msgPackFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.MSGPACK,
-		Description: "MessagePack",
-		DecodeFn:    decodeMsgPack,
-		Functions:   []string{"torepr"},
-	})
+	interp.RegisterFormat(
+		format.Msgpack,
+		&decode.Format{
+			Description: "MessagePack",
+			DecodeFn:    decodeMsgPack,
+			Functions:   []string{"torepr"},
+		})
 	interp.RegisterFS(msgPackFS)
 }
 

--- a/format/ogg/ogg_page.go
+++ b/format/ogg/ogg_page.go
@@ -12,11 +12,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.OGG_PAGE,
-		Description: "OGG page",
-		DecodeFn:    pageDecode,
-	})
+	interp.RegisterFormat(
+		format.OggPage,
+		&decode.Format{
+			Description: "OGG page",
+			DecodeFn:    pageDecode,
+		})
 }
 
 func pageDecode(d *decode.D) any {

--- a/format/opus/opus_packet.go
+++ b/format/opus/opus_packet.go
@@ -13,14 +13,15 @@ import (
 var vorbisComment decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.OPUS_PACKET,
-		Description: "Opus packet",
-		DecodeFn:    opusDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.VORBIS_COMMENT}, Group: &vorbisComment},
-		},
-	})
+	interp.RegisterFormat(
+		format.OpusPacket,
+		&decode.Format{
+			Description: "Opus packet",
+			DecodeFn:    opusDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.VorbisComment}, Out: &vorbisComment},
+			},
+		})
 }
 
 func opusDecode(d *decode.D) any {
@@ -51,7 +52,7 @@ func opusDecode(d *decode.D) any {
 	case bytes.Equal(prefix, []byte("OpusTags")):
 		d.FieldValueStr("type", "tags")
 		d.FieldUTF8("prefix", 8)
-		d.FieldFormat("comment", vorbisComment, nil)
+		d.FieldFormat("comment", &vorbisComment, nil)
 	default:
 		d.FieldValueStr("type", "audio")
 		d.FieldStruct("toc", func(d *decode.D) {

--- a/format/pcap/shared.go
+++ b/format/pcap/shared.go
@@ -25,7 +25,7 @@ func fieldFlows(d *decode.D, fd *flowsdecoder.Decoder, tcpStreamFormat decode.Gr
 			if dv, _, _ := d.TryFieldFormatBitBuf(
 				"ipv4_packet",
 				br,
-				ipv4PacketFormat,
+				&ipv4PacketFormat,
 				nil,
 			); dv == nil {
 				d.FieldRootBitBuf("ipv4_packet", br)
@@ -47,7 +47,7 @@ func fieldFlows(d *decode.D, fd *flowsdecoder.Decoder, tcpStreamFormat decode.Gr
 					dv, outV, _ := d.TryFieldFormatBitBuf(
 						"stream",
 						br,
-						tcpStreamFormat,
+						&tcpStreamFormat,
 						tsi,
 					)
 					if dv == nil {

--- a/format/prores/prores_frame.go
+++ b/format/prores/prores_frame.go
@@ -10,11 +10,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.PRORES_FRAME,
-		Description: "Apple ProRes frame",
-		DecodeFn:    decodeProResFrame,
-	})
+	interp.RegisterFormat(
+		format.ProresFrame,
+		&decode.Format{
+			Description: "Apple ProRes frame",
+			DecodeFn:    decodeProResFrame,
+		})
 }
 
 func decodeProResFrame(d *decode.D) any {

--- a/format/protobuf/protobuf.go
+++ b/format/protobuf/protobuf.go
@@ -17,11 +17,12 @@ import (
 var protobufFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.PROTOBUF,
-		Description: "Protobuf",
-		DecodeFn:    protobufDecode,
-	})
+	interp.RegisterFormat(
+		format.Protobuf,
+		&decode.Format{
+			Description: "Protobuf",
+			DecodeFn:    protobufDecode,
+		})
 	interp.RegisterFS(protobufFS)
 }
 

--- a/format/protobuf/protobuf_widevine.go
+++ b/format/protobuf/protobuf_widevine.go
@@ -9,17 +9,18 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var widevineProtoBufFormat decode.Group
+var widevineProtoBufGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.PROTOBUF_WIDEVINE,
-		Description: "Widevine protobuf",
-		DecodeFn:    widevineDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.PROTOBUF}, Group: &widevineProtoBufFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.ProtobufWidevine,
+		&decode.Format{
+			Description: "Widevine protobuf",
+			DecodeFn:    widevineDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Protobuf}, Out: &widevineProtoBufGroup},
+			},
+		})
 }
 
 func widevineDecode(d *decode.D) any {
@@ -42,7 +43,7 @@ func widevineDecode(d *decode.D) any {
 		}},
 	}
 
-	d.Format(widevineProtoBufFormat, format.ProtoBufIn{Message: widewinePb})
+	d.Format(&widevineProtoBufGroup, format.ProtoBufIn{Message: widewinePb})
 
 	return nil
 }

--- a/format/riff/aiff.go
+++ b/format/riff/aiff.go
@@ -10,13 +10,14 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AIFF,
-		ProbeOrder:  format.ProbeOrderBinFuzzy,
-		Description: "Audio Interchange File Format",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    aiffDecode,
-	})
+	interp.RegisterFormat(
+		format.Aiff,
+		&decode.Format{
+			ProbeOrder:  format.ProbeOrderBinFuzzy,
+			Description: "Audio Interchange File Format",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    aiffDecode,
+		})
 }
 
 const aiffRiffType = "AIFF"

--- a/format/rtmp/amf0.go
+++ b/format/rtmp/amf0.go
@@ -10,11 +10,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.AMF0,
-		Description: "Action Message Format 0",
-		DecodeFn:    amf0Decode,
-	})
+	interp.RegisterFormat(
+		format.Amf0,
+		&decode.Format{
+			Description: "Action Message Format 0",
+			DecodeFn:    amf0Decode,
+		})
 }
 
 const (

--- a/format/tar/tar.go
+++ b/format/tar/tar.go
@@ -13,18 +13,19 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var probeFormat decode.Group
+var probeGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.TAR,
-		Description: "Tar archive",
-		Groups:      []string{format.PROBE},
-		DecodeFn:    tarDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.PROBE}, Group: &probeFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Tar,
+		&decode.Format{
+			Description: "Tar archive",
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    tarDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Probe}, Out: &probeGroup},
+			},
+		})
 }
 
 var unixTimeEpochDate = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -75,7 +76,7 @@ func tarDecode(d *decode.D) any {
 				d.FieldUTF8("prefix", 155, mapTrimSpaceNull)
 				d.FieldRawLen("header_block_padding", blockPadding(d), d.BitBufIsZero())
 
-				d.FieldFormatOrRawLen("data", int64(size), probeFormat, nil)
+				d.FieldFormatOrRawLen("data", int64(size), &probeGroup, nil)
 
 				d.FieldRawLen("data_block_padding", blockPadding(d), d.BitBufIsZero())
 			})

--- a/format/tiff/exif.go
+++ b/format/tiff/exif.go
@@ -12,10 +12,11 @@ import (
 // currently just a alias for tiff
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.EXIF,
-		Description: "Exchangeable Image File Format",
-		Groups:      []string{},
-		DecodeFn:    tiffDecode,
-	})
+	interp.RegisterFormat(
+		format.Exif,
+		&decode.Format{
+			Description: "Exchangeable Image File Format",
+			Groups:      []*decode.Group{},
+			DecodeFn:    tiffDecode,
+		})
 }

--- a/format/tiff/tiff.go
+++ b/format/tiff/tiff.go
@@ -12,15 +12,16 @@ import (
 var tiffIccProfile decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.TIFF,
-		Description: "Tag Image File Format",
-		Groups:      []string{format.PROBE, format.IMAGE},
-		DecodeFn:    tiffDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.ICC_PROFILE}, Group: &tiffIccProfile},
-		},
-	})
+	interp.RegisterFormat(
+		format.Tiff,
+		&decode.Format{
+			Description: "Tag Image File Format",
+			Groups:      []*decode.Group{format.Probe, format.Image},
+			DecodeFn:    tiffDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.IccProfile}, Out: &tiffIccProfile},
+			},
+		})
 }
 
 const littleEndian = 0x49492a00 // "II*\0"
@@ -138,7 +139,7 @@ func decodeIfd(d *decode.D, s *strips, tagNames scalar.UintMapSymStr) int64 {
 							case typ == UNDEFINED:
 								switch tag {
 								case InterColorProfile:
-									d.FieldFormatRange("icc", int64(valueByteOffset)*8, int64(valueByteSize)*8, tiffIccProfile, nil)
+									d.FieldFormatRange("icc", int64(valueByteOffset)*8, int64(valueByteSize)*8, &tiffIccProfile, nil)
 								default:
 									d.RangeFn(int64(valueByteOffset*8), int64(valueByteSize*8), func(d *decode.D) {
 										d.FieldRawLen("value", d.BitsLeft())

--- a/format/tls/tls.go
+++ b/format/tls/tls.go
@@ -39,19 +39,20 @@ import (
 //go:embed tls.md
 var tlsFS embed.FS
 
-var asn1BerFormat decode.Group
+var asn1BerGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:         format.TLS,
-		Description:  "Transport layer security",
-		Groups:       []string{format.TCP_STREAM},
-		DecodeFn:     decodeTLS,
-		DefaultInArg: format.TLSIn{},
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.ASN1_BER}, Group: &asn1BerFormat},
-		},
-	})
+	interp.RegisterFormat(
+		format.Tls,
+		&decode.Format{
+			Description:  "Transport layer security",
+			Groups:       []*decode.Group{format.TcpStream},
+			DecodeFn:     decodeTLS,
+			DefaultInArg: format.TLSIn{},
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Asn1Ber}, Out: &asn1BerGroup},
+			},
+		})
 	interp.RegisterFS(tlsFS)
 }
 
@@ -366,7 +367,7 @@ func decodeTLSHandshake(d *decode.D, tc *tlsCtx) {
 					for !d.End() {
 						d.FieldStruct("certificate", func(d *decode.D) {
 							length := d.FieldU24("length")
-							d.FieldFormatLen("data", int64(length)*8, asn1BerFormat, nil)
+							d.FieldFormatLen("data", int64(length)*8, &asn1BerGroup, nil)
 						})
 					}
 				})

--- a/format/toml/toml.go
+++ b/format/toml/toml.go
@@ -21,14 +21,15 @@ import (
 var tomlFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.TOML,
-		Description: "Tom's Obvious, Minimal Language",
-		ProbeOrder:  format.ProbeOrderTextFuzzy,
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeTOML,
-		Functions:   []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Toml,
+		&decode.Format{
+			Description: "Tom's Obvious, Minimal Language",
+			ProbeOrder:  format.ProbeOrderTextFuzzy,
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeTOML,
+			Functions:   []string{"_todisplay"},
+		})
 	interp.RegisterFS(tomlFS)
 	interp.RegisterFunc0("to_toml", toTOML)
 }

--- a/format/tzif/tzif.go
+++ b/format/tzif/tzif.go
@@ -14,12 +14,13 @@ import (
 var tzifFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.TZIF,
-		Description: "Time Zone Information Format",
-		DecodeFn:    decodeTZIF,
-		Groups:      []string{format.PROBE},
-	})
+	interp.RegisterFormat(
+		format.Tzif,
+		&decode.Format{
+			Description: "Time Zone Information Format",
+			DecodeFn:    decodeTZIF,
+			Groups:      []*decode.Group{format.Probe},
+		})
 	interp.RegisterFS(tzifFS)
 }
 

--- a/format/vorbis/vorbis_comment.go
+++ b/format/vorbis/vorbis_comment.go
@@ -13,14 +13,15 @@ import (
 var flacPicture decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.VORBIS_COMMENT,
-		Description: "Vorbis comment",
-		DecodeFn:    commentDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.FLAC_PICTURE}, Group: &flacPicture},
-		},
-	})
+	interp.RegisterFormat(
+		format.VorbisComment,
+		&decode.Format{
+			Description: "Vorbis comment",
+			DecodeFn:    commentDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.FlacPicture}, Out: &flacPicture},
+			},
+		})
 }
 
 func commentDecode(d *decode.D) any {
@@ -46,7 +47,7 @@ func commentDecode(d *decode.D) any {
 				"picture",
 				userCommentStart+base64Offset, base64Len,
 				func(r io.Reader) io.Reader { return base64.NewDecoder(base64.StdEncoding, r) },
-				flacPicture, nil,
+				&flacPicture, nil,
 			)
 			if dv == nil && base64Br != nil {
 				d.FieldRootBitBuf("picture", base64Br)

--- a/format/vorbis/vorbis_packet.go
+++ b/format/vorbis/vorbis_packet.go
@@ -14,14 +14,15 @@ import (
 var vorbisComment decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.VORBIS_PACKET,
-		Description: "Vorbis packet",
-		DecodeFn:    vorbisDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.VORBIS_COMMENT}, Group: &vorbisComment},
-		},
-	})
+	interp.RegisterFormat(
+		format.VorbisPacket,
+		&decode.Format{
+			Description: "Vorbis packet",
+			DecodeFn:    vorbisDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.VorbisComment}, Out: &vorbisComment},
+			},
+		})
 }
 
 const (
@@ -114,7 +115,7 @@ func vorbisDecode(d *decode.D) any {
 		// }
 
 	case packetTypeComment:
-		d.FieldFormat("comment", vorbisComment, nil)
+		d.FieldFormat("comment", &vorbisComment, nil)
 
 		// note this uses vorbis bitpacking convention, bits are added LSB first per byte
 		d.FieldRawLen("padding0", 7, d.BitBufIsZero())

--- a/format/vpx/vp8_frame.go
+++ b/format/vpx/vp8_frame.go
@@ -12,11 +12,12 @@ import (
 // TODO: vpx frame?
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.VP8_FRAME,
-		Description: "VP8 frame",
-		DecodeFn:    vp8Decode,
-	})
+	interp.RegisterFormat(
+		format.Vp8Frame,
+		&decode.Format{
+			Description: "VP8 frame",
+			DecodeFn:    vp8Decode,
+		})
 }
 
 func vp8Decode(d *decode.D) any {

--- a/format/vpx/vp9_cfm.go
+++ b/format/vpx/vp9_cfm.go
@@ -9,13 +9,14 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.VP9_CFM,
-		Description: "VP9 Codec Feature Metadata",
-		DecodeFn:    vp9CFMDecode,
-		RootArray:   true,
-		RootName:    "features",
-	})
+	interp.RegisterFormat(
+		format.Vp9Cfm,
+		&decode.Format{
+			Description: "VP9 Codec Feature Metadata",
+			DecodeFn:    vp9CFMDecode,
+			RootArray:   true,
+			RootName:    "features",
+		})
 }
 
 func vp9CFMDecode(d *decode.D) any {

--- a/format/vpx/vp9_frame.go
+++ b/format/vpx/vp9_frame.go
@@ -55,11 +55,12 @@ var vp9ProfilesMap = scalar.UintMapDescription{
 }
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.VP9_FRAME,
-		Description: "VP9 frame",
-		DecodeFn:    vp9Decode,
-	})
+	interp.RegisterFormat(
+		format.Vp9Frame,
+		&decode.Format{
+			Description: "VP9 frame",
+			DecodeFn:    vp9Decode,
+		})
 }
 
 func vp9DecodeFrameSyncCode(d *decode.D) {

--- a/format/vpx/vpx_ccr.go
+++ b/format/vpx/vpx_ccr.go
@@ -9,11 +9,12 @@ import (
 )
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.VPX_CCR,
-		Description: "VPX Codec Configuration Record",
-		DecodeFn:    vpxCCRDecode,
-	})
+	interp.RegisterFormat(
+		format.VpxCcr,
+		&decode.Format{
+			Description: "VPX Codec Configuration Record",
+			DecodeFn:    vpxCCRDecode,
+		})
 }
 
 func vpxCCRDecode(d *decode.D) any {

--- a/format/wasm/wasm.go
+++ b/format/wasm/wasm.go
@@ -17,12 +17,13 @@ import (
 var wasmFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.WASM,
-		Description: "WebAssembly Binary Format",
-		DecodeFn:    decodeWASM,
-		Groups:      []string{format.PROBE},
-	})
+	interp.RegisterFormat(
+		format.Wasm,
+		&decode.Format{
+			Description: "WebAssembly Binary Format",
+			DecodeFn:    decodeWASM,
+			Groups:      []*decode.Group{format.Probe},
+		})
 	interp.RegisterFS(wasmFS)
 }
 

--- a/format/webp/webp.go
+++ b/format/webp/webp.go
@@ -11,18 +11,19 @@ import (
 	"github.com/wader/fq/pkg/scalar"
 )
 
-var vp8Frame decode.Group
+var vp8FrameGroup decode.Group
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.WEBP,
-		Description: "WebP image",
-		Groups:      []string{format.PROBE, format.IMAGE},
-		DecodeFn:    webpDecode,
-		Dependencies: []decode.Dependency{
-			{Names: []string{format.VP8_FRAME}, Group: &vp8Frame},
-		},
-	})
+	interp.RegisterFormat(
+		format.Webp,
+		&decode.Format{
+			Description: "WebP image",
+			Groups:      []*decode.Group{format.Probe, format.Image},
+			DecodeFn:    webpDecode,
+			Dependencies: []decode.Dependency{
+				{Groups: []*decode.Group{format.Vp8Frame}, Out: &vp8FrameGroup},
+			},
+		})
 }
 
 func decodeChunk(d *decode.D, expectedChunkID string, fn func(d *decode.D)) {
@@ -55,7 +56,7 @@ func webpDecode(d *decode.D) any {
 		case bytes.Equal(p, []byte("VP8 ")):
 			d.FieldStruct("image", func(d *decode.D) {
 				decodeChunk(d, "VP8", func(d *decode.D) {
-					d.Format(vp8Frame, nil)
+					d.Format(&vp8FrameGroup, nil)
 				})
 			})
 		case bytes.Equal(p, []byte("VP8L")):

--- a/format/xml/html.go
+++ b/format/xml/html.go
@@ -17,17 +17,18 @@ import (
 var htmlFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.HTML,
-		Description: "HyperText Markup Language",
-		DecodeFn:    decodeHTML,
-		DefaultInArg: format.HTMLIn{
-			Seq:             false,
-			Array:           false,
-			AttributePrefix: "@",
-		},
-		Functions: []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Html,
+		&decode.Format{
+			Description: "HyperText Markup Language",
+			DecodeFn:    decodeHTML,
+			DefaultInArg: format.HTMLIn{
+				Seq:             false,
+				Array:           false,
+				AttributePrefix: "@",
+			},
+			Functions: []string{"_todisplay"},
+		})
 	interp.RegisterFS(htmlFS)
 }
 

--- a/format/xml/xml.go
+++ b/format/xml/xml.go
@@ -36,19 +36,20 @@ import (
 var xmlFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.XML,
-		Description: "Extensible Markup Language",
-		ProbeOrder:  format.ProbeOrderTextFuzzy,
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeXML,
-		DefaultInArg: format.XMLIn{
-			Seq:             false,
-			Array:           false,
-			AttributePrefix: "@",
-		},
-		Functions: []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Xml,
+		&decode.Format{
+			Description: "Extensible Markup Language",
+			ProbeOrder:  format.ProbeOrderTextFuzzy,
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeXML,
+			DefaultInArg: format.XMLIn{
+				Seq:             false,
+				Array:           false,
+				AttributePrefix: "@",
+			},
+			Functions: []string{"_todisplay"},
+		})
 	interp.RegisterFS(xmlFS)
 	interp.RegisterFunc1("to_xml", toXML)
 	interp.RegisterFunc0("from_xmlentities", func(_ *interp.Interp, c string) any {

--- a/format/yaml/yaml.go
+++ b/format/yaml/yaml.go
@@ -20,14 +20,15 @@ import (
 var yamlFS embed.FS
 
 func init() {
-	interp.RegisterFormat(decode.Format{
-		Name:        format.YAML,
-		Description: "YAML Ain't Markup Language",
-		ProbeOrder:  format.ProbeOrderTextFuzzy,
-		Groups:      []string{format.PROBE},
-		DecodeFn:    decodeYAML,
-		Functions:   []string{"_todisplay"},
-	})
+	interp.RegisterFormat(
+		format.Yaml,
+		&decode.Format{
+			Description: "YAML Ain't Markup Language",
+			ProbeOrder:  format.ProbeOrderTextFuzzy,
+			Groups:      []*decode.Group{format.Probe},
+			DecodeFn:    decodeYAML,
+			Functions:   []string{"_todisplay"},
+		})
 	interp.RegisterFS(yamlFS)
 	interp.RegisterFunc0("to_yaml", toYAML)
 }

--- a/pkg/decode/errors.go
+++ b/pkg/decode/errors.go
@@ -14,7 +14,7 @@ type RecoverableErrorer interface {
 
 type FormatError struct {
 	Err        error
-	Format     Format
+	Format     *Format
 	Stacktrace recoverfn.Raw
 }
 

--- a/pkg/decode/format.go
+++ b/pkg/decode/format.go
@@ -1,17 +1,21 @@
 package decode
 
-type Group []Format
+type Group struct {
+	Name         string
+	Formats      []*Format
+	DefaultInArg any
+}
 
 type Dependency struct {
-	Names []string
-	Group *Group
+	Groups []*Group
+	Out    *Group
 }
 
 type Format struct {
 	Name               string
 	ProbeOrder         int // probe order is from low to hi value then by name
 	Description        string
-	Groups             []string
+	Groups             []*Group
 	DecodeFn           func(d *D) any
 	DefaultInArg       any
 	RootArray          bool
@@ -21,8 +25,10 @@ type Format struct {
 	SkipDecodeFunction bool
 }
 
-func FormatFn(d func(d *D) any) Group {
-	return Group{{
-		DecodeFn: d,
-	}}
+func FormatFn(fn func(d *D) any) *Group {
+	return &Group{
+		Formats: []*Format{
+			{DecodeFn: fn},
+		},
+	}
 }

--- a/pkg/interp/decode.jq
+++ b/pkg/interp/decode.jq
@@ -51,7 +51,7 @@ def decode($name; $decode_opts):
     )
   );
 def decode($name): decode($name; {});
-def decode: decode(options.decode_format; {});
+def decode: decode(options.decode_group; {});
 
 def topath: _decode_value(._path);
 def tovalue($opts): _tovalue(options($opts));

--- a/pkg/interp/default_register.go
+++ b/pkg/interp/default_register.go
@@ -11,8 +11,8 @@ import (
 // DefaultRegistry global registry used by formats
 var DefaultRegistry = NewRegistry()
 
-func RegisterFormat(format decode.Format) {
-	DefaultRegistry.Format(format)
+func RegisterFormat(group *decode.Group, format *decode.Format) {
+	DefaultRegistry.Format(group, format)
 }
 
 func RegisterFS(fs fs.ReadDirFS) {

--- a/pkg/interp/format_decode.jq
+++ b/pkg/interp/format_decode.jq
@@ -8,9 +8,8 @@
 [ _registry as $r
 | $r.groups
 | to_entries[]
-# TODO: nicer way to skip "all" which also would override builtin all/*
 # skip_decode_function is used to skip bits/bytes as they are special tobits/tobytes
-| select(.key != "all" and ($r.formats[.key].skip_decode_function | not))
+| select($r.formats[.key].skip_decode_function | not)
 | "def \(.key)($opts): decode(\(.key | tojson); $opts);"
 , "def \(.key): decode(\(.key | tojson); {});"
 , "def from_\(.key)($opts): decode(\(.key | tojson); $opts) | if ._error then error(._error.error) end;"

--- a/pkg/interp/init.jq
+++ b/pkg/interp/init.jq
@@ -43,7 +43,7 @@ def input:
       catch
         ( . as $err
         | _input_decode_errors(. += {($name): $err}) as $_
-        | [ $opts.decode_format
+        | [ $opts.decode_group
           , if $err | _is_string then ": \($err)"
             # TODO: if not string assume decode itself failed for now
             else ": failed to decode: try fq -d FORMAT to force format, see fq -h formats for list"

--- a/pkg/interp/options.jq
+++ b/pkg/interp/options.jq
@@ -43,7 +43,7 @@ def _opt_build_default_fixed:
       },
       compact:            false,
       completion_timeout: (env.COMPLETION_TIMEOUT | if . != null then tonumber else 1 end),
-      decode_format:      "probe",
+      decode_group:       "probe",
       decode_progress:    (env.NO_DECODE_PROGRESS == null),
       depth:              0,
       expr:               ".",
@@ -83,7 +83,7 @@ def _opt_options:
     colors:             "csv_kv_obj",
     compact:            "boolean",
     completion_timeout: "number",
-    decode_format:      "string",
+    decode_group:       "string",
     decode_progress:    "boolean",
     depth:              "number",
     display_bytes:      "number",
@@ -409,10 +409,10 @@ def _opt_cli_opts:
       description: "Force color output",
       bool: true
     },
-    "decode_format": {
+    "decode_group": {
       short: "-d",
       long: "--decode",
-      description: "Decode format (probe)",
+      description: "Decode format or group (probe)",
       string: "NAME"
     },
     "expr_file": {

--- a/pkg/interp/testdata/args.fqtest
+++ b/pkg/interp/testdata/args.fqtest
@@ -29,7 +29,7 @@ Example usages:
 --argjson NAME JSON          Set variable $NAME to JSON
 --color-output,-C            Force color output
 --compact-output,-c          Compact output
---decode,-d NAME             Decode format (probe)
+--decode,-d NAME             Decode format or group (probe)
 --from-file,-f PATH          Read EXPR from file
 --help,-h [TOPIC]            Show help for TOPIC (ex: -h formats, -h mp4)
 --include-path,-L PATH       Include search path
@@ -78,7 +78,7 @@ color               false
 colors              array=white,dumpaddr=yellow,dumpheader=yellow+underline,error=brightred,false=yellow,index=white,null=brightblack,number=cyan,object=white,objectkey=brightblue,prompt_repl_level=brightblack,prompt_value=white,string=green,true=yellow,value=white
 compact             false
 completion_timeout  10
-decode_format       probe
+decode_group        probe
 decode_progress     false
 depth               0
 display_bytes       16

--- a/pkg/interp/testdata/options.fqtest
+++ b/pkg/interp/testdata/options.fqtest
@@ -60,7 +60,7 @@ $ fq -n options
   },
   "compact": false,
   "completion_timeout": 10,
-  "decode_format": "probe",
+  "decode_group": "probe",
   "decode_progress": false,
   "depth": 0,
   "display_bytes": 16,


### PR DESCRIPTION
Replaces []Format with a Group type.
A bit more type safe.
Breaking change for RegisterFormat, now takes a first argument that is a "single" format group. Lots of naming cleanup.

This is also preparation for decode group argument which will enable doing intresting probing, ex a format decoder could know it's decode as part of probe group  (html could be probed possibly), or have "arg probe" group for decoder who inspect args to know if they should probe (-d /path/to/schema etc) to enable nice CLI-ergonomics.