### PR TITLE
gojq: Update rebased fq fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	// fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-	github.com/wader/gojq v0.12.1-0.20230308145020-2de2194791c0
+	github.com/wader/gojq v0.12.1-0.20230529153812-b7e613069119
 	// fork of github.com/chzyer/readline, see github.com/wader/readline fq branch
 	github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/wader/gojq v0.12.1-0.20230308145020-2de2194791c0 h1:OjBLxUJRtmoYbNtgBqvqLwZdKi1lGdXHBFMCQLpOP5M=
-github.com/wader/gojq v0.12.1-0.20230308145020-2de2194791c0/go.mod h1:jQY39j9tgky+JYcJrKNz5OYTe/sPDAw7FvVj13JGqVk=
+github.com/wader/gojq v0.12.1-0.20230529153812-b7e613069119 h1:9GNJxrBtaN5wHFGapIrWcZMCIjXNjPDgiJJUONo73fk=
+github.com/wader/gojq v0.12.1-0.20230529153812-b7e613069119/go.mod h1:jQY39j9tgky+JYcJrKNz5OYTe/sPDAw7FvVj13JGqVk=
 github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448 h1:AzpBtmgdXa3uznrb3esNeEoaLqtNEwckRmaUH0qWD6w=
 github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448/go.mod h1:Zgz8IJWvJoe7NK23CCPpC109XMCqJCpUhpHcnnA4XaM=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=

--- a/pkg/interp/testdata/argvars.fqtest
+++ b/pkg/interp/testdata/argvars.fqtest
@@ -41,7 +41,7 @@ $ fq -n -d mp4 --argdecode filea test.mp3 '$filea'
 $ fq -n --argjson a '(' '$a'
 exitcode: 2
 stderr:
-error: --argjson a: invalid character '(' looking for beginning of value
+error: --argjson a: fromjson cannot be applied to "(": invalid character '(' looking for beginning of value
 $ fq -n --argjson a
 exitcode: 2
 stderr:

--- a/pkg/interp/testdata/binary.fqtest
+++ b/pkg/interp/testdata/binary.fqtest
@@ -252,7 +252,7 @@ mp3> .frames[1].audio_data | tobytes | match([0x33, 0x85]), first(scan([0x33, 0x
 "3385"
 "07aac38e"
 mp3> scan("")
-error: match cannot be applied to: object ({"footers":[],"frames":[{" ...)
+error: match(""; "g") cannot be applied to: object ({"footers":[],"frames":[{" ...)
 mp3> tobytes| scan("")
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.: raw bits 0x0-NA (0)
 mp3> .frames[1] | tobytes | mp3_frame | ., ((.header.bitrate | tobitsrange) as $v | tobitsrange | [.[:$v.start], (0xf | tobits), .[$v.start+$v.size:]] | mp3_frame) | .header.bitrate


### PR DESCRIPTION
From upstream:
e940c43 update GitHub action dependencies
2d97ddb update jq links to the new jqlang organization 2a6cb00 improve error message of various functions 5e26bef add a note on differences of supported functions missing in jq 96c4843 fix functions returning arrays not to emit nil slices 4a681c8 improve .dockerignore
850177b Merge pull request #213 from movableink/uri-decode dbba5e7 add urid to decode URI values, mirroring uri