### PR TITLE
gojq: Update fq fork

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# 0.8.0 - WIP
+
+- Updated gojq fork with fixes from upstream:
+  - Improved error messages for indices, setpath, delpaths
+  - Add `abs` function
+  - Change behavior of walk with multiple outputs
+  - Change zero division to produce an error when dividend is zero
+  - Fix empty string repeating with the maximum integer
+  - Fix string multiplication by zero to emit empty string
+  - Remove deprecated `leaf_paths` function
+
 # 0.7.0
 
 Added LuaJIT bytecode decoder by @dlatchx, otherwise mostly small things. Been busy with nice weather and

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	// fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-	github.com/wader/gojq v0.12.1-0.20230529153812-b7e613069119
+	github.com/wader/gojq v0.12.1-0.20230808095425-173f59d33159
 	// fork of github.com/chzyer/readline, see github.com/wader/readline fq branch
 	github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/wader/gojq v0.12.1-0.20230529153812-b7e613069119 h1:9GNJxrBtaN5wHFGapIrWcZMCIjXNjPDgiJJUONo73fk=
-github.com/wader/gojq v0.12.1-0.20230529153812-b7e613069119/go.mod h1:jQY39j9tgky+JYcJrKNz5OYTe/sPDAw7FvVj13JGqVk=
+github.com/wader/gojq v0.12.1-0.20230808095425-173f59d33159 h1:Xz+k6HkJetG8PR7Y/JLdMYWTMfPjWg1ch4rGXwNfr9g=
+github.com/wader/gojq v0.12.1-0.20230808095425-173f59d33159/go.mod h1:kWVMiqIHem9U93XhJV1jj8MLMRdLjWmWFWLb3jA5SRU=
 github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448 h1:AzpBtmgdXa3uznrb3esNeEoaLqtNEwckRmaUH0qWD6w=
 github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448/go.mod h1:Zgz8IJWvJoe7NK23CCPpC109XMCqJCpUhpHcnnA4XaM=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=

--- a/pkg/interp/testdata/value_array.fqtest
+++ b/pkg/interp/testdata/value_array.fqtest
@@ -189,7 +189,7 @@ mp3> .headers._gap | ., type, length?
 false
 "boolean"
 mp3> .headers.a = 1
-error: expected an object but got: array ([{"frames":[{"flags":{"co ...])
+error: setpath(["headers","a"]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: array ([{"frames":[{"flags":{"co ...])
 mp3> .headers[0] = 1
 {
   "footers": [],
@@ -853,13 +853,13 @@ mp3> .headers[0] |= empty
   "headers": []
 }
 mp3> .headers | setpath(["a"]; 1)
-error: expected an object but got: array ([{"frames":[{"flags":{"co ...])
+error: setpath(["a"]; 1) cannot be applied to [{"frames":[{"flags":{"com ...: expected an object but got: array ([{"frames":[{"flags":{"co ...])
 mp3> .headers | setpath([0]; 1)
 [
   1
 ]
 mp3> .headers | delpaths([["a"]])
-error: expected an object but got: array ([{"frames":[{"flags":{"co ...])
+error: delpaths([["a"]]) cannot be applied to [{"frames":[{"flags":{"com ...: expected an object but got: array ([{"frames":[{"flags":{"co ...])
 mp3> .headers | delpaths([[0]])
 []
 mp3> ^D

--- a/pkg/interp/testdata/value_boolean.fqtest
+++ b/pkg/interp/testdata/value_boolean.fqtest
@@ -95,19 +95,19 @@ mp3> .headers[0].header.flags.unsynchronisation._gap | ., type, length?
 false
 "boolean"
 mp3> .headers[0].header.flags.unsynchronisation.a = 1
-error: expected an object but got: boolean (false)
+error: setpath(["headers",0,"header","fl ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation[0] = 1
-error: expected an array but got: boolean (false)
+error: setpath(["headers",0,"header","fl ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation.a |= empty
 error: expected an object but got: boolean
 mp3> .headers[0].header.flags.unsynchronisation[0] |= empty
 error: expected an array but got: boolean
 mp3> .headers[0].header.flags.unsynchronisation | setpath(["a"]; 1)
-error: expected an object but got: boolean (false)
+error: setpath(["a"]; 1) cannot be applied to false: expected an object but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation | setpath([0]; 1)
-error: expected an array but got: boolean (false)
+error: setpath([0]; 1) cannot be applied to false: expected an array but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation | delpaths([["a"]])
-error: expected an object but got: boolean (false)
+error: delpaths([["a"]]) cannot be applied to false: expected an object but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation | delpaths([[0]])
-error: expected an array but got: boolean (false)
+error: delpaths([[0]]) cannot be applied to false: expected an array but got: boolean (false)
 mp3> ^D

--- a/pkg/interp/testdata/value_json_array.fqtest
+++ b/pkg/interp/testdata/value_json_array.fqtest
@@ -111,13 +111,13 @@ error: expected an object but got: array
 json> (.)[0] |= empty
 []
 json> (.) | setpath(["a"]; 1)
-error: expected an object but got: array ([])
+error: setpath(["a"]; 1) cannot be applied to []: expected an object but got: array ([])
 json> (.) | setpath([0]; 1)
 [
   1
 ]
 json> (.) | delpaths([["a"]])
-error: expected an object but got: array ([])
+error: delpaths([["a"]]) cannot be applied to []: expected an object but got: array ([])
 json> (.) | delpaths([[0]])
 []
 json> ^D

--- a/pkg/interp/testdata/value_json_object.fqtest
+++ b/pkg/interp/testdata/value_json_object.fqtest
@@ -105,9 +105,9 @@ json> (.) | setpath(["a"]; 1)
   "a": 1
 }
 json> (.) | setpath([0]; 1)
-error: expected an array but got: object ({})
+error: setpath([0]; 1) cannot be applied to {}: expected an array but got: object ({})
 json> (.) | delpaths([["a"]])
 {}
 json> (.) | delpaths([[0]])
-error: expected an array but got: object ({})
+error: delpaths([[0]]) cannot be applied to {}: expected an array but got: object ({})
 json> ^D

--- a/pkg/interp/testdata/value_null.fqtest
+++ b/pkg/interp/testdata/value_null.fqtest
@@ -107,19 +107,19 @@ mp3> .headers[0].padding._gap | ., type, length?
 false
 "boolean"
 mp3> .headers[0].padding.a = 1
-error: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: setpath(["headers",0,"padding","a"]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding[0] = 1
-error: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: setpath(["headers",0,"padding",0]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding.a |= empty
 error: expected an object with key "a" but got: string
 mp3> .headers[0].padding[0] |= empty
-error: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: delpaths([["headers",0,"padding",0]]) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding | setpath(["a"]; 1)
-error: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: setpath(["a"]; 1) cannot be applied to "\u0000\u0000\u0000\u0000\ ...: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding | setpath([0]; 1)
-error: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: setpath([0]; 1) cannot be applied to "\u0000\u0000\u0000\u0000\ ...: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding | delpaths([["a"]])
-error: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: delpaths([["a"]]) cannot be applied to "\u0000\u0000\u0000\u0000\ ...: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding | delpaths([[0]])
-error: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
+error: delpaths([[0]]) cannot be applied to "\u0000\u0000\u0000\u0000\ ...: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> ^D

--- a/pkg/interp/testdata/value_number.fqtest
+++ b/pkg/interp/testdata/value_number.fqtest
@@ -96,19 +96,19 @@ mp3> .headers[0].header.version._gap | ., type, length?
 false
 "boolean"
 mp3> .headers[0].header.version.a = 1
-error: expected an object but got: number (4)
+error: setpath(["headers",0,"header","ve ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: number (4)
 mp3> .headers[0].header.version[0] = 1
-error: expected an array but got: number (4)
+error: setpath(["headers",0,"header","ve ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: number (4)
 mp3> .headers[0].header.version.a |= empty
 error: expected an object but got: number
 mp3> .headers[0].header.version[0] |= empty
 error: expected an array but got: number
 mp3> .headers[0].header.version | setpath(["a"]; 1)
-error: expected an object but got: number (4)
+error: setpath(["a"]; 1) cannot be applied to 4: expected an object but got: number (4)
 mp3> .headers[0].header.version | setpath([0]; 1)
-error: expected an array but got: number (4)
+error: setpath([0]; 1) cannot be applied to 4: expected an array but got: number (4)
 mp3> .headers[0].header.version | delpaths([["a"]])
-error: expected an object but got: number (4)
+error: delpaths([["a"]]) cannot be applied to 4: expected an object but got: number (4)
 mp3> .headers[0].header.version | delpaths([[0]])
-error: expected an array but got: number (4)
+error: delpaths([[0]]) cannot be applied to 4: expected an array but got: number (4)
 mp3> ^D

--- a/pkg/interp/testdata/value_object.fqtest
+++ b/pkg/interp/testdata/value_object.fqtest
@@ -477,7 +477,7 @@ mp3> .headers[0].header.flags.a = 1
   ]
 }
 mp3> .headers[0].header.flags[0] = 1
-error: expected an array but got: object ({"experimental_indicator" ...})
+error: setpath(["headers",0,"header","fl ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: object ({"experimental_indicator" ...})
 mp3> .headers[0].header.flags.a |= empty
 {
   "footers": [],
@@ -855,7 +855,7 @@ mp3> .headers[0].header.flags | setpath(["a"]; 1)
   "unused": 0
 }
 mp3> .headers[0].header.flags | setpath([0]; 1)
-error: expected an array but got: object ({"experimental_indicator" ...})
+error: setpath([0]; 1) cannot be applied to {"experimental_indicator": ...: expected an array but got: object ({"experimental_indicator" ...})
 mp3> .headers[0].header.flags | delpaths([["a"]])
 {
   "experimental_indicator": false,
@@ -864,5 +864,5 @@ mp3> .headers[0].header.flags | delpaths([["a"]])
   "unused": 0
 }
 mp3> .headers[0].header.flags | delpaths([[0]])
-error: expected an array but got: object ({"experimental_indicator" ...})
+error: delpaths([[0]]) cannot be applied to {"experimental_indicator": ...: expected an array but got: object ({"experimental_indicator" ...})
 mp3> ^D

--- a/pkg/interp/testdata/value_string.fqtest
+++ b/pkg/interp/testdata/value_string.fqtest
@@ -108,19 +108,19 @@ mp3> .headers[0].header.magic._gap | ., type, length?
 false
 "boolean"
 mp3> .headers[0].header.magic.a = 1
-error: expected an object but got: string ("ID3")
+error: setpath(["headers",0,"header","ma ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: string ("ID3")
 mp3> .headers[0].header.magic[0] = 1
-error: expected an array but got: string ("ID3")
+error: setpath(["headers",0,"header","ma ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("ID3")
 mp3> .headers[0].header.magic.a |= empty
 error: expected an object but got: string
 mp3> .headers[0].header.magic[0] |= empty
-error: expected an array but got: string ("ID3")
+error: delpaths([["headers",0,"header","m ...]) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("ID3")
 mp3> .headers[0].header.magic | setpath(["a"]; 1)
-error: expected an object but got: string ("ID3")
+error: setpath(["a"]; 1) cannot be applied to "ID3": expected an object but got: string ("ID3")
 mp3> .headers[0].header.magic | setpath([0]; 1)
-error: expected an array but got: string ("ID3")
+error: setpath([0]; 1) cannot be applied to "ID3": expected an array but got: string ("ID3")
 mp3> .headers[0].header.magic | delpaths([["a"]])
-error: expected an object but got: string ("ID3")
+error: delpaths([["a"]]) cannot be applied to "ID3": expected an object but got: string ("ID3")
 mp3> .headers[0].header.magic | delpaths([[0]])
-error: expected an array but got: string ("ID3")
+error: delpaths([[0]]) cannot be applied to "ID3": expected an array but got: string ("ID3")
 mp3> ^D


### PR DESCRIPTION
Changes from upstream:
8fcc90e implement abs function
cbbd4bb fix default module paths assuming gojq is located in a bin directory 45d4c5b change behavior of walk with multiple outputs 846cf99 fix stderr to output strings in raw format c352d50 change zero division to produce an error when dividend is zero d579009 fix empty string repeating with the maximum integer d4de65c fix string multiplication by zero to emit empty string 04b48fd remove deprecated leaf_paths function
c882861 bump up version to 0.12.13
c310d5d update CHANGELOG.md for v0.12.13
8fb5cc3 update dependencies
fb00b66 improve error message of indices, setpath, delpaths functions