### PR TITLE
decode,interp: Don't shadow _key and error on missing _key

### DIFF
--- a/pkg/interp/testdata/completion.fqtest
+++ b/pkg/interp/testdata/completion.fqtest
@@ -46,6 +46,7 @@ _error
 _format
 _format_root
 _gap
+_index
 _len
 _name
 _out

--- a/pkg/interp/testdata/value.fqtest
+++ b/pkg/interp/testdata/value.fqtest
@@ -127,77 +127,77 @@ true
 "_format"
 true
 "_abc"
-"expected a extkey but got: _abc"
+false
 mp3> .headers as $c | ("_start", "_stop", "_len", "_name", "_root", "_buffer_root", "_format_root", "_parent", "_sym", "_description", "_path", "_bits", "_bytes", "_error", "_gap", "_format", "_abc") as $n | $n, try ($c | has($n)) catch .
 "_start"
-true
+"cannot check whether array has a key: _start"
 "_stop"
-true
+"cannot check whether array has a key: _stop"
 "_len"
-true
+"cannot check whether array has a key: _len"
 "_name"
-true
+"cannot check whether array has a key: _name"
 "_root"
-true
+"cannot check whether array has a key: _root"
 "_buffer_root"
-true
+"cannot check whether array has a key: _buffer_root"
 "_format_root"
-true
+"cannot check whether array has a key: _format_root"
 "_parent"
-true
+"cannot check whether array has a key: _parent"
 "_sym"
-true
+"cannot check whether array has a key: _sym"
 "_description"
-true
+"cannot check whether array has a key: _description"
 "_path"
-true
+"cannot check whether array has a key: _path"
 "_bits"
-true
+"cannot check whether array has a key: _bits"
 "_bytes"
-true
+"cannot check whether array has a key: _bytes"
 "_error"
-true
+"cannot check whether array has a key: _error"
 "_gap"
-true
+"cannot check whether array has a key: _gap"
 "_format"
-true
+"cannot check whether array has a key: _format"
 "_abc"
-"expected a extkey but got: _abc"
+"cannot check whether array has a key: _abc"
 mp3> .headers[0].header.magic as $c | ("_start", "_stop", "_len", "_name", "_root", "_buffer_root", "_format_root", "_parent", "_sym", "_description", "_path", "_bits", "_bytes", "_error", "_gap", "_format", "_abc") as $n | $n, try ($c | has($n)) catch .
 "_start"
-true
+"has cannot be applied to: string"
 "_stop"
-true
+"has cannot be applied to: string"
 "_len"
-true
+"has cannot be applied to: string"
 "_name"
-true
+"has cannot be applied to: string"
 "_root"
-true
+"has cannot be applied to: string"
 "_buffer_root"
-true
+"has cannot be applied to: string"
 "_format_root"
-true
+"has cannot be applied to: string"
 "_parent"
-true
+"has cannot be applied to: string"
 "_sym"
-true
+"has cannot be applied to: string"
 "_description"
-true
+"has cannot be applied to: string"
 "_path"
-true
+"has cannot be applied to: string"
 "_bits"
-true
+"has cannot be applied to: string"
 "_bytes"
-true
+"has cannot be applied to: string"
 "_error"
-true
+"has cannot be applied to: string"
 "_gap"
-true
+"has cannot be applied to: string"
 "_format"
-true
+"has cannot be applied to: string"
 "_abc"
-"expected a extkey but got: _abc"
+"has cannot be applied to: string"
 mp3> ^D
 $ fq -d mp3 -i . test.mp3
 mp3> ._start
@@ -255,13 +255,13 @@ false
 mp3> ._format
 "mp3"
 mp3> ._abc
-error: expected a extkey but got: _abc
+null
 mp3> fgrep("toc") | arrays[10]._index
 10
 mp3> .headers._index
-error: expected a extkey but got: _index
+null
 mp3> ._index
-error: expected a extkey but got: _index
+null
 mp3> .headers[0].header.version as $r | {a:12} | tojson({indent: $r}) | println
 {
     "a": 12

--- a/pkg/interp/testdata/value_array.fqtest
+++ b/pkg/interp/testdata/value_array.fqtest
@@ -113,7 +113,9 @@ mp3> .headers[-1000:2000] | ., type, length?
 "array"
 1
 mp3> .headers["test"] | ., type, length?
-error: expected an object with key "test" but got: array
+null
+"null"
+0
 mp3> [.headers[]] | type, length?
 "array"
 1
@@ -522,7 +524,7 @@ mp3> .headers[0] = 1
   ]
 }
 mp3> .headers.a |= empty
-error: expected an object with key "a" but got: array
+error: delpaths([["headers","a"]]) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: array ([{"frames":[{"flags":{"co ...])
 mp3> .headers[0] |= empty
 {
   "footers": [],

--- a/pkg/interp/testdata/value_boolean.fqtest
+++ b/pkg/interp/testdata/value_boolean.fqtest
@@ -19,7 +19,9 @@ error: expected an array but got: boolean
 mp3> .headers[0].header.flags.unsynchronisation[-1000:2000] | ., type, length?
 error: expected an array but got: boolean
 mp3> .headers[0].header.flags.unsynchronisation["test"] | ., type, length?
-error: expected an object but got: boolean
+null
+"null"
+0
 mp3> [.headers[0].header.flags.unsynchronisation[]] | type, length?
 error: cannot iterate over: boolean
 mp3> .headers[0].header.flags.unsynchronisation | keys
@@ -99,7 +101,7 @@ error: setpath(["headers",0,"header","fl ...]; 1) cannot be applied to {"footers
 mp3> .headers[0].header.flags.unsynchronisation[0] = 1
 error: setpath(["headers",0,"header","fl ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation.a |= empty
-error: expected an object but got: boolean
+error: delpaths([["headers",0,"header","f ...]) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: boolean (false)
 mp3> .headers[0].header.flags.unsynchronisation[0] |= empty
 error: expected an array but got: boolean
 mp3> .headers[0].header.flags.unsynchronisation | setpath(["a"]; 1)

--- a/pkg/interp/testdata/value_json_array.fqtest
+++ b/pkg/interp/testdata/value_json_array.fqtest
@@ -31,7 +31,9 @@ json> (.)[-1000:2000] | ., type, length?
 "array"
 0
 json> (.)["test"] | ., type, length?
-error: expected an object but got: array
+null
+"null"
+0
 json> [(.)[]] | type, length?
 "array"
 0
@@ -101,13 +103,13 @@ json> (.)._gap | ., type, length?
 false
 "boolean"
 json> (.).a = 1
-error: expected an object but got: array
+error: setpath(["a"]; 1) cannot be applied to []: expected an object but got: array ([])
 json> (.)[0] = 1
 [
   1
 ]
 json> (.).a |= empty
-error: expected an object but got: array
+error: delpaths([["a"]]) cannot be applied to []: expected an object but got: array ([])
 json> (.)[0] |= empty
 []
 json> (.) | setpath(["a"]; 1)

--- a/pkg/interp/testdata/value_null.fqtest
+++ b/pkg/interp/testdata/value_null.fqtest
@@ -32,7 +32,9 @@ mp3> .headers[0].padding[-1000:2000] | ., type, length?
 "string"
 10
 mp3> .headers[0].padding["test"] | ., type, length?
-error: expected an object with key "test" but got: string
+null
+"null"
+0
 mp3> [.headers[0].padding[]] | type, length?
 error: cannot iterate over: string
 mp3> .headers[0].padding | keys
@@ -111,7 +113,7 @@ error: setpath(["headers",0,"padding","a"]; 1) cannot be applied to {"footers":[
 mp3> .headers[0].padding[0] = 1
 error: setpath(["headers",0,"padding",0]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding.a |= empty
-error: expected an object with key "a" but got: string
+error: delpaths([["headers",0,"padding","a"]]) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding[0] |= empty
 error: delpaths([["headers",0,"padding",0]]) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("\u0000\u0000\u0000\u0000 ...")
 mp3> .headers[0].padding | setpath(["a"]; 1)

--- a/pkg/interp/testdata/value_number.fqtest
+++ b/pkg/interp/testdata/value_number.fqtest
@@ -20,7 +20,9 @@ error: expected an array but got: number
 mp3> .headers[0].header.version[-1000:2000] | ., type, length?
 error: expected an array but got: number
 mp3> .headers[0].header.version["test"] | ., type, length?
-error: expected an object but got: number
+null
+"null"
+0
 mp3> [.headers[0].header.version[]] | type, length?
 error: cannot iterate over: number
 mp3> .headers[0].header.version | keys
@@ -100,7 +102,7 @@ error: setpath(["headers",0,"header","ve ...]; 1) cannot be applied to {"footers
 mp3> .headers[0].header.version[0] = 1
 error: setpath(["headers",0,"header","ve ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: number (4)
 mp3> .headers[0].header.version.a |= empty
-error: expected an object but got: number
+error: delpaths([["headers",0,"header","v ...]) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: number (4)
 mp3> .headers[0].header.version[0] |= empty
 error: expected an array but got: number
 mp3> .headers[0].header.version | setpath(["a"]; 1)

--- a/pkg/interp/testdata/value_shadow.fqtest
+++ b/pkg/interp/testdata/value_shadow.fqtest
@@ -1,0 +1,15 @@
+$ fq -i
+null> (`{"_format": "format", "_a": "a"}`, `{"_a":"a"}`) | fromjson | ._format, ._a, ._b, has("_format", "_a", "_b")
+"format"
+"a"
+null
+true
+true
+false
+"json"
+"a"
+null
+true
+true
+false
+null> ^D

--- a/pkg/interp/testdata/value_string.fqtest
+++ b/pkg/interp/testdata/value_string.fqtest
@@ -32,7 +32,9 @@ mp3> .headers[0].header.magic[-1000:2000] | ., type, length?
 "string"
 3
 mp3> .headers[0].header.magic["test"] | ., type, length?
-error: expected an object but got: string
+null
+"null"
+0
 mp3> [.headers[0].header.magic[]] | type, length?
 error: cannot iterate over: string
 mp3> .headers[0].header.magic | keys
@@ -112,7 +114,7 @@ error: setpath(["headers",0,"header","ma ...]; 1) cannot be applied to {"footers
 mp3> .headers[0].header.magic[0] = 1
 error: setpath(["headers",0,"header","ma ...]; 1) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("ID3")
 mp3> .headers[0].header.magic.a |= empty
-error: expected an object but got: string
+error: delpaths([["headers",0,"header","m ...]) cannot be applied to {"footers":[],"frames":[{" ...: expected an object but got: string ("ID3")
 mp3> .headers[0].header.magic[0] |= empty
 error: delpaths([["headers",0,"header","m ...]) cannot be applied to {"footers":[],"frames":[{" ...: expected an array but got: string ("ID3")
 mp3> .headers[0].header.magic | setpath(["a"]; 1)


### PR DESCRIPTION
For fromjson and other "value" decode values fq make then behave both like a normal jq value and decode value. This is to make tobytes, format etc work. Before all _* would be treated as special keys. Now they are first looked up in the wrapped value and then as decode values.

Also now ._key that don't exist reutrn null instead of throw error.

$ fq -n '`{"_format": 123}` | fromjson | ._format' Now:
123
Before:
"json"

$ fq -n '`{}` | fromjson | ._missing'
Now:
null
Before
error