### PR TITLE
interp: split: Correctly split binary

### DIFF
--- a/pkg/interp/binary.jq
+++ b/pkg/interp/binary.jq
@@ -36,13 +36,13 @@ def _splits_binary($regex; $flags):
   ( . as $b
   # last null output is to do a last iteration that output from end of last match to end of binary
   | foreach (_match_binary($regex; $flags), null) as $m (
-      {prev: null, curr: null};
-      ( .prev = .curr
-      | .curr = $m
+      {prev: null, current: null};
+      ( .prev = .current
+      | .current = $m
       );
-      if .prev == null then $b[0:.curr.offset]
-      elif .curr == null then $b[.prev.offset+.prev.length:]
-      else $b[.prev.offset+.prev.length:.curr.offset+.curr.length]
+      if .prev == null then $b[0:.current.offset]
+      elif .current == null then $b[.prev.offset+.prev.length:]
+      else $b[.prev.offset+.prev.length:.current.offset]
       end
     )
   );

--- a/pkg/interp/testdata/binary.fqtest
+++ b/pkg/interp/testdata/binary.fqtest
@@ -414,13 +414,13 @@ null> "ååå" as $p | "cbbcåååccåååcbc", "åååcbbc", "cbbcååå" | ., 
 "binary_rune"
 [
   "cbbc",
-  "ccååå",
+  "cc",
   "cbc"
 ]
 "binary_byte"
 [
   "cbbc",
-  "ccååå",
+  "cc",
   "cbc"
 ]
 "åååcbbc"
@@ -464,17 +464,15 @@ null> "å(?<n>å)(å)" as $p | "cbbcåååccåååcbc", "åååcbbc", "cbbcåå�
 "binary_rune"
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|63 62 62 63                                    |cbbc            |.: raw bits 0x0-0x3.7 (4)
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x00|                              63 63 c3 a5 c3 a5|          cc....|.: raw bits 0xa-0x11.7 (8)
-0x10|c3 a5                                          |..              |
+   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
+0x0|                              63 63            |          cc    |.: raw bits 0xa-0xb.7 (2)
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x10|      63 62 63|                                |  cbc|          |.: raw bits 0x12-0x14.7 (3)
 "binary_byte"
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|63 62 62 63                                    |cbbc            |.: raw bits 0x0-0x3.7 (4)
-    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
-0x00|                              63 63 c3 a5 c3 a5|          cc....|.: raw bits 0xa-0x11.7 (8)
-0x10|c3 a5                                          |..              |
+   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
+0x0|                              63 63            |          cc    |.: raw bits 0xa-0xb.7 (2)
     |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x10|      63 62 63|                                |  cbc|          |.: raw bits 0x12-0x14.7 (3)
 "åååcbbc"


### PR DESCRIPTION
The thing splitted on should not be included.