### PR TITLE
avi: Add extended chunks support and option

### DIFF
--- a/doc/formats.md
+++ b/doc/formats.md
@@ -267,20 +267,21 @@ Decode value as avc_au
 
 ### Options
 
-|Name            |Default|Description|
-|-               |-      |-|
-|`decode_samples`|true   |Decode samples|
+|Name                    |Default|Description|
+|-                       |-      |-|
+|`decode_extended_chunks`|true   |Decode extended chunks|
+|`decode_samples`        |true   |Decode samples|
 
 ### Examples
 
 Decode file using avi options
 ```
-$ fq -d avi -o decode_samples=true . file
+$ fq -d avi -o decode_extended_chunks=true -o decode_samples=true . file
 ```
 
 Decode value as avi
 ```
-... | avi({decode_samples:true})
+... | avi({decode_extended_chunks:true,decode_samples:true})
 ```
 
 ### Samples
@@ -296,6 +297,13 @@ $ fq '.streams[1].samples[] | tobytes' file.avi > stream01.mp3
 ### Show stream summary
 ```sh
 $ fq -o decode_samples=false '[.chunks[0] | grep_by(.id=="LIST" and .type=="strl") | grep_by(.id=="strh") as {$type} | grep_by(.id=="strf") as {$format_tag, $compression} | {$type,$format_tag,$compression}]' *.avi
+```
+
+### Speed up decoding by disabling sample and extended chunks decoding
+
+If your not interested in sample details or extended chunks you can speed up decoding by using:
+```sh
+$ fq -o decode_samples=false -o decode_extended_chunks=false d file.avi
 ```
 
 ### References

--- a/format/format.go
+++ b/format/format.go
@@ -352,7 +352,8 @@ type MP4_In struct {
 }
 
 type AVI_In struct {
-	DecodeSamples bool `doc:"Decode samples"`
+	DecodeSamples        bool `doc:"Decode samples"`
+	DecodeExtendedChunks bool `doc:"Decode extended chunks"`
 }
 
 type Zip_In struct {

--- a/format/riff/avi.md
+++ b/format/riff/avi.md
@@ -13,6 +13,13 @@ $ fq '.streams[1].samples[] | tobytes' file.avi > stream01.mp3
 $ fq -o decode_samples=false '[.chunks[0] | grep_by(.id=="LIST" and .type=="strl") | grep_by(.id=="strh") as {$type} | grep_by(.id=="strf") as {$format_tag, $compression} | {$type,$format_tag,$compression}]' *.avi
 ```
 
+### Speed up decoding by disabling sample and extended chunks decoding
+
+If your not interested in sample details or extended chunks you can speed up decoding by using:
+```sh
+$ fq -o decode_samples=false -o decode_extended_chunks=false d file.avi
+```
+
 ### References
 
 - [AVI RIFF File Reference](https://learn.microsoft.com/en-us/windows/win32/directshow/avi-riff-file-reference)

--- a/format/riff/testdata/avc.avi.fqtest
+++ b/format/riff/testdata/avc.avi.fqtest
@@ -490,3 +490,4 @@ $ fq dv avc.avi
        |                                               |                |      type: "vids"
        |                                               |                |      handler: "H264"
        |                                               |                |      compression: "H264"
+       |                                               |                |  extended_chunks[0:0]: 0x2442-0x2442 (0)

--- a/format/riff/testdata/flac.avi.fqtest
+++ b/format/riff/testdata/flac.avi.fqtest
@@ -263,3 +263,4 @@ $ fq dv flac.avi
       |                                               |                |      type: "auds"
       |                                               |                |      handler: "\x01\x00\x00\x00"
       |                                               |                |      format_tag: "flac" (61868)
+      |                                               |                |  extended_chunks[0:0]: 0x18cc-0x18cc (0)

--- a/format/riff/testdata/help_avi.fqtest
+++ b/format/riff/testdata/help_avi.fqtest
@@ -4,7 +4,8 @@ avi: Audio Video Interleaved decoder
 Options
 =======
 
-  decode_samples=true  Decode samples
+  decode_extended_chunks=true  Decode extended chunks
+  decode_samples=true          Decode samples
 
 Decode examples
 ===============
@@ -14,9 +15,9 @@ Decode examples
   # Decode value as avi
   ... | avi
   # Decode file using avi options
-  $ fq -d avi -o decode_samples=true . file
+  $ fq -d avi -o decode_extended_chunks=true -o decode_samples=true . file
   # Decode value as avi
-  ... | avi({decode_samples:true})
+  ... | avi({decode_extended_chunks:true,decode_samples:true})
 
 Samples
 =======
@@ -30,6 +31,12 @@ Extract samples for stream 1
 Show stream summary
 ===================
   $ fq -o decode_samples=false '[.chunks[0] | grep_by(.id=="LIST" and .type=="strl") | grep_by(.id=="strh") as {$type} | grep_by(.id=="strf") as {$format_tag, $compression} | {$type,$format_tag,$compression}]' *.avi
+
+Speed up decoding by disabling sample and extended chunks decoding
+==================================================================
+If your not interested in sample details or extended chunks you can speed up decoding by using:
+
+  $ fq -o decode_samples=false -o decode_extended_chunks=false d file.avi
 
 References
 ==========

--- a/format/riff/testdata/mp3.avi.fqtest
+++ b/format/riff/testdata/mp3.avi.fqtest
@@ -537,3 +537,4 @@ $ fq dv mp3.avi
       |                                               |                |      type: "auds"
       |                                               |                |      handler: "\x01\x00\x00\x00"
       |                                               |                |      format_tag: "mp3" (85)
+      |                                               |                |  extended_chunks[0:0]: 0x18e8-0x18e8 (0)

--- a/format/riff/testdata/pcm.avi.fqtest
+++ b/format/riff/testdata/pcm.avi.fqtest
@@ -243,3 +243,4 @@ $ fq dv pcm.avi
       |                                               |                |      type: "auds"
       |                                               |                |      handler: "\x01\x00\x00\x00"
       |                                               |                |      format_tag: "pcm_s16le" (1)
+      |                                               |                |  extended_chunks[0:0]: 0x390a-0x390a (0)


### PR DESCRIPTION
This is used for >1gb files. Disable decode will speed up deocde a lot but will probably also produce some gaps as same part of the movi chunks will not be reference by the indx index.