### PR TITLE
mp4: Don't decode samples if track has external data reference

### DIFF
--- a/format/mp4/mp4.go
+++ b/format/mp4/mp4.go
@@ -144,6 +144,8 @@ type track struct {
 	objectType         int // if data format is "mp4a"
 	defaultIVSize      int
 	moofs              []*moof // for fmp4
+	dref               bool
+	drefURL            string
 }
 
 type pathEntry struct {
@@ -287,8 +289,12 @@ func mp4Tracks(d *decode.D, ctx *decodeContext) {
 						trackSDDataFormat = sd.originalFormat
 					}
 				}
-
 				d.FieldValueStr("data_format", trackSDDataFormat, dataFormatNames)
+
+				if t.dref && t.drefURL != "" {
+					d.FieldValueStr("data_reference_url", t.drefURL)
+					return
+				}
 
 				switch trackSDDataFormat {
 				case "lpcm",

--- a/format/mp4/testdata/aac.fqtest
+++ b/format/mp4/testdata/aac.fqtest
@@ -182,7 +182,7 @@ $ fq -d mp4 dv aac.mp4
 0x410|                     75 72 6c 20               |       url      |                              type: "url " 0x417-0x41b (4)
 0x410|                                 00            |           .    |                              version: 0 0x41b-0x41c (1)
 0x410|                                    00 00 01   |            ... |                              flags: 1 0x41c-0x41f (3)
-     |                                               |                |                              data: raw bits 0x41f-0x41f (0)
+     |                                               |                |                              data: "" 0x41f-0x41f (0)
      |                                               |                |                    [2]{}: box 0x41f-0x53b (284)
 0x410|                                             00|               .|                      size: 284 0x41f-0x423 (4)
 0x420|00 01 1c                                       |...             |

--- a/format/mp4/testdata/av1.fqtest
+++ b/format/mp4/testdata/av1.fqtest
@@ -168,7 +168,7 @@ $ fq -d mp4 dv av1.mp4
 0x1340|                                       00      |             .  |                              version: 0 0x134d-0x134e (1)
 0x1340|                                          00 00|              ..|                              flags: 1 0x134e-0x1351 (3)
 0x1350|01                                             |.               |
-      |                                               |                |                              data: raw bits 0x1351-0x1351 (0)
+      |                                               |                |                              data: "" 0x1351-0x1351 (0)
       |                                               |                |                    [2]{}: box 0x1351-0x1450 (255)
 0x1350|   00 00 00 ff                                 | ....           |                      size: 255 0x1351-0x1355 (4)
 0x1350|               73 74 62 6c                     |     stbl       |                      type: "stbl" (Sample table box, container for the time/space map) 0x1355-0x1359 (4)

--- a/format/mp4/testdata/avc.fqtest
+++ b/format/mp4/testdata/avc.fqtest
@@ -186,7 +186,7 @@ $ fq -d mp4 dv avc.mp4
 0x00f00|                                          00   |              . |                              version: 0 0xf0e-0xf0f (1)
 0x00f00|                                             00|               .|                              flags: 1 0xf0f-0xf12 (3)
 0x00f10|00 01                                          |..              |
-       |                                               |                |                              data: raw bits 0xf12-0xf12 (0)
+       |                                               |                |                              data: "" 0xf12-0xf12 (0)
        |                                               |                |                    [2]{}: box 0xf12-0x107e (364)
 0x00f10|      00 00 01 6c                              |  ...l          |                      size: 364 0xf12-0xf16 (4)
 0x00f10|                  73 74 62 6c                  |      stbl      |                      type: "stbl" (Sample table box, container for the time/space map) 0xf16-0xf1a (4)

--- a/format/mp4/testdata/dash.fqtest
+++ b/format/mp4/testdata/dash.fqtest
@@ -201,7 +201,7 @@ $ fq -d mp4 dv dash_audio_init.mp4
 0x200|6c 20                                          |l               |
 0x200|      00                                       |  .             |                              version: 0 0x202-0x203 (1)
 0x200|         00 00 01                              |   ...          |                              flags: 1 0x203-0x206 (3)
-     |                                               |                |                              data: raw bits 0x206-0x206 (0)
+     |                                               |                |                              data: "" 0x206-0x206 (0)
      |                                               |                |                    [1]{}: box 0x206-0x31a (276)
 0x200|                  00 00 01 14                  |      ....      |                      size: 276 0x206-0x20a (4)
 0x200|                              73 74 62 6c      |          stbl  |                      type: "stbl" (Sample table box, container for the time/space map) 0x20a-0x20e (4)

--- a/format/mp4/testdata/flac.fqtest
+++ b/format/mp4/testdata/flac.fqtest
@@ -182,7 +182,7 @@ $ fq -d mp4 dv flac.mp4
 0x410|72 6c 20                                       |rl              |
 0x410|         00                                    |   .            |                              version: 0 0x413-0x414 (1)
 0x410|            00 00 01                           |    ...         |                              flags: 1 0x414-0x417 (3)
-     |                                               |                |                              data: raw bits 0x417-0x417 (0)
+     |                                               |                |                              data: "" 0x417-0x417 (0)
      |                                               |                |                    [2]{}: box 0x417-0x4e1 (202)
 0x410|                     00 00 00 ca               |       ....     |                      size: 202 0x417-0x41b (4)
 0x410|                                 73 74 62 6c   |           stbl |                      type: "stbl" (Sample table box, container for the time/space map) 0x41b-0x41f (4)

--- a/format/mp4/testdata/fragmented.fqtest
+++ b/format/mp4/testdata/fragmented.fqtest
@@ -144,7 +144,7 @@ $ fq -d mp4 dv fragmented.mp4
 0x00180|                                       00      |             .  |                              version: 0 0x18d-0x18e (1)
 0x00180|                                          00 00|              ..|                              flags: 1 0x18e-0x191 (3)
 0x00190|01                                             |.               |
-       |                                               |                |                              data: raw bits 0x191-0x191 (0)
+       |                                               |                |                              data: "" 0x191-0x191 (0)
        |                                               |                |                    [2]{}: box 0x191-0x284 (243)
 0x00190|   00 00 00 f3                                 | ....           |                      size: 243 0x191-0x195 (4)
 0x00190|               73 74 62 6c                     |     stbl       |                      type: "stbl" (Sample table box, container for the time/space map) 0x195-0x199 (4)
@@ -405,7 +405,7 @@ $ fq -d mp4 dv fragmented.mp4
 0x00370|   75 72 6c 20                                 | url            |                              type: "url " 0x371-0x375 (4)
 0x00370|               00                              |     .          |                              version: 0 0x375-0x376 (1)
 0x00370|                  00 00 01                     |      ...       |                              flags: 1 0x376-0x379 (3)
-       |                                               |                |                              data: raw bits 0x379-0x379 (0)
+       |                                               |                |                              data: "" 0x379-0x379 (0)
        |                                               |                |                    [2]{}: box 0x379-0x443 (202)
 0x00370|                           00 00 00 ca         |         ....   |                      size: 202 0x379-0x37d (4)
 0x00370|                                       73 74 62|             stb|                      type: "stbl" (Sample table box, container for the time/space map) 0x37d-0x381 (4)

--- a/format/mp4/testdata/hevc.fqtest
+++ b/format/mp4/testdata/hevc.fqtest
@@ -186,7 +186,7 @@ $ fq -d mp4 dv hevc.mp4
 0x0a00|                                          00   |              . |                              version: 0 0xa0e-0xa0f (1)
 0x0a00|                                             00|               .|                              flags: 1 0xa0f-0xa12 (3)
 0x0a10|00 01                                          |..              |
-      |                                               |                |                              data: raw bits 0xa12-0xa12 (0)
+      |                                               |                |                              data: "" 0xa12-0xa12 (0)
       |                                               |                |                    [2]{}: box 0xa12-0x1439 (2599)
 0x0a10|      00 00 0a 27                              |  ...'          |                      size: 2599 0xa12-0xa16 (4)
 0x0a10|                  73 74 62 6c                  |      stbl      |                      type: "stbl" (Sample table box, container for the time/space map) 0xa16-0xa1a (4)

--- a/format/mp4/testdata/in24.fqtest
+++ b/format/mp4/testdata/in24.fqtest
@@ -174,7 +174,7 @@ $ fq dv in24.mp4
 0x2e0|20                                             |                |
 0x2e0|   00                                          | .              |                              version: 0 0x2e1-0x2e2 (1)
 0x2e0|      00 00 01                                 |  ...           |                              flags: 1 0x2e2-0x2e5 (3)
-     |                                               |                |                              data: raw bits 0x2e5-0x2e5 (0)
+     |                                               |                |                              data: "" 0x2e5-0x2e5 (0)
      |                                               |                |                    [3]{}: box 0x2e5-0x3cb (230)
 0x2e0|               00 00 00 e6                     |     ....       |                      size: 230 0x2e5-0x2e9 (4)
 0x2e0|                           73 74 62 6c         |         stbl   |                      type: "stbl" (Sample table box, container for the time/space map) 0x2e9-0x2ed (4)

--- a/format/mp4/testdata/lpcm.fqtest
+++ b/format/mp4/testdata/lpcm.fqtest
@@ -175,7 +175,7 @@ $ fq dv lpcm.mp4
 0x410|               75 72 6c 20                     |     url        |                              type: "url " 0x415-0x419 (4)
 0x410|                           00                  |         .      |                              version: 0 0x419-0x41a (1)
 0x410|                              00 00 01         |          ...   |                              flags: 1 0x41a-0x41d (3)
-     |                                               |                |                              data: raw bits 0x41d-0x41d (0)
+     |                                               |                |                              data: "" 0x41d-0x41d (0)
      |                                               |                |                    [3]{}: box 0x41d-0x4f1 (212)
 0x410|                                       00 00 00|             ...|                      size: 212 0x41d-0x421 (4)
 0x420|d4                                             |.               |

--- a/format/mp4/testdata/mp3.fqtest
+++ b/format/mp4/testdata/mp3.fqtest
@@ -181,7 +181,7 @@ $ fq -d mp4 dv mp3.mp4
 0x420|         75 72 6c 20                           |   url          |                              type: "url " 0x423-0x427 (4)
 0x420|                     00                        |       .        |                              version: 0 0x427-0x428 (1)
 0x420|                        00 00 01               |        ...     |                              flags: 1 0x428-0x42b (3)
-     |                                               |                |                              data: raw bits 0x42b-0x42b (0)
+     |                                               |                |                              data: "" 0x42b-0x42b (0)
      |                                               |                |                    [2]{}: box 0x42b-0x503 (216)
 0x420|                                 00 00 00 d8   |           .... |                      size: 216 0x42b-0x42f (4)
 0x420|                                             73|               s|                      type: "stbl" (Sample table box, container for the time/space map) 0x42f-0x433 (4)

--- a/format/mp4/testdata/mpeg2.fqtest
+++ b/format/mp4/testdata/mpeg2.fqtest
@@ -184,7 +184,7 @@ $ fq -d mp4 dv mpeg2.mp4
 0x2130|72 6c 20                                       |rl              |
 0x2130|         00                                    |   .            |                              version: 0 0x2133-0x2134 (1)
 0x2130|            00 00 01                           |    ...         |                              flags: 1 0x2134-0x2137 (3)
-      |                                               |                |                              data: raw bits 0x2137-0x2137 (0)
+      |                                               |                |                              data: "" 0x2137-0x2137 (0)
       |                                               |                |                    [2]{}: box 0x2137-0x2247 (272)
 0x2130|                     00 00 01 10               |       ....     |                      size: 272 0x2137-0x213b (4)
 0x2130|                                 73 74 62 6c   |           stbl |                      type: "stbl" (Sample table box, container for the time/space map) 0x213b-0x213f (4)

--- a/format/mp4/testdata/opus.fqtest
+++ b/format/mp4/testdata/opus.fqtest
@@ -178,7 +178,7 @@ $ fq -d mp4 dv opus.mp4
 0x310|                                    75 72 6c 20|            url |                              type: "url " 0x31c-0x320 (4)
 0x320|00                                             |.               |                              version: 0 0x320-0x321 (1)
 0x320|   00 00 01                                    | ...            |                              flags: 1 0x321-0x324 (3)
-     |                                               |                |                              data: raw bits 0x324-0x324 (0)
+     |                                               |                |                              data: "" 0x324-0x324 (0)
      |                                               |                |                    [2]{}: box 0x324-0x3d7 (179)
 0x320|            00 00 00 b3                        |    ....        |                      size: 179 0x324-0x328 (4)
 0x320|                        73 74 62 6c            |        stbl    |                      type: "stbl" (Sample table box, container for the time/space map) 0x328-0x32c (4)

--- a/format/mp4/testdata/png.mp4.fqtest
+++ b/format/mp4/testdata/png.mp4.fqtest
@@ -185,7 +185,7 @@ $ fq dv png.mp4
 0x210|      75 72 6c 20                              |  url           |                              type: "url " 0x212-0x216 (4)
 0x210|                  00                           |      .         |                              version: 0 0x216-0x217 (1)
 0x210|                     00 00 01                  |       ...      |                              flags: 1 0x217-0x21a (3)
-     |                                               |                |                              data: raw bits 0x21a-0x21a (0)
+     |                                               |                |                              data: "" 0x21a-0x21a (0)
      |                                               |                |                    [2]{}: box 0x21a-0x33e (292)
 0x210|                              00 00 01 24      |          ...$  |                      size: 292 0x21a-0x21e (4)
 0x210|                                          73 74|              st|                      type: "stbl" (Sample table box, container for the time/space map) 0x21e-0x222 (4)

--- a/format/mp4/testdata/png_no_hdlr.mp4.fqtest
+++ b/format/mp4/testdata/png_no_hdlr.mp4.fqtest
@@ -147,7 +147,7 @@ $ fq dv png_no_hdlr.mp4
 0x180|75 72 6c 20                                    |url             |                              type: "url " 0x180-0x184 (4)
 0x180|            00                                 |    .           |                              version: 0 0x184-0x185 (1)
 0x180|               00 00 01                        |     ...        |                              flags: 1 0x185-0x188 (3)
-     |                                               |                |                              data: raw bits 0x188-0x188 (0)
+     |                                               |                |                              data: "" 0x188-0x188 (0)
      |                                               |                |                    [2]{}: box 0x188-0x2ac (292)
 0x180|                        00 00 01 24            |        ...$    |                      size: 292 0x188-0x18c (4)
 0x180|                                    73 74 62 6c|            stbl|                      type: "stbl" (Sample table box, container for the time/space map) 0x18c-0x190 (4)

--- a/format/mp4/testdata/stz2.fqtest
+++ b/format/mp4/testdata/stz2.fqtest
@@ -178,7 +178,7 @@ $ fq -d mp4 'dv' stz2.mp4
 0x1b0|6c 20                                          |l               |
 0x1b0|      00                                       |  .             |                              version: 0 0x1b2-0x1b3 (1)
 0x1b0|         00 00 01                              |   ...          |                              flags: 1 0x1b3-0x1b6 (3)
-     |                                               |                |                              data: raw bits 0x1b6-0x1b6 (0)
+     |                                               |                |                              data: "" 0x1b6-0x1b6 (0)
      |                                               |                |                    [2]{}: box 0x1b6-0x27c (198)
 0x1b0|                  00 00 00 c6                  |      ....      |                      size: 198 0x1b6-0x1ba (4)
 0x1b0|                              73 74 62 6c      |          stbl  |                      type: "stbl" (Sample table box, container for the time/space map) 0x1ba-0x1be (4)

--- a/format/mp4/testdata/vorbis.fqtest
+++ b/format/mp4/testdata/vorbis.fqtest
@@ -183,7 +183,7 @@ $ fq -d mp4 dv vorbis.mp4
 0x0360|      75 72 6c 20                              |  url           |                              type: "url " 0x362-0x366 (4)
 0x0360|                  00                           |      .         |                              version: 0 0x366-0x367 (1)
 0x0360|                     00 00 01                  |       ...      |                              flags: 1 0x367-0x36a (3)
-      |                                               |                |                              data: raw bits 0x36a-0x36a (0)
+      |                                               |                |                              data: "" 0x36a-0x36a (0)
       |                                               |                |                    [2]{}: box 0x36a-0x1127 (3517)
 0x0360|                              00 00 0d bd      |          ....  |                      size: 3517 0x36a-0x36e (4)
 0x0360|                                          73 74|              st|                      type: "stbl" (Sample table box, container for the time/space map) 0x36e-0x372 (4)

--- a/format/mp4/testdata/vp9.fqtest
+++ b/format/mp4/testdata/vp9.fqtest
@@ -167,7 +167,7 @@ $ fq -d mp4 dv vp9.mp4
 0x16f0|20                                             |                |
 0x16f0|   00                                          | .              |                              version: 0 0x16f1-0x16f2 (1)
 0x16f0|      00 00 01                                 |  ...           |                              flags: 1 0x16f2-0x16f5 (3)
-      |                                               |                |                              data: raw bits 0x16f5-0x16f5 (0)
+      |                                               |                |                              data: "" 0x16f5-0x16f5 (0)
       |                                               |                |                    [2]{}: box 0x16f5-0x17ed (248)
 0x16f0|               00 00 00 f8                     |     ....       |                      size: 248 0x16f5-0x16f9 (4)
 0x16f0|                           73 74 62 6c         |         stbl   |                      type: "stbl" (Sample table box, container for the time/space map) 0x16f9-0x16fd (4)

--- a/format/prores/testdata/prores_frame.fqtest
+++ b/format/prores/testdata/prores_frame.fqtest
@@ -198,7 +198,7 @@ $ fq -d mp4 dv prores_frame.mov
 0x6df0|      75 72 6c 20                              |  url           |                              type: "url " 0x6df2-0x6df6 (4)
 0x6df0|                  00                           |      .         |                              version: 0 0x6df6-0x6df7 (1)
 0x6df0|                     00 00 01                  |       ...      |                              flags: 1 0x6df7-0x6dfa (3)
-      |                                               |                |                              data: raw bits 0x6dfa-0x6dfa (0)
+      |                                               |                |                              data: "" 0x6dfa-0x6dfa (0)
       |                                               |                |                    [3]{}: box 0x6dfa-0x6ede (228)
 0x6df0|                              00 00 00 e4      |          ....  |                      size: 228 0x6dfa-0x6dfe (4)
 0x6df0|                                          73 74|              st|                      type: "stbl" (Sample table box, container for the time/space map) 0x6dfe-0x6e02 (4)


### PR DESCRIPTION
Also add field for data reference url

Fixes FileFormatConformance/data/file_features/published/isobmff/02_dref_edts_img.mp4