### PR TITLE
interp: Support ~/.config/fq as fallback on macOS

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -853,9 +853,9 @@ variable `CLIUNICODE`.
 ## Configuration
 
 To add own functions you can use `init.fq` that will be read from
-- `$HOME/Library/Application Support/fq/init.jq` on macOS
-- `$HOME/.config/fq/init.jq` on Linux, BSD etc
-- `%AppData%\fq\init.jq` on Windows
+- `$HOME/Library/Application Support/fq` or `$HOME/.config/fq` on macOS
+- `$HOME/.config/fq` on Linux, BSD etc
+- `%AppData%` on Windows
 
 ## Use as script interpreter
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -151,11 +151,27 @@ func (*stdOS) Args() []string { return os.Args }
 func (*stdOS) Environ() []string { return os.Environ() }
 
 func (*stdOS) ConfigDir() (string, error) {
-	p, err := os.UserConfigDir()
+	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(p, "fq"), nil
+	fqDir := filepath.Join(configDir, "fq")
+
+	if runtime.GOOS != "darwin" {
+		return fqDir, nil
+	}
+
+	// this is to support fallback to ~/.config on macOS/darwin
+	if _, err := os.Stat(fqDir); err == nil {
+		return fqDir, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(homeDir, ".config", "fq"), nil
 }
 
 type stdOSFS struct{}


### PR DESCRIPTION
Got fed up with ~/Library/Application Support/fq