### PR TITLE
pkg/cli/test_exp.sh: use command -v

### DIFF
--- a/pkg/cli/test_exp.sh
+++ b/pkg/cli/test_exp.sh
@@ -4,7 +4,7 @@ set -eu
 FQ="$1"
 shift
 
-if which expect >/dev/null 2>&1; then
+if command -v expect >/dev/null 2>&1; then
     TEMPDIR=$(mktemp -d)
     cp "$FQ" "${TEMPDIR}/fq"
     PATH="${TEMPDIR}:${PATH}" expect "$1" >"${TEMPDIR}/fq.log" && FAIL=0 || FAIL=1


### PR DESCRIPTION
`which` is non-portable and not part of POSIX, but we can use `command -v` for the same effect.

Debian [0] and Gentoo [1] are both trying to drop which from their base system.

[0] https://lwn.net/Articles/874049/
[1] https://bugs.gentoo.org/646588