### PR TITLE
gojq: Update fq fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wader/fq
 go 1.18
 
 // fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-require github.com/wader/gojq v0.12.1-0.20240324083939-2b4dc721594a
+require github.com/wader/gojq v0.12.1-0.20240401131232-6c6bc364201a
 
 require (
 	// bump: gomod-BurntSushi/toml /github\.com\/BurntSushi\/toml v(.*)/ https://github.com/BurntSushi/toml.git|^1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/wader/gojq v0.12.1-0.20240324083939-2b4dc721594a h1:8SdZghxMYax232ktkzCOqtjnIQ9hO7sP7AXJipAZh8o=
-github.com/wader/gojq v0.12.1-0.20240324083939-2b4dc721594a/go.mod h1:gPc2V6SapmFtdvALwJRg9WKk97piqkagc6vW6PoPqM4=
+github.com/wader/gojq v0.12.1-0.20240401131232-6c6bc364201a h1:P881Oecjt9FEXrwkGJ6UObJksxejJaF/fKq1ZfXpiVE=
+github.com/wader/gojq v0.12.1-0.20240401131232-6c6bc364201a/go.mod h1:qVrzkUdnBtJvM4twyRQ6xdziPSnSp35dLm4s/DN2iP4=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=

--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -295,8 +295,9 @@ func toBytes(v any) ([]byte, error) {
 func queryErrorPosition(expr string, v error) pos.Pos {
 	var offset int
 
-	if tokIf, ok := v.(interface{ Token() (string, int) }); ok {
-		_, offset = tokIf.Token()
+	var e *gojq.ParseError
+	if errors.As(v, &e) {
+		offset = e.Offset
 	}
 	if offset >= 0 {
 		return pos.NewFromOffset(expr, offset)
@@ -398,7 +399,7 @@ func (i *Interp) Main(ctx context.Context, output Output, versionStr string) err
 
 		switch v := v.(type) {
 		case error:
-			var haltErr gojq.HaltError
+			var haltErr *gojq.HaltError
 			if errors.As(v, &haltErr) {
 				if haltErrV := haltErr.Value(); haltErrV != nil {
 					if str, ok := haltErrV.(string); ok {


### PR DESCRIPTION
Fixes issue using ascii_downcase and ascii_upcase with decode value.

From upstream https://github.com/itchyny/gojq/blob/main/CHANGELOG.md:
* implement `ltrim`, `rtrim`, and `trim` functions
* implement `gojq.ParseError` for getting the offset and token of query parsing error
* implement `gojq.HaltError` for detecting halt errors and stopping outer iteration
* fix object construction with duplicate keys (`{x:0,y:1} | {a:.x,a:.y}`)
* fix `halt` and `halt_error` functions to stop the command execution immediately
* fix variable scope of binding syntax (`"a" as $v | def f: $v; "b" as $v | f`)
* fix pre-defined variables to be available in initial modules (`$ARGS` in `~/.jq`)
* fix `ltrimstr` and `rtrimstr` functions to emit error on non-string input
* fix `nearbyint` and `rint` functions to round ties to even
* improve parser to allow `reduce`, `foreach`, `if`, `try`-`catch` syntax as object values
* remove `pow10` in favor of `exp10`, define `scalbn` and `scalbln` by `ldexp`