### PR TITLE
Update github-golangci-lint to 1.58.1 from 1.58.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "1.58.0"
+  GOLANGCILINT_VERSION: "1.58.1"
 
 jobs:
   lint:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v1.58.1)  
