### PR TITLE
interp: Add bits_format=byte_array support

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -55,6 +55,8 @@ fq -Vr .path.to.string file
 fq -o bits_format=truncate tovalue file
 # JSON but raw bit fields as md5 hex string
 fq -o bits_format=md5 tovalue file
+# JSON but raw bit fields as byte arrays
+fq -o bits_format=byte_array tovalue file
 # look up a path
 fq '.some[1].path' file
 # look up a path and output JSON
@@ -898,12 +900,13 @@ fq has some general options in addition to decode and decoders specific options.
 
 How to represent raw binary as JSON.
 
-- `-o bits_format=string` String with raw bytes (zero bit padded if size is not byte aligned). The string is binary safe internally in fq but bytes not representable as UTF-8 will be lost if turn to JSON.
-- `-o bits_format=md5` MD5 hex string (zero bit padded).
-- `-o bits_format=hex` Hex string.
 - `-o bits_format=base64` Base64 string.
-- `-p bits_format=truncate` Truncated string.
+- `-o bits_format=byte_array` Array of bytes (zero bit padded if size is not byte aligned).
+- `-o bits_format=hex` Hex string.
+- `-o bits_format=md5` MD5 hex string (zero bit padded).
 - `-o bits_format=snippet` Truncated Base64 string prefixed with bit length.
+- `-o bits_format=string` String with raw bytes (zero bit padded if size is not byte aligned). The string is binary safe internally in fq but bytes not representable as UTF-8 will be lost if turn into JSON (default).
+- `-p bits_format=truncate` Truncated string.
 
 ```sh
 $ fq -V -o bits_format=base64 . file

--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -1134,6 +1134,18 @@ func bitsFormatFnFromOptions(opts Options) (func(br bitio.ReaderAtSeeker) (any, 
 
 			return fmt.Sprintf("<%s>%s", mathx.Bits(brLen).StringByteBits(opts.Sizebase), b.String()), nil
 		}, nil
+	case "byte_array":
+		return func(br bitio.ReaderAtSeeker) (any, error) {
+			b := &bytes.Buffer{}
+			if _, err := bitiox.CopyBits(b, br); err != nil {
+				return "", err
+			}
+			var v []any
+			for _, bv := range b.Bytes() {
+				v = append(v, int(bv))
+			}
+			return v, nil
+		}, nil
 	default:
 		return nil, fmt.Errorf("invalid bits format %q", opts.BitsFormat)
 	}

--- a/pkg/interp/testdata/binary.fqtest
+++ b/pkg/interp/testdata/binary.fqtest
@@ -35,12 +35,30 @@ $ fq -d mp3 '.frames[]._bits[0:12] | tonumber' test.mp3
 4095
 $ fq -d mp3 '.headers[0].header.magic._bits[0:24] | tostring' test.mp3
 "ID3"
-$ fq -d mp3 '.frames[0].audio_data | ("", "md5", "hex", "base64", "snippet") as $f | try tovalue({bits_format: $f}) catch .' test.mp3
+$ fq -d mp3 '.frames[0].audio_data, (.frames[0].tag.header | tobytes) | ("", "md5", "hex", "base64", "snippet", "byte_array") as $f | try tovalue({bits_format: $f}) catch .' test.mp3
 "invalid bits format \"\""
 "ca9c491ac66b2c62500882e93f3719a8"
 "0000000000"
 "AAAAAAA="
 "<5>AAAAAAA="
+[
+  0,
+  0,
+  0,
+  0,
+  0
+]
+"invalid bits format \"\""
+"4059b0251f66a18cb56f544728796875"
+"496e666f"
+"SW5mbw=="
+"<4>SW5mbw=="
+[
+  73,
+  110,
+  102,
+  111
+]
 $ fq -o bits_format=hex -n '[1,2,3] | tobytes'
    |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
 0x0|01 02 03|                                      |...|            |.: raw bits 0x0-0x3 (3)


### PR DESCRIPTION
Represent binary values into an array of bytes when turn values into JSON