### PR TITLE
intepr: Support each for binary values

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -405,8 +405,9 @@ There is also `tobitsrange` and `tobytesrange` which does the same thing but wil
   - `[0x12, 0x34, 0x56] | tobits[4:12]` will be a binary with the byte `0x23`
   - `[0x12, 0x34, 0x56] | tobits[4:20]` will be a binary with the byte `0x23`, `0x45`
   - `[0x12, 0x34, 0x56] | tobits[4:20] | tobytes[1:]` will be a binary with the byte `0x45`,
-
-Both `.[index]` and `.[start:end]` support negative indices to index from end.
+  - Both `.[index]` and `.[start:end]` support negative indices to index from end.
+- `.[]` outputs all bytes or bit as integers, same as `explode[]`.
+- `explode` output an array with all byte or bits as integers, same as `[.[]]`.
 
 #### Binary array
 

--- a/pkg/interp/binary.go
+++ b/pkg/interp/binary.go
@@ -414,7 +414,12 @@ func (b Binary) JQValueKey(name string) any {
 	return nil
 }
 func (b Binary) JQValueEach() any {
-	return nil
+	l := int(b.r.Len / int64(b.unit))
+	vs := make([]gojq.PathValue, l)
+	for i := 0; i < l; i++ {
+		vs[i] = gojq.PathValue{Path: i, Value: b.JQValueIndex(i)}
+	}
+	return vs
 }
 func (b Binary) JQValueType() string {
 	return gojq.JQTypeString


### PR DESCRIPTION
Makes it possible to output all bytes or bits as integers in a binary value. Ex: [1,2,3] | [tobytes[]] -> [1,2,3]