### PR TITLE
tzx: add readme instructions for bits_format=byte_array

### DIFF
--- a/doc/formats.md
+++ b/doc/formats.md
@@ -1223,6 +1223,15 @@ You will often find this format embedded inside the TZX tape format.
 
 The default file extension is `.tap`.
 
+### Processing JSON files
+
+When needing to process a generated JSON file it's recommended to convert the
+plain data bytes to an array by setting `bits_format=byte_array`:
+
+```bash
+fq -o bits_format=byte_array -d tap -V d /path/to/file.tap
+```
+
 ### Authors
 
 - Michael R. Cook work.mrc@pm.me, original author
@@ -1412,6 +1421,15 @@ The format was originally created by Tomaz Kac, who was maintainer until
 the company Ramsoft became the maintainers, and created revision `v1.20`.
 
 The default file extension is `.tzx`.
+
+### Processing JSON files
+
+When needing to process a generated JSON file it's recommended to convert the
+plain data bytes to an array by setting `bits_format=byte_array`:
+
+```bash
+fq -o bits_format=byte_array -d tzx -V d /path/to/file.tzx
+```
 
 ### Authors
 

--- a/format/tap/tap.md
+++ b/format/tap/tap.md
@@ -7,6 +7,15 @@ You will often find this format embedded inside the TZX tape format.
 
 The default file extension is `.tap`.
 
+### Processing JSON files
+
+When needing to process a generated JSON file it's recommended to convert the
+plain data bytes to an array by setting `bits_format=byte_array`:
+
+```bash
+fq -o bits_format=byte_array -d tap -V d /path/to/file.tap
+```
+
 ### Authors
 
 - Michael R. Cook work.mrc@pm.me, original author

--- a/format/tzx/tzx.md
+++ b/format/tzx/tzx.md
@@ -8,6 +8,15 @@ the company Ramsoft became the maintainers, and created revision `v1.20`.
 
 The default file extension is `.tzx`.
 
+### Processing JSON files
+
+When needing to process a generated JSON file it's recommended to convert the
+plain data bytes to an array by setting `bits_format=byte_array`:
+
+```bash
+fq -o bits_format=byte_array -d tzx -V d /path/to/file.tzx
+```
+
 ### Authors
 
 - Michael R. Cook work.mrc@pm.me, original author


### PR DESCRIPTION
A small update to the TZX/TAP formats readme, with reference to the new `bits_format=byte_array`.