### PR TITLE
Replace `exp/slices` package with standard library

### DIFF
--- a/format/mp4/mp4.go
+++ b/format/mp4/mp4.go
@@ -19,12 +19,12 @@ import (
 	"cmp"
 	"embed"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/wader/fq/format"
 	"github.com/wader/fq/pkg/decode"
 	"github.com/wader/fq/pkg/interp"
-	"golang.org/x/exp/slices"
 )
 
 //go:embed mp4.jq

--- a/format/opentimestamps/opentimestamps.go
+++ b/format/opentimestamps/opentimestamps.go
@@ -4,12 +4,12 @@ package opentimestamps
 
 import (
 	"embed"
+	"slices"
 
 	"github.com/wader/fq/format"
 	"github.com/wader/fq/pkg/decode"
 	"github.com/wader/fq/pkg/interp"
 	"github.com/wader/fq/pkg/scalar"
-	"golang.org/x/exp/slices"
 )
 
 //go:embed opentimestamps.md

--- a/format/xml/xml.go
+++ b/format/xml/xml.go
@@ -16,6 +16,7 @@ import (
 	"html"
 	"io"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -28,7 +29,6 @@ import (
 	"github.com/wader/fq/pkg/decode"
 	"github.com/wader/fq/pkg/interp"
 	"github.com/wader/fq/pkg/scalar"
-	"golang.org/x/exp/slices"
 )
 
 //go:embed xml.jq

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -11,13 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/wader/fq/internal/shquote"
 	"github.com/wader/fq/pkg/bitio"
 	"github.com/wader/fq/pkg/interp"
-	"golang.org/x/exp/slices"
 )
 
 var unescapeRe = regexp.MustCompile(`\\(?:t|b|n|r|0(?:b[01]{8}|x[0-f]{2}))`)

--- a/pkg/decode/value.go
+++ b/pkg/decode/value.go
@@ -4,11 +4,11 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/wader/fq/pkg/bitio"
 	"github.com/wader/fq/pkg/ranges"
 	"github.com/wader/fq/pkg/scalar"
-	"golang.org/x/exp/slices"
 )
 
 type Compound struct {

--- a/pkg/interp/registry.go
+++ b/pkg/interp/registry.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/wader/fq/internal/gojqx"
 	"github.com/wader/fq/pkg/decode"
-	"golang.org/x/exp/slices"
 )
 
 type EnvFuncFn func(env *Interp) gojqx.Function

--- a/pkg/ranges/ranges.go
+++ b/pkg/ranges/ranges.go
@@ -3,10 +3,9 @@ package ranges
 import (
 	"cmp"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 type Range struct {


### PR DESCRIPTION
The experimental functions in `golang.org/x/exp/slices` are now included in the standard library since Go 1.21 [^1].

[^1]: https://go.dev/doc/go1.21#slices

However, we cannot remove the `golang.org/x/exp` dependency yet because we still rely on the `golang.org/x/exp/constraints` package, which has not yet been included into the standard library (https://github.com/golang/go/issues/61914).

An alternative approach is to create our own implementation, e.g. `constraints.go` like this PR https://github.com/hashicorp/terraform-plugin-testing/pull/260 so we can remove the `golang.org/x/exp` dependency completely.

https://github.com/wader/fq/blob/4e3ab79695fbec3e7fa275cb5bacac8587d852c1/format/apple/loop_detector.go#L4

https://github.com/wader/fq/blob/4e3ab79695fbec3e7fa275cb5bacac8587d852c1/internal/mathx/num.go#L11