### PR TITLE
gojq: Update fq fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ cpuprof: prof
 	go tool pprof -http :5555 fq.prof fq.cpu.prof
 
 update-gomod: always
-	GOPROXY=direct go get -d github.com/wader/gojq@fq
+	GOPROXY=direct go get github.com/wader/gojq@fq
 	go mod tidy
 
 # Usage: make fuzz # fuzz all foramts

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.8
 
 // fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-require github.com/wader/gojq v0.12.1-0.20240822064856-a7688e3344e7
+require github.com/wader/gojq v0.12.1-0.20250208151254-0aa7b87b2c2b
 
 require (
 	// bump: gomod-BurntSushi/toml /github\.com\/BurntSushi\/toml v(.*)/ https://github.com/BurntSushi/toml.git|^1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/wader/gojq v0.12.1-0.20240822064856-a7688e3344e7 h1:zrUiUpIX/C5QzEkR/+wb7dIRtcxfXrTUqvDvCQeeibw=
-github.com/wader/gojq v0.12.1-0.20240822064856-a7688e3344e7/go.mod h1:EPKZhJLM6ILU40HkgFbhrsV7MHf5flxQDS5fSf/KNpE=
+github.com/wader/gojq v0.12.1-0.20250208151254-0aa7b87b2c2b h1:WCz2ZrmrvrqYt7Fxwx1b9Ba9FDq0hX4sEPezrsAxveo=
+github.com/wader/gojq v0.12.1-0.20250208151254-0aa7b87b2c2b/go.mod h1:EPKZhJLM6ILU40HkgFbhrsV7MHf5flxQDS5fSf/KNpE=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=


### PR DESCRIPTION
Changes from upstream:
f561d02 update CHANGELOG.md for v0.12.17
5fbda3f implement --library-path option as the alias of -L option af0c3da use strings.Repeat to repeat a space in formatting flags 8a09826 fix reduce syntax to emit results for each initial value b685aac avoid repeating the same return type
8f6a146 refactor stream input iterator to use jsonInputIter 9de339f refactor color parsing and environ loader using strings.Cut b144489 handle error of setting environment variables in tests 086bd2b implement skip/2, fix limit/2 to emit error on negative count c91bf50 remove build tags with legacy syntax
eeebe07 improve definition and tests of fromstream function a09589e remove use of deprecated -d flag of go get 94dd99a fix last/1 to yield no values when the argument yields no values af0303e improve tests for nth functions
7a1698a resolve search paths of import statements in the query (fix #265)