### PR TITLE
mp4: Add skip_samples options

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -357,7 +357,8 @@ func (t TCP_Stream_In) MustIsPort(fn func(format string, a ...any), ports ...int
 }
 
 type MP4_In struct {
-	DecodeSamples  bool `doc:"Decode samples"`
+	DecodeSamples  bool `doc:"Decode track samples"`
+	SkipSamples    bool `doc:"Skip track samples"`
 	AllowTruncated bool `doc:"Allow box to be truncated"`
 }
 

--- a/format/mp4/mp4.go
+++ b/format/mp4/mp4.go
@@ -336,6 +336,10 @@ func mp4Tracks(d *decode.D, ctx *decodeContext) {
 					return
 				}
 
+				if ctx.opts.SkipSamples {
+					return
+				}
+
 				d.FieldArray("samples", func(d *decode.D) {
 					// TODO: warning? could also be init fragment etc
 

--- a/format/mp4/testdata/help_mp4.fqtest
+++ b/format/mp4/testdata/help_mp4.fqtest
@@ -5,7 +5,8 @@ Options
 =======
 
   allow_truncated=false  Allow box to be truncated
-  decode_samples=true    Decode samples
+  decode_samples=true    Decode track samples
+  skip_samples=false     Skip track samples
 
 Decode examples
 ===============
@@ -15,9 +16,9 @@ Decode examples
   # Decode value as mp4
   ... | mp4
   # Decode file using mp4 options
-  $ fq -d mp4 -o allow_truncated=false -o decode_samples=true . file
+  $ fq -d mp4 -o allow_truncated=false -o decode_samples=true -o skip_samples=false . file
   # Decode value as mp4
-  ... | mp4({allow_truncated:false,decode_samples:true})
+  ... | mp4({allow_truncated:false,decode_samples:true,skip_samples:false})
 
 Speed up decoding by not decoding samples
 =========================================


### PR DESCRIPTION
Will skip create sample array for each track. Can be used to decode broken mp4s.