### PR TITLE
Update github-golangci-lint to 2.1.2 from 2.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "2.1.1"
+  GOLANGCILINT_VERSION: "2.1.2"
 
 jobs:
   lint:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.1.2)  
