### PR TITLE
Update gojq fork

### DIFF
--- a/format/json/json.go
+++ b/format/json/json.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wader/fq/format"
 	"github.com/wader/fq/internal/colorjson"
+	"github.com/wader/fq/internal/gojqx"
 	"github.com/wader/fq/pkg/bitio"
 	"github.com/wader/fq/pkg/decode"
 	"github.com/wader/fq/pkg/interp"
@@ -70,9 +71,9 @@ func decodeJSONEx(d *decode.D, lines bool) any {
 		if len(vs) == 0 {
 			d.Fatalf("not lines found")
 		}
-		s.Actual = gojq.NormalizeNumbers(vs)
+		s.Actual = gojqx.NormalizeNumbers(vs)
 	} else {
-		s.Actual = gojq.NormalizeNumbers(vs[0])
+		s.Actual = gojqx.NormalizeNumbers(vs[0])
 	}
 	d.Value.V = &s
 	d.Value.Range.Len = d.Len()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 // fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-require github.com/wader/gojq v0.12.1-0.20250208151254-0aa7b87b2c2b
+require github.com/wader/gojq v0.12.1-0.20251019091009-98f8efce4ca9
 
 require (
 	// bump: gomod-BurntSushi/toml /github\.com\/BurntSushi\/toml v(.*)/ https://github.com/BurntSushi/toml.git|^1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/wader/gojq v0.12.1-0.20250208151254-0aa7b87b2c2b h1:WCz2ZrmrvrqYt7Fxwx1b9Ba9FDq0hX4sEPezrsAxveo=
-github.com/wader/gojq v0.12.1-0.20250208151254-0aa7b87b2c2b/go.mod h1:EPKZhJLM6ILU40HkgFbhrsV7MHf5flxQDS5fSf/KNpE=
+github.com/wader/gojq v0.12.1-0.20251019091009-98f8efce4ca9 h1:jGtVeavxUIaOI5uOXdAkx0lUOBPVab1PTIelR22kjds=
+github.com/wader/gojq v0.12.1-0.20251019091009-98f8efce4ca9/go.mod h1:HHadLeynSPri8pOLkVaScleGUaADR1SVLd6UegzQd6Y=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
 golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=

--- a/internal/gojqx/normalize.go
+++ b/internal/gojqx/normalize.go
@@ -1,0 +1,68 @@
+package gojqx
+
+import (
+	"encoding/json"
+	"math"
+	"math/big"
+
+	"github.com/wader/gojq"
+)
+
+// from gojq
+func NormalizeNumbers(v any) any {
+	switch v := v.(type) {
+	case json.Number:
+		return gojq.ParseNumber(v)
+	case *big.Int:
+		if v.IsInt64() {
+			if i := v.Int64(); math.MinInt <= i && i <= math.MaxInt {
+				return int(i)
+			}
+		}
+		return v
+	case int64:
+		if math.MinInt <= v && v <= math.MaxInt {
+			return int(v)
+		}
+		return big.NewInt(v)
+	case int32:
+		return int(v)
+	case int16:
+		return int(v)
+	case int8:
+		return int(v)
+	case uint:
+		if v <= math.MaxInt {
+			return int(v)
+		}
+		return new(big.Int).SetUint64(uint64(v))
+	case uint64:
+		if v <= math.MaxInt {
+			return int(v)
+		}
+		return new(big.Int).SetUint64(v)
+	case uint32:
+		if uint64(v) <= math.MaxInt {
+			return int(v)
+		}
+		return new(big.Int).SetUint64(uint64(v))
+	case uint16:
+		return int(v)
+	case uint8:
+		return int(v)
+	case float32:
+		return float64(v)
+	case []any:
+		for i, x := range v {
+			v[i] = NormalizeNumbers(x)
+		}
+		return v
+	case map[string]any:
+		for k, x := range v {
+			v[k] = NormalizeNumbers(x)
+		}
+		return v
+	default:
+		return v
+	}
+}

--- a/internal/gojqx/totype.go
+++ b/internal/gojqx/totype.go
@@ -6,6 +6,7 @@
 package gojqx
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/big"
@@ -65,6 +66,8 @@ func ToGoJQValueFn(v any, valueFn func(v any) (any, error)) (any, error) {
 			}
 		}
 		return vv, nil
+	case json.Number:
+		return gojq.ParseNumber(vv), nil
 	case string:
 		return vv, nil
 	case []byte:

--- a/internal/gojqx/types.go
+++ b/internal/gojqx/types.go
@@ -372,7 +372,7 @@ func (v String) JQValueToNumber() any {
 	if !gojq.ValidNumber(string(v)) {
 		return fmt.Errorf("invalid number: %q", string(v))
 	}
-	return gojq.NormalizeNumber(json.Number(string(v)))
+	return gojq.ParseNumber(json.Number(string(v)))
 }
 func (v String) JQValueToString() any { return string(v) }
 func (v String) JQValueToGoJQ() any   { return string(v) }


### PR DESCRIPTION
Move NormalizeNumbers to fq as gojq does not use it anymore.

fq visible gojq upstream changes:
- fix repeating string to emit an error when the result is too large
- fix last/1 to be included in builtins/0
- implement toboolean/0 function
- implement trimstr/1 function
- increase the array index limit to 2^29
- round up end index of slicing for jq compatibility