### PR TITLE
Update github-golangci-lint to 2.6.0 from 2.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "2.5.0"
+  GOLANGCILINT_VERSION: "2.6.0"
 
 jobs:
   lint:

--- a/format/crypto/hash.go
+++ b/format/crypto/hash.go
@@ -14,7 +14,7 @@ import (
 	"github.com/wader/fq/pkg/bitio"
 	"github.com/wader/fq/pkg/interp"
 
-	//nolint: staticcheck
+	//nolint: all
 	"golang.org/x/crypto/md4"
 	"golang.org/x/crypto/sha3"
 )

--- a/internal/hexdump/hexdump_test.go
+++ b/internal/hexdump/hexdump_test.go
@@ -1,16 +1,16 @@
 // TODO: fix tests
 //go:build ignore
-// +build ignore
 
 package hexdump_test
 
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/wader/fq/internal/asciiwriter"
 	"github.com/wader/fq/internal/hexdump"
 	"github.com/wader/fq/internal/hexpairwriter"
-	"testing"
 )
 
 func TestHexdump(t *testing.T) {

--- a/internal/iox/runereader.go
+++ b/internal/iox/runereader.go
@@ -61,7 +61,7 @@ func (brr RuneReadSeeker) ReadRune() (r rune, size int, err error) {
 		return rune(c), 1, nil
 	}
 
-	ss := utf8Bytes(b[0])
+	ss := utf8Bytes(c)
 	if ss < 0 {
 		return utf8.RuneError, 1, nil
 	}


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.6.0)  
