### PR TITLE
gojq: Update fq fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 // fork of github.com/itchyny/gojq, see github.com/wader/gojq fq branch
-require github.com/wader/gojq v0.12.1-0.20251019091009-98f8efce4ca9
+require github.com/wader/gojq v0.12.1-0.20251123141257-3aa0db91510a
 
 require (
 	// bump: gomod-BurntSushi/toml /github\.com\/BurntSushi\/toml v(.*)/ https://github.com/BurntSushi/toml.git|^1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/wader/gojq v0.12.1-0.20251019091009-98f8efce4ca9 h1:jGtVeavxUIaOI5uOXdAkx0lUOBPVab1PTIelR22kjds=
-github.com/wader/gojq v0.12.1-0.20251019091009-98f8efce4ca9/go.mod h1:HHadLeynSPri8pOLkVaScleGUaADR1SVLd6UegzQd6Y=
+github.com/wader/gojq v0.12.1-0.20251123141257-3aa0db91510a h1:1fXIKcqbbdppTns/kPWDLd0kVSS5V4t6g98vCwSusZg=
+github.com/wader/gojq v0.12.1-0.20251123141257-3aa0db91510a/go.mod h1:HHadLeynSPri8pOLkVaScleGUaADR1SVLd6UegzQd6Y=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=

--- a/pkg/interp/interp.go
+++ b/pkg/interp/interp.go
@@ -451,7 +451,7 @@ type readlineOpts struct {
 
 func (i *Interp) _readline(c any, opts readlineOpts) gojq.Iter {
 	if i.EvalInstance.IsCompleting {
-		return gojq.NewIter()
+		return gojq.NewIter[any]()
 	}
 
 	expr, err := i.OS.Readline(ReadlineOpts{
@@ -604,13 +604,13 @@ func (i *Interp) _stdioWrite(c any, fdName string) gojq.Iter {
 		return gojq.NewIter(fmt.Errorf("%s is not a writeable", fdName))
 	}
 	if i.EvalInstance.IsCompleting {
-		return gojq.NewIter()
+		return gojq.NewIter[any]()
 	}
 
 	if _, err := fmt.Fprint(w, c); err != nil {
 		return gojq.NewIter(err)
 	}
-	return gojq.NewIter()
+	return gojq.NewIter[any]()
 }
 
 func (i *Interp) _stdioInfo(c any, fdName string) any {
@@ -654,7 +654,7 @@ func (i *Interp) _display(c any, v any) gojq.Iter {
 		if err := v.Display(i.EvalInstance.Output, opts); err != nil {
 			return gojq.NewIter(err)
 		}
-		return gojq.NewIter()
+		return gojq.NewIter[any]()
 	default:
 		return gojq.NewIter(fmt.Errorf("%+#v: not displayable", c))
 	}
@@ -679,7 +679,7 @@ func (i *Interp) _hexdump(c any, v any) gojq.Iter {
 		return gojq.NewIter(err)
 	}
 
-	return gojq.NewIter()
+	return gojq.NewIter[any]()
 }
 
 func (i *Interp) _printColorJSON(c any, v any) gojq.Iter {
@@ -715,7 +715,7 @@ func (i *Interp) _printColorJSON(c any, v any) gojq.Iter {
 		return gojq.NewIter(err)
 	}
 
-	return gojq.NewIter()
+	return gojq.NewIter[any]()
 }
 
 func (i *Interp) _isCompleting(c any) any {


### PR DESCRIPTION
This should make fq use much less memory when decoding lots of files in one run.

From upstream:
Restore data offset when popping fork