### PR TITLE
repl: Make input_filename output null instead of last filename

### DIFF
--- a/pkg/interp/init.jq
+++ b/pkg/interp/init.jq
@@ -20,7 +20,11 @@ include "@config/init?";
 def input:
   def _input($opts; f):
     ( _input_filenames
-    | if length == 0 then error("break") end
+    | if length == 0 then
+        ( _input_filename(null) as $_
+        | error("break")
+        )
+      end
     | [.[0], .[1:]] as [$h, $t]
     | _input_filenames($t)
     | _input_filename(null) as $_

--- a/pkg/interp/testdata/inputs.fqtest
+++ b/pkg/interp/testdata/inputs.fqtest
@@ -19,7 +19,7 @@ $ fq -d mp3_frame '(.,input,input,input) | try todescription catch .' a b c
 "c"
 exitcode: 5
 stderr:
-error: c: break
+error: break
 $ fq -d mp3_frame -n '(.,inputs) | try todescription catch .' a b c
 "expected decode value but got: null (null)"
 "a"
@@ -41,7 +41,7 @@ $ fq -d mp3_frame -n '(input,input,input,input) | todescription' a b c
 "c"
 exitcode: 5
 stderr:
-error: c: break
+error: break
 $ fq -d mp3_frame input_filename
 "<stdin>"
 stdin:


### PR DESCRIPTION
Ideally input_filename in REPL should work the same as from CLI but that requires some more refactor. This is less confusing at least.