### PR TITLE
Update github-golangci-lint to 2.11.1 from 2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "2.9.0"
+  GOLANGCILINT_VERSION: "2.11.1"
 
 jobs:
   lint:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.11.1)  
