### PR TITLE
Update make-golangci-lint to 2.11.2 from 2.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ gogenerate: always
 lint: always
 # bump: make-golangci-lint /golangci-lint@v([\d.]+)/ git:https://github.com/golangci/golangci-lint.git|^2
 # bump: make-golangci-lint link "Release notes" https://github.com/golangci/golangci-lint/releases/tag/v$LATEST
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.2 run
 
 depgraph.svg: always
 	go run github.com/kisielk/godepgraph@latest github.com/wader/fq | dot -Tsvg -o godepgraph.svg


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.11.2)  
