### PR TITLE
Update github-golangci-lint to 2.12.1 from 2.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "2.11.4"
+  GOLANGCILINT_VERSION: "2.12.1"
 
 jobs:
   lint:


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.12.1)  
