### PR TITLE
Update github-golangci-lint to 2.12.2 from 2.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "2.11.4"
+  GOLANGCILINT_VERSION: "2.12.2"
 
 jobs:
   lint:

--- a/format/crypto/hash.go
+++ b/format/crypto/hash.go
@@ -2,6 +2,8 @@ package crypto
 
 import (
 	"crypto/md5"
+	"crypto/sha3"
+
 	//nolint: gosec
 	"crypto/sha1"
 	"crypto/sha256"
@@ -16,7 +18,6 @@ import (
 
 	//nolint: staticcheck
 	"golang.org/x/crypto/md4"
-	"golang.org/x/crypto/sha3"
 )
 
 //go:embed hash.jq


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.12.2)  
