### PR TITLE
Add Gentoo install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ You can also build and install the development (VCS) package using an [AUR helpe
 ```sh
 paru -S fq-git
 ```
+
+### Gentoo
+
+`fq` can be installed from the Gentoo package repository using `emerge`:
+
+```sh
+emerge dev-util/fq
+```
+
 ### Guix
 
 ```sh


### PR DESCRIPTION
Adds Gentoo install instructions to README per #541.

Package is available in stable via `emerge dev-util/fq`.