### PR TITLE
Add llms.txt for LLM/agent-readable project summary

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# fq
+
+> jq for binary formats — a CLI tool, query language, and set of decoders for inspecting, querying, slicing, and transforming binary and text file formats. Supports 100+ formats including MP4, JPEG, PCAP, ELF, protobuf, JSON, and CBOR.
+
+## Getting Started
+
+- [Install](https://github.com/wader/fq#install): Prebuilt releases for macOS/Linux/Windows, or Homebrew, MacPorts, Scoop, pacman, Guix, Nix, FreeBSD, Alpine, or `go install github.com/wader/fq@latest`.
+- [Basic usage](https://github.com/wader/fq/blob/master/doc/usage.md): `fq . file`, `fq d file`, `fq 'query' file` — command patterns and common recipes.
+
+## Usage
+
+- [CLI arguments](https://github.com/wader/fq/blob/master/doc/usage.md): jq-compatible flags plus fq-specific ones like `--decode`/`-d NAME` to force a format instead of probing.
+- [Supported formats](https://github.com/wader/fq/blob/master/doc/formats.md): Full list and per-format reference (media containers, network protocols, filesystems, serialization formats, etc.).
+
+## Development
+
+- [Development guide](https://github.com/wader/fq/blob/master/doc/dev.md): How to add a new decoder and the internal architecture.
+
+## Optional
+
+- [Presentations and media](https://github.com/wader/fq#presentations-and-media): FOSDEM 2023 talk, podcast episodes, conference slides.
+- [Related and similar tools](https://github.com/wader/fq#similar-or-related-works): HexFiend, ImHex, kaitai, Wireshark, and others, with notes on how fq differs.
+- [License](https://github.com/wader/fq/blob/master/LICENSE): MIT.


### PR DESCRIPTION
This repo doesn't have an [`llms.txt`](https://llmstxt.org) file yet — a small, curated markdown index (title, one-line summary, and grouped links to the docs that matter) that AI coding agents can read to understand a project quickly, instead of having to crawl and guess through the full README and `doc/` tree.

fq has a genuinely large surface area — a custom jq-derived query language, 100+ format decoders, and CLI flags that overlap with but aren't identical to jq's — which is exactly the kind of project where an agent benefits from a short index pointing straight at `doc/usage.md` and `doc/formats.md` instead of inferring behavior from README examples alone. Given fq's own pitch is "jq for binary formats," its users are already comfortable with the idea of tools built for programmatic/scripted use, which made this feel like a natural fit.

Content is derived entirely from your existing docs (README sections on install, background, goals, and supported formats, plus `doc/usage.md` and `doc/dev.md`) — no new claims, just pointers. Validated against the [llms.txt spec](https://llmstxt.org) with [llms-txt-lint](https://github.com/abyworkings-coder/llms-txt-lint) (disclosure: a small validator tool I maintain — happy to drop that line from the PR if you'd rather not have it).

Totally understand if this isn't something you want to maintain — no worries either way, feel free to close.