### PR TITLE
interp: open: Make file behave more properly as a binary

### DIFF
--- a/doc/fq.1
+++ b/doc/fq.1
@@ -1088,7 +1088,7 @@ Transform input to binary with byte as unit and preserve source range.
 .sp
 \f(CR\fBopen\fP\fP
 .RS 4
-Open file for reading.
+Open file for reading. Returns a binary. Ex: \f(CR"file" | open | decode\fP, \f(CR"file" | open | tostring\fP.
 .RE
 .sp
 The standard jq functions \f(CRtest\fP, \f(CRmatch\fP, \f(CRcapture\fP, \f(CRscan\fP and \f(CRsplit\fP also work on binary values, matching against the raw bytes.

--- a/doc/fq.1.adoc
+++ b/doc/fq.1.adoc
@@ -436,7 +436,7 @@ There is also `tobitsrange` and `tobytesrange` which do the same thing but will 
   Transform input to binary with byte as unit and preserve source range.
 
 `*open*`::
-  Open file for reading.
+  Open file for reading. Returns a binary. Ex: `"file" | open | decode`, `"file" | open | tostring`.
 
 The standard jq functions `test`, `match`, `capture`, `scan` and `split` also work on binary values, matching against the raw bytes.
 

--- a/doc/fq.1.tmpl.adoc
+++ b/doc/fq.1.tmpl.adoc
@@ -345,7 +345,7 @@ There is also `tobitsrange` and `tobytesrange` which do the same thing but will 
   Transform input to binary with byte as unit and preserve source range.
 
 `*open*`::
-  Open file for reading.
+  Open file for reading. Returns a binary. Ex: `"file" | open | decode`, `"file" | open | tostring`.
 
 The standard jq functions `test`, `match`, `capture`, `scan` and `split` also work on binary values, matching against the raw bytes.
 

--- a/doc/fq.1.tmpl.adoc.jq
+++ b/doc/fq.1.tmpl.adoc.jq
@@ -13,7 +13,6 @@ def fq_tmpl_adoc($replace_svg):
 			( .image
 			| gsub(".svg"; ".txt")
 			| open
-			| tobytes
 			| tostring
 			| "[source,shell]\n----\n\(.)----\n"
 			)

--- a/pkg/interp/binary.go
+++ b/pkg/interp/binary.go
@@ -286,7 +286,10 @@ func (i *Interp) _open(c any) any {
 
 	// bitio.Buffer -> (bitio.Reader) -> aheadreadseeker -> progressreadseeker -> ctxreadseeker -> readseeker
 
-	bbf.br = bitio.NewIOBitReadSeeker(aheadRs)
+	bbf.Binary, err = NewBinaryFromBitReader(bitio.NewIOBitReadSeeker(aheadRs), 8, 0)
+	if err != nil {
+		return err
+	}
 
 	return bbf
 }

--- a/pkg/interp/init.jq
+++ b/pkg/interp/init.jq
@@ -31,10 +31,9 @@ def input:
     | ($h // "<stdin>") as $name
     | $h
     | try
+        ( _input_filename($name) as $_
         # null input here means stdin
-        ( open
-        | _input_filename($name) as $_
-        | .
+        | open
         )
       catch
         ( . as $err

--- a/pkg/interp/options.jq
+++ b/pkg/interp/options.jq
@@ -137,7 +137,6 @@ def _opt_eval($rest):
           | try
               ( .[1:]
               | open
-              | tobytes
               | tostring
               )
             catch
@@ -195,7 +194,7 @@ def _opt_eval($rest):
         ( . as {$expr_file, $args, $jsonargs}
         | $expr_file
         | if . then
-            try (open | tobytes | tostring)
+            try (open | tostring)
             catch ("\($expr_file): \(.)" | _fatal_error(_exit_code_args_error))
           else ($rest[0] // $args[0] // $jsonargs[0])
           end
@@ -237,7 +236,7 @@ def _opt_eval($rest):
         | if . then
             ( map(.[1] |=
                 ( . as $f
-                | try (open | tobytes | tostring)
+                | try (open | tostring)
                   catch ("\($f): \(.)" | _fatal_error(_exit_code_args_error))
                 )
               )

--- a/pkg/interp/testdata/open.fqtest
+++ b/pkg/interp/testdata/open.fqtest
@@ -1,0 +1,8 @@
+/a:
+abc
+$ fq -n '"a" | open | tostring, tobytes, .[1:2]'
+"abc\n"
+   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
+0x0|61 62 63 0a|                                   |abc.|           |.: raw bits 0x0-0x4 (4)
+   |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|
+0x0|   62                                          | b              |.: raw bits 0x1-0x2 (1)


### PR DESCRIPTION
Makes it possible to do "open | tostring"
Fixes panic if sliced etc