### PR TITLE
mp4,heif: Rework ftyp brand probe

### DIFF
--- a/format/isobmff/boxes.go
+++ b/format/isobmff/boxes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/wader/fq/format"
@@ -285,6 +286,11 @@ func decodeBoxes(ctx *decodeContext, d *decode.D, extraTypeMappers ...scalar.Str
 		func() bool { return d.BitsLeft() >= 8*8 },
 		func(d *decode.D) {
 			decodeBox(ctx, d, extraTypeMappers...)
+			ctx.boxCount++
+
+			if !ctx.ftypSeen && ctx.boxCount > 3 {
+				d.Errorf("no ftyp box found within first %d boxes", ctx.boxCount)
+			}
 		})
 
 	if d.BitsLeft() > 0 {
@@ -328,11 +334,13 @@ func decodeBoxIrefEntry(irefBox *irefBox, d *decode.D) {
 }
 
 func decodeBoxFtyp(ctx *decodeContext, d *decode.D) {
-	brand := d.FieldUTF8("major_brand", 4, scalar.ActualTrimSpace)
-	ctx.current.data = &ftypBox{majorBrand: brand}
+	majorBrand := d.FieldUTF8("major_brand", 4, scalar.ActualTrimSpace)
+	ctx.current.data = &ftypBox{majorBrand: majorBrand}
+
+	brands := []string{majorBrand}
 
 	d.FieldU32("minor_version", scalar.UintFn(func(s scalar.Uint) (scalar.Uint, error) {
-		switch brand {
+		switch majorBrand {
 		case "qt":
 			// https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-BBCGDDDF
 			// "For QuickTime movie files, this takes the form of four binary-coded decimal values, indicating the century,
@@ -345,9 +353,26 @@ func decodeBoxFtyp(ctx *decodeContext, d *decode.D) {
 	numBrands := d.BitsLeft() / 8 / 4
 	var i int64
 	d.FieldArrayLoop("brands", func() bool { return i < numBrands }, func(d *decode.D) {
-		d.FieldUTF8("brand", 4, brandDescriptions, scalar.ActualTrimSpace)
+		b := d.FieldUTF8("brand", 4, brandDescriptions, scalar.ActualTrimSpace)
+		brands = append(brands, b)
 		i++
 	})
+
+	ctx.ftypSeen = true
+
+	foundBrand := false
+	for _, b := range ctx.brands {
+		foundBrand = slices.Contains(brands, b)
+		if foundBrand {
+			break
+		}
+	}
+
+	if !foundBrand {
+		d.Errorf("non of %v found for ftyp with brands %v",
+			ctx.brands, brands,
+		)
+	}
 }
 
 func decodeBoxType(ctx *decodeContext, d *decode.D, typ string) {

--- a/format/isobmff/heif.go
+++ b/format/isobmff/heif.go
@@ -173,23 +173,8 @@ func heifDecode(d *decode.D) any {
 	var hi format.HEIF_In
 	d.ArgAs(&hi)
 
-	ctx := isobmffDecode(d, hi.AllowTruncated, func(firstType string, ftyp ftypBox) {
-		switch firstType {
-		case "ftyp":
-		default:
-			d.Errorf("type not ftyp")
-		}
-		switch ftyp.majorBrand {
-		case "mif1", "mif3", "msf1", "avif":
-			return
-		}
-		for _, b := range ftyp.minorBrands {
-			switch b {
-			case "mif1", "mif3", "msf1", "avif":
-				return
-			}
-		}
-		d.Errorf("not a HEIF brand (mif1/mif3/msf1/avif)")
+	ctx := isobmffDecode(d, hi.AllowTruncated, []string{
+		"mif1", "mif3", "msf1", "avif",
 	})
 
 	heifItems(d, ctx)

--- a/format/isobmff/isobmff.go
+++ b/format/isobmff/isobmff.go
@@ -142,38 +142,28 @@ type decodeContext struct {
 	allowTruncated bool
 	root           *box
 	current        *box
+	boxCount       int
+	ftypSeen       bool
+	brands         []string
 }
 
-func isobmffDecode(d *decode.D, allowTruncated bool, brandsFn func(firstType string, ftyp ftypBox)) *decodeContext {
+func isobmffDecode(d *decode.D, allowTruncated bool, brands []string) *decodeContext {
 	root := &box{typ: ""}
 	ctx := &decodeContext{
 		allowTruncated: allowTruncated,
 		root:           root,
 		current:        root,
+		ftypSeen:       false,
+		brands:         brands,
 	}
 
-	// TODO: nicer, validate functions without field?
-	d.AssertLeastBytesLeft(16)
-	size := d.U32()
-	if size < 8 {
-		d.Fatalf("first box size too small < 8")
-	}
-	var ftyp ftypBox
-	firstType := strings.TrimSpace(d.UTF8(4))
-	// this is to make it possible to force decode when the first box is not ftyp or styp
-	switch firstType {
-	case "ftyp", "styp":
-		ftyp.majorBrand = strings.TrimSpace(d.UTF8(4))
-		minorCount := (size - (4 * 4)) / 4 /* size,type,major,minor_version */
-		ftyp.minorVersion = uint32(d.U32())
-		for range int(minorCount) {
-			ftyp.minorBrands = append(ftyp.minorBrands, strings.TrimSpace(d.UTF8(4)))
-		}
-	}
-
-	brandsFn(firstType, ftyp)
-	d.SeekAbs(0)
 	decodeBoxes(ctx, d)
+	if ctx.boxCount == 0 {
+		d.Fatalf("no boxes found")
+	}
+	if !ctx.ftypSeen {
+		d.Errorf("no ftyp box found")
+	}
 
 	return ctx
 }

--- a/format/isobmff/mp4.go
+++ b/format/isobmff/mp4.go
@@ -171,9 +171,7 @@ type moofBox struct {
 }
 
 type ftypBox struct {
-	majorBrand   string
-	minorVersion uint32
-	minorBrands  []string
+	majorBrand string
 }
 
 type avcCBox struct {
@@ -530,25 +528,13 @@ func mp4Decode(d *decode.D) any {
 	var mi format.MP4_In
 	d.ArgAs(&mi)
 
-	ctx := isobmffDecode(d, mi.AllowTruncated, func(firstType string, ftyp ftypBox) {
-		switch firstType {
-		case "free", // seems to happen
-			"moov", // seems to happen
-			"pnot", // video preview file
-			"jP":   // JPEG 2000
-		case "ftyp",
-			"styp": // segment
-			switch ftyp.majorBrand {
-			case "isom", // iso media (mp4ish)
-				"isml",
-				"qt",  // quicktime mov
-				"jp2": // JPEG 2000
-			default:
-				d.Errorf("major_brand not isom, qt or jp2")
-			}
-		default:
-			d.Errorf("type not ftyp, styp or moov")
-		}
+	ctx := isobmffDecode(d, mi.AllowTruncated, []string{
+		"isom", // iso media (mp4ish)
+		"isml",
+		"qt",   // quicktime mov
+		"jp2",  // JPEG 2000
+		"mp41", // MP4 v1
+		"mp42", // MP4 v2
 	})
 
 	traks := slices.Collect(ctx.root.findAll("moov/trak"))

--- a/pkg/interp/testdata/argvars.fqtest
+++ b/pkg/interp/testdata/argvars.fqtest
@@ -35,9 +35,11 @@ stderr:
 error: --argdecode filea: no such file or directory
 $ fq -n -d mp4 --argdecode filea test.mp3 '$filea'
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f|0123456789abcdef|.{}: test.mp3 (mp4)
-     |                                               |                |  error: mp4: error at position 0x8: type not ftyp, styp or moov
-0x000|49 44 33 04 00 00 00 00 00 23 54 53 53 45 00 00|ID3......#TSSE..|  gap0: raw bits
-*    |until 0x283.7 (end) (644)                      |                |
+     |                                               |                |  error: mp4: BitBufRange: failed at position 0 (read size 1229206276 seek pos 0): outside buffer
+0x000|49 44 33 04 00 00 00 00                        |ID3.....        |  boxes[0:1]:
+0x000|                        00 23 54 53 53 45 00 00|        .#TSSE..|  gap0: raw bits
+0x010|00 0f 00 00 03 4c 61 76 66 35 38 2e 34 35 2e 31|.....Lavf58.45.1|
+*    |until 0x283.7 (end) (636)                      |                |
 $ fq -n --argjson a '(' '$a'
 exitcode: 2
 stderr:


### PR DESCRIPTION
Now probe and normal box decode uses same code.
Supported brand is not check against major and minor brands. Add mp41 and mp42 brands to mp4 decoder.