### PR TITLE
Update github-golangci-lint to 2.13.1 from 2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCILINT_VERSION: "2.12.2"
+  GOLANGCILINT_VERSION: "2.13.1"
 
 jobs:
   lint:

--- a/internal/difftest/difftest.go
+++ b/internal/difftest/difftest.go
@@ -8,6 +8,8 @@
 //
 // Note that output path can be the same as input which useful if the function
 // implements some kind of transcript that includes both input and output.
+//
+//nolint:wastedassign
 package difftest
 
 import (


### PR DESCRIPTION
[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.13.1)  
