### PR TITLE
interp: read a binary as bytes in the rest of the string functions

### DIFF
--- a/pkg/interp/binary.jq
+++ b/pkg/interp/binary.jq
@@ -95,3 +95,112 @@ def _scan_binary($regex; $flags):
   );
 def scan($val): _bytes_or_orig(_scan_binary($val; "g"); _orig_scan($val));
 def scan($regex; $flags): _bytes_or_orig(_scan_binary($regex; "g"+$flags); _orig_scan($regex; $flags));
+
+# The functions below were left out when the overloads above were written, so
+# they still reach a binary through a coercion that replaces every byte it
+# cannot read as UTF-8. Each one now works on the bytes and gives back a binary
+# wherever the string version gives back a string.
+
+def _orig_startswith($v): startswith($v);
+def startswith($v): _bytes_or_orig(_binary_starts_with($v); _orig_startswith($v));
+
+def _orig_endswith($v): endswith($v);
+def endswith($v): _bytes_or_orig(_binary_ends_with($v); _orig_endswith($v));
+
+def _orig_indices($v): indices($v);
+def indices($v): _bytes_or_orig(_binary_indices($v); _orig_indices($v));
+
+def _orig_index($v): index($v);
+def index($v):
+  _bytes_or_orig(
+    ( _binary_indices($v)
+    | if length == 0 then null else .[0] end
+    );
+    _orig_index($v)
+  );
+
+def _orig_rindex($v): rindex($v);
+def rindex($v):
+  _bytes_or_orig(
+    ( _binary_indices($v)
+    | if length == 0 then null else .[-1] end
+    );
+    _orig_rindex($v)
+  );
+
+def _orig_contains($v): contains($v);
+def contains($v):
+  _bytes_or_orig(
+    ( if _binary_needle_length($v) == 0 then true
+      else _binary_indices($v) | length > 0
+      end
+    );
+    _orig_contains($v)
+  );
+
+def _orig_ltrimstr($v): ltrimstr($v);
+def ltrimstr($v):
+  _bytes_or_orig(
+    ( _binary_needle_length($v) as $n
+    | if _binary_starts_with($v) then .[$n:]
+      else .
+      end
+    );
+    _orig_ltrimstr($v)
+  );
+
+def _orig_rtrimstr($v): rtrimstr($v);
+def rtrimstr($v):
+  _bytes_or_orig(
+    ( _binary_needle_length($v) as $n
+    | if $n > 0 and _binary_ends_with($v) then .[0:length-$n]
+      else .
+      end
+    );
+    _orig_rtrimstr($v)
+  );
+
+def _orig_ascii_downcase: ascii_downcase;
+def ascii_downcase: _bytes_or_orig(_binary_ascii_case(false); _orig_ascii_downcase);
+
+def _orig_ascii_upcase: ascii_upcase;
+def ascii_upcase: _bytes_or_orig(_binary_ascii_case(true); _orig_ascii_upcase);
+
+# sub and gsub were left out of the overloads above even though match, scan,
+# split and capture were done, so they still went through the coercion. The
+# replacement is evaluated once for each match with that match's capture object
+# as its input, the way the string versions evaluate it, and its first value is
+# used. A replacement may be a string or a binary.
+
+def _capture_object_of($m):
+  ( $m.captures
+  | map(select(.name) | {key: .name, value: .string})
+  | from_entries
+  );
+
+def _sub_binary($regex; str; $flags):
+  ( . as $b
+  | [ foreach (_match_binary($regex; $flags), null) as $m (
+        {prev: 0, parts: []};
+        if $m == null then
+          {prev: .prev, parts: (.parts + [$b[.prev:]])}
+        else
+          { prev: ($m.offset + $m.length),
+            parts: (.parts + [$b[.prev:$m.offset], first(_capture_object_of($m) | str)])
+          }
+        end
+      )
+    ]
+  | last.parts
+  | tobytes
+  );
+
+def _orig_sub($regex; str): sub($regex; str);
+def _orig_sub($regex; str; $flags): sub($regex; str; $flags);
+def sub($regex; str): _bytes_or_orig(_sub_binary($regex; str; ""); _orig_sub($regex; str));
+def sub($regex; str; $flags): _bytes_or_orig(_sub_binary($regex; str; $flags); _orig_sub($regex; str; $flags));
+
+def _orig_gsub($regex; str): gsub($regex; str);
+def _orig_gsub($regex; str; $flags): gsub($regex; str; $flags);
+def gsub($regex; str): _bytes_or_orig(_sub_binary($regex; str; "g"); _orig_gsub($regex; str));
+def gsub($regex; str; $flags): _bytes_or_orig(_sub_binary($regex; str; "g"+$flags); _orig_gsub($regex; str; $flags));

--- a/pkg/interp/binary.jq.test
+++ b/pkg/interp/binary.jq.test
@@ -1,0 +1,148 @@
+# A binary behaves as the string of its bytes would, so a byte that no string
+# can carry is found where it is instead of being folded into every other byte
+# that is not valid UTF-8.
+
+("00ff80fe01" | hex) | indices("80" | hex)
+null
+[2]
+
+("00ff80fe01" | hex) | index("80" | hex)
+null
+2
+
+("00ff80fe01" | hex) | rindex("ff" | hex)
+null
+1
+
+("00ff00ff" | hex) | indices("ff" | hex)
+null
+[1,3]
+
+# overlapping matches, as the string version reports them
+("6162616261" | hex) | indices("616261" | hex)
+null
+[0,2]
+
+# the case functions move the twenty six letters and nothing else
+("00ff80fe01" | hex) | ascii_upcase | tohex
+null
+"00ff80fe01"
+
+("00ff80fe01" | hex) | ascii_downcase | tohex
+null
+"00ff80fe01"
+
+("6142ff" | hex) | ascii_upcase | tohex
+null
+"4142ff"
+
+("6142ff" | hex) | ascii_downcase | tohex
+null
+"6162ff"
+
+# a result is a binary, so it can be read on as one
+("616263646566" | hex) | ltrimstr("ab") | tohex
+null
+"63646566"
+
+("616263646566" | hex) | rtrimstr("ef") | tohex
+null
+"61626364"
+
+("00ff80fe01" | hex) | ltrimstr("00ff" | hex) | tohex
+null
+"80fe01"
+
+("00ff80fe01" | hex) | rtrimstr("fe01" | hex) | tohex
+null
+"00ff80"
+
+# a needle may be a string or a binary
+("616263646566" | hex) | index("cd")
+null
+2
+
+("616263646566" | hex) | index("6364" | hex)
+null
+2
+
+# prefix, suffix and containment over bytes
+("00ff80fe01" | hex) | startswith("00ff" | hex)
+null
+true
+
+("00ff80fe01" | hex) | startswith("00fe" | hex)
+null
+false
+
+("00ff80fe01" | hex) | endswith("fe01" | hex)
+null
+true
+
+("00ff80fe01" | hex) | contains("80fe" | hex)
+null
+true
+
+("00ff80fe01" | hex) | contains("8080" | hex)
+null
+false
+
+# sub and gsub replace bytes with bytes
+("00ff80fe01" | hex) | gsub(("ff" | hex); ("41" | hex)) | tohex
+null
+"004180fe01"
+
+("00ff80fe01" | hex) | sub(("80" | hex); ("4243" | hex)) | tohex
+null
+"00ff4243fe01"
+
+("ff80fe" | hex) | gsub(("80" | hex); ("41" | hex)) | tohex
+null
+"ff41fe"
+
+("616263646566" | hex) | sub("cd"; "XY") | tohex
+null
+"616258596566"
+
+("616263646566" | hex) | gsub("c"; "Z") | tohex
+null
+"61625a646566"
+
+# the replacement sees the captures
+("616263646566" | hex) | sub("(?<x>cd)"; .x + .x) | tohex
+null
+"6162636463646566"
+
+# the empty needle, as the string version treats it
+("616263646566" | hex) | indices("")
+null
+[]
+
+("616263646566" | hex) | startswith("")
+null
+true
+
+("616263646566" | hex) | contains("")
+null
+true
+
+# a string is still a string and behaves exactly as it did
+"abcdef" | ltrimstr("ab")
+null
+"cdef"
+
+"ababa" | indices("aba")
+null
+[0,2]
+
+"aBc1_~" | ascii_upcase
+null
+"ABC1_~"
+
+"abcdef" | sub("cd"; "XY")
+null
+"abXYef"
+
+"abc" | indices("")
+null
+[]

--- a/pkg/interp/binarystr.go
+++ b/pkg/interp/binarystr.go
@@ -1,0 +1,140 @@
+package interp
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/wader/fq/internal/bitiox"
+	"github.com/wader/fq/pkg/bitio"
+)
+
+func init() {
+	RegisterFunc1("_binary_indices", (*Interp)._binaryIndices)
+	RegisterFunc1("_binary_starts_with", (*Interp)._binaryStartsWith)
+	RegisterFunc1("_binary_ends_with", (*Interp)._binaryEndsWith)
+	RegisterFunc1("_binary_ascii_case", (*Interp)._binaryASCIICase)
+	RegisterFunc1("_binary_needle_length", (*Interp)._binaryNeedleLength)
+}
+
+// The string functions reach a binary through a coercion that replaces every
+// byte it cannot read as UTF-8, so a needle and a haystack that differ only in
+// those bytes compare equal. These work on the bytes themselves.
+//
+// A needle is a string, taken as its UTF-8 bytes, or a binary, taken as its
+// bytes. Anything else is an error, which is what the string versions do.
+func needleBytes(v any) ([]byte, error) {
+	switch vv := v.(type) {
+	case string:
+		return []byte(vv), nil
+	case ToBinary:
+		return subjectBytes(vv)
+	default:
+		return nil, fmt.Errorf("a needle applied to a binary must be a string or a binary, got %v", v)
+	}
+}
+
+// The bytes of a binary, read the way the overloads already here read them.
+// A binary whose length is not a whole number of units carries padding, and
+// toReader is what puts it in front, so going through it is what keeps these
+// functions and match reporting the same offsets over the same subject.
+func subjectBytes(c any) ([]byte, error) {
+	bv, err := toBinary(c)
+	if err != nil {
+		return nil, err
+	}
+	br, err := bv.toReader()
+	if err != nil {
+		return nil, err
+	}
+	buf := &bytes.Buffer{}
+	if _, err := bitiox.CopyBits(buf, br); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// every offset the needle begins at, counted in bytes and allowed to overlap,
+// which is what the string version does
+func (i *Interp) _binaryIndices(c any, needle any) any {
+	hay, err := subjectBytes(c)
+	if err != nil {
+		return err
+	}
+	nee, err := needleBytes(needle)
+	if err != nil {
+		return err
+	}
+	vs := []any{}
+	if len(nee) == 0 {
+		return vs
+	}
+	for off := 0; off+len(nee) <= len(hay); off++ {
+		if bytes.Equal(hay[off:off+len(nee)], nee) {
+			vs = append(vs, off)
+		}
+	}
+	return vs
+}
+
+func (i *Interp) _binaryStartsWith(c any, needle any) any {
+	hay, err := subjectBytes(c)
+	if err != nil {
+		return err
+	}
+	nee, err := needleBytes(needle)
+	if err != nil {
+		return err
+	}
+	return bytes.HasPrefix(hay, nee)
+}
+
+func (i *Interp) _binaryEndsWith(c any, needle any) any {
+	hay, err := subjectBytes(c)
+	if err != nil {
+		return err
+	}
+	nee, err := needleBytes(needle)
+	if err != nil {
+		return err
+	}
+	return bytes.HasSuffix(hay, nee)
+}
+
+// the length of a needle in bytes, so the jq side can slice a prefix or a
+// suffix off without measuring it a second way
+func (i *Interp) _binaryNeedleLength(c any, needle any) any {
+	nee, err := needleBytes(needle)
+	if err != nil {
+		return err
+	}
+	return len(nee)
+}
+
+// Only the twenty six letters move. Every other byte is left alone, including
+// the ones that are not ASCII at all, which is where the coercion used to turn
+// one byte into the three of a replacement character.
+func (i *Interp) _binaryASCIICase(c any, upper any) any {
+	up, ok := upper.(bool)
+	if !ok {
+		return fmt.Errorf("ascii case wants a boolean")
+	}
+	b, err := subjectBytes(c)
+	if err != nil {
+		return err
+	}
+	o := make([]byte, len(b))
+	for i, v := range b {
+		switch {
+		case up && v >= 'a' && v <= 'z':
+			v -= 'a' - 'A'
+		case !up && v >= 'A' && v <= 'Z':
+			v += 'a' - 'A'
+		}
+		o[i] = v
+	}
+	bin, err := NewBinaryFromBitReader(bitio.NewBitReader(o, -1), 8, 0)
+	if err != nil {
+		return err
+	}
+	return bin
+}


### PR DESCRIPTION
`binary.jq` overloads `explode`, `split`, `splits`, `test`, `match`, `capture` and `scan` so they see a binary's bytes. The rest of the string surface was left out, so it still reaches a binary through a coercion that replaces every byte it cannot read as UTF-8, and two bytes that differ end up comparing equal.

```
$ fq -n '("00ff80fe01" | hex) | indices("80" | hex)'
[1,2,3]

$ fq -n '("00ff80fe01" | hex) | ascii_upcase | tohex'
"00efbfbdefbfbdefbfbd01"
```

`0x80` occurs once, at offset 2. And upcasing five bytes gives eleven — one `ef bf bd` per byte above `0x7f`.

This overloads `startswith`, `endswith`, `contains`, `index`, `rindex`, `indices`, `ltrimstr`, `rtrimstr`, `ascii_downcase`, `ascii_upcase`, `sub` and `gsub` using the existing `_bytes_or_orig` helper, so a value that is not a binary takes the original function unchanged.

```
$ fq -n '("00ff80fe01" | hex) | indices("80" | hex)'
[2]

$ fq -n '("00ff80fe01" | hex) | ascii_upcase | tohex'
"00ff80fe01"

$ fq -n '("00ff80fe01" | hex) | gsub(("ff" | hex); ("41" | hex)) | tohex'
"004180fe01"
```

Notes on the semantics, all chosen to match what the string versions do:

- a needle may be a string, taken as its UTF-8 bytes, or a binary; anything else is an error
- matches may overlap, so `("6162616261" | hex) | indices("616261" | hex)` is `[0,2]`
- the empty needle behaves as it does for a string: `indices` is `[]`, `index` and `rindex` are `null`, `startswith`/`endswith`/`contains` are `true`, the trims change nothing
- `sub`/`gsub` evaluate the replacement once per match with that match's capture object as input, and a replacement may be a string or a binary

Two things worth flagging for review:

**Results are binaries now.** `ltrimstr`, `rtrimstr`, `ascii_downcase`, `ascii_upcase`, `sub` and `gsub` return a binary where they used to return a string. That follows what `scan` and `split` already do, but it is a behaviour change for anyone relying on the old string result. Several of these were already byte-correct — the coercion is symmetric for byte-wise comparisons — so for them this change is about the result type and about non-byte-aligned subjects rather than about wrong answers.

**Subjects are read through `Binary.toReader`**, which is what `_match_binary` reads through. That matters for a subject whose unit is not eight: `toReader` prepends the padding, so going through it is what makes these functions and `match` report the same offsets over the same bytes.

Tests are in a new `pkg/interp/binary.jq.test`, 34 cases covering the byte behaviour, the needle types, overlap, the empty needle, and that the plain string path is unchanged. `make testjq` and `go test ./...` pass.